### PR TITLE
Add control mode with Projects, the new default mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ Tabs open in file order; the first tab reuses the workspace's root tab and the r
 are created behind it. A tab with no `command` is just an empty shell. With no
 project files yet, control mode shows an onboarding screen explaining all of this.
 
+### Split panes within a tab
+
+A tab can hold up to **4 panes**. Instead of a single `command`, give the tab
+`[[tabs.panes]]` entries. Each pane after the first sets `split` to `"down"`
+(stacked, top/bottom) or `"right"` (side by side) — the direction it splits off the
+previous pane. An omitted `split` defaults to `"down"`.
+
+```toml
+[[tabs]]
+name = "server"
+
+[[tabs.panes]]
+command = "php artisan serve"
+
+[[tabs.panes]]
+command = "npm run dev"
+split = "down"
+```
+
+A tab uses *either* `command` *or* `[[tabs.panes]]`, not both. In the projects list,
+split tabs are shown with a `×N` pane count (e.g. `server ×2`).
+
 ## Installing
 
 **Homebrew** (the repo is its own tap):

--- a/README.md
+++ b/README.md
@@ -4,21 +4,59 @@ herdr-plus is an add-on platform for [herdr](https://herdr.dev) — a place to b
 extensions and plugins on top of herdr's terminal panes. The same binary can run
 in different **modes**; each mode decides what to do when it talks to herdr.
 
-We're in explore mode: the list of modes will grow over time. Today there is one.
+We're in explore mode: the list of modes will grow over time.
 
 ## Modes
 
 Pick a mode with `--mode=<slug>`. With no flag, the default mode runs.
 
-| Mode | Slug | What it does |
-|------|------|--------------|
-| Quick Actions | `quick-actions` (default) | A fuzzy launcher: pick an action and run it. |
+| Mode | Slug | Key | What it does |
+|------|------|-----|--------------|
+| Control | `control` (default) | `prefix+up` | herdr-plus's home base — a full-screen workspace for driving herdr. First feature: **Projects**. |
+| Quick Actions | `quick-actions` | `prefix+down` | A fuzzy launcher: pick an action and run it in a split. |
 
 ```bash
-herdr-plus                       # default mode (quick-actions)
-herdr-plus --mode=quick-actions  # explicit
+herdr-plus                       # default mode (control)
+herdr-plus --mode=quick-actions  # the fuzzy launcher
 herdr-plus version               # print the version and exit
 ```
+
+## Control mode & Projects
+
+Pressing `prefix+up` opens a brand-new, full-screen herdr workspace titled
+**Herdr Plus** with a `projects` tab, and runs the projects browser there. This is
+control mode — over time it will gain more features; today it has Projects.
+
+A **project** is a declarative herdr workspace template: a name, a description, a
+working directory, and an ordered list of tabs (each with an optional startup
+command). Fuzzy-find a project, press `enter`, and herdr-plus spins up a whole
+workspace — every tab created and every command running — then closes the ephemeral
+"Herdr Plus" workspace. It replaces hand-written workspace shell scripts with simple
+config files.
+
+Projects live in `~/.config/herdr-plus/projects/` (honoring `$XDG_CONFIG_HOME`), one
+TOML file per project (the file name doesn't matter):
+
+```toml
+name = "Options Cafe"
+description = "The main options.cafe monorepo"
+working_dir = "~/Development/options-cafe/options.cafe"   # ~ and $VARS expand
+
+[[tabs]]
+name = "claude"
+command = "claude --dangerously-skip-permissions --chrome"
+
+[[tabs]]
+name = "lazygit"
+command = "lazygit"
+
+[[tabs]]
+name = "terminal"   # no command — just an empty shell
+```
+
+Tabs open in file order; the first tab reuses the workspace's root tab and the rest
+are created behind it. A tab with no `command` is just an empty shell. With no
+project files yet, control mode shows an onboarding screen explaining all of this.
 
 ## Installing
 
@@ -51,10 +89,13 @@ picker there. Choose an action, and the pane closes itself when the action runs.
 ## Install the keybinding
 
 ```bash
-herdr-plus install                 # binds prefix+down -> quick-actions
-herdr-plus install --key=prefix+a  # pick a different key
-herdr-plus install --mode=<slug>   # bind a specific mode
+herdr-plus install                      # binds prefix+up -> control (the default mode)
+herdr-plus install --mode=quick-actions # binds prefix+down -> quick-actions
+herdr-plus install --key=prefix+a       # override the key for any mode
 ```
+
+Each mode has its own default key (control → `prefix+up`, quick-actions →
+`prefix+down`), so the two can be installed side by side. Pass `--key` to override.
 
 `install` adds a `[[keys.command]]` entry to herdr's `config.toml` that runs the
 **absolute path** of the binary you invoked, then reloads the running herdr
@@ -64,22 +105,26 @@ press your herdr prefix (default `ctrl+b`) followed by the bound key.
 
 ## Configuration
 
-All config lives under `~/.config/herdr-plus/` (honoring `$XDG_CONFIG_HOME`), with
-one subdirectory per mode:
+All config lives under `~/.config/herdr-plus/` (honoring `$XDG_CONFIG_HOME`):
 
 ```
 ~/.config/herdr-plus/
-  quick-actions/
+  projects/          # one *.toml per project (control mode)
+    options-cafe.toml
+    bevio.toml
+    ...
+  quick-actions/     # one *.toml per action (quick-actions mode)
     github.toml
     google.toml
-    open-repo.toml
     ...
 ```
 
-Each `*.toml` file in a mode's directory defines **one action**. Add a file to
-add an action; delete a file to remove it. The first time you run a mode, the
-directory is seeded with a set of example actions you can edit or delete — they
-won't come back once the directory exists.
+For **quick-actions**, each `*.toml` defines one action; the directory is seeded
+with editable examples the first time you run the mode. For **projects** (see
+[Control mode & Projects](#control-mode--projects)), each `*.toml` defines one
+project and the directory starts empty — control mode's onboarding screen explains
+how to add your first one. In both cases: add a file to add an entry, delete a file
+to remove it.
 
 ## Actions
 

--- a/control.go
+++ b/control.go
@@ -1,0 +1,193 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// controlWorkspaceLabel is the title herdr-plus gives the workspace it opens for
+// control mode. It is the home base from which you drive herdr.
+const controlWorkspaceLabel = "Herdr Plus"
+
+// controlProjectsTabLabel is the name of the tab inside the control workspace
+// where the projects browser runs.
+const controlProjectsTabLabel = "projects"
+
+// launchControl is control mode's launcher. Unlike quick-actions (which splits
+// the current pane), it opens a brand-new, full-screen workspace titled
+// "Herdr Plus", renames its root tab to "projects", and starts the control UI
+// inside that pane. It returns immediately so the pane the user pressed the
+// keybinding from keeps its prompt.
+func launchControl(client *herdrClient) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Resolve our own absolute path so the new pane's shell can launch the
+	// control UI even when the binary is not on PATH.
+	exe, err := os.Executable()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Open the focused control workspace rooted at the home directory.
+	ws, tab, pane, err := client.workspaceCreate(home, controlWorkspaceLabel, true)
+	if err != nil {
+		errExit("could not create control workspace:", err)
+	}
+
+	// Rename the root tab to "projects". Best effort: if it fails the tab simply
+	// keeps its default numbered name.
+	_ = client.tabRename(tab, controlProjectsTabLabel)
+
+	// Give the freshly spawned shell a brief moment to initialize before we send
+	// the command that starts the control UI.
+	time.Sleep(250 * time.Millisecond)
+
+	// Start the control UI in the new pane, handing it the control workspace id so
+	// it can tear the whole workspace down when the user picks a project or quits.
+	launch := fmt.Sprintf("%s control %s\n", shellQuote(exe), ws)
+	if err := client.sendInput(pane, launch); err != nil {
+		errExit("failed to start control UI:", err)
+	}
+}
+
+// runControlCmd parses the internal `control` invocation. Its single positional
+// argument is the id of the control workspace to close on exit.
+func runControlCmd(args []string) {
+	fs := flag.NewFlagSet("control", flag.ExitOnError)
+	_ = fs.Parse(args)
+
+	controlWS := ""
+	if rest := fs.Args(); len(rest) > 0 {
+		controlWS = rest[0]
+	}
+
+	runControl(controlWS)
+}
+
+// runControl loads the projects, renders the full-screen browser, and acts on
+// the result: opening the chosen project's workspace, or — on cancel — tearing
+// down the ephemeral control workspace. controlWS is the workspace this UI runs
+// in, which is closed once we are done with it.
+func runControl(controlWS string) {
+	projects, err := loadProjects()
+	if err != nil {
+		// Leave the pane open so the user can read the config error.
+		errExit(err)
+	}
+
+	dir, _ := projectsConfigDir()
+
+	p := tea.NewProgram(newControlModel(projects, dir), tea.WithAltScreen())
+	result, err := p.Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "herdr-plus:", err)
+	}
+
+	m, ok := result.(controlModel)
+	if !ok || m.chosen == nil {
+		// Cancelled (or the program never produced a model) — remove the
+		// ephemeral control workspace and return focus to where the user was.
+		closeControlWorkspace(controlWS)
+		return
+	}
+
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+	if err := openProject(client, *m.chosen, controlWS); err != nil {
+		// Leave the control workspace open so the error stays on screen.
+		errExit("could not open project:", err)
+	}
+}
+
+// openProject turns a project into a live herdr workspace: it creates a focused
+// workspace rooted at the project's working directory, lays out one tab per
+// entry (the first reusing the workspace's root tab, the rest created behind
+// it), runs each tab's startup command, and finally closes the control
+// workspace we were launched from.
+func openProject(client *herdrClient, p Project, controlWS string) error {
+	dir := p.expandedWorkingDir()
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return fmt.Errorf("working directory does not exist: %s", dir)
+	}
+
+	ws, rootTab, rootPane, err := client.workspaceCreate(dir, p.Name, true)
+	if err != nil {
+		return fmt.Errorf("create workspace: %w", err)
+	}
+
+	// pendingRun pairs a pane with the command it should run once all tabs exist.
+	type pendingRun struct {
+		pane    string
+		command string
+	}
+	var runs []pendingRun
+
+	// Create every tab in the project's order. tab[0] reuses the workspace's root
+	// tab (renamed); each later tab is created without focus so the first tab
+	// stays in front while the rest spin up.
+	for i, t := range p.Tabs {
+		pane := rootPane
+		if i == 0 {
+			if err := client.tabRename(rootTab, t.Name); err != nil {
+				return fmt.Errorf("rename root tab: %w", err)
+			}
+		} else {
+			_, pane, err = client.tabCreate(ws, t.Name, false)
+			if err != nil {
+				return fmt.Errorf("create tab %q: %w", t.Name, err)
+			}
+		}
+		if strings.TrimSpace(t.Command) != "" {
+			runs = append(runs, pendingRun{pane: pane, command: t.Command})
+		}
+	}
+
+	// Let the freshly spawned shells initialize before we type into them, then
+	// run each tab's startup command (as if typed at the prompt).
+	if len(runs) > 0 {
+		time.Sleep(300 * time.Millisecond)
+		for _, r := range runs {
+			if err := client.sendInput(r.pane, r.command+"\n"); err != nil {
+				return fmt.Errorf("run command in pane %s: %w", r.pane, err)
+			}
+		}
+	}
+
+	// Tear down the ephemeral control workspace. Focus is already on the new
+	// project workspace, so this only removes the launcher. This also closes the
+	// pane this process is running in, so it is the last thing we do.
+	if controlWS != "" {
+		_ = client.workspaceClose(controlWS)
+	}
+	return nil
+}
+
+// closeControlWorkspace asks herdr to close the control workspace. Failures are
+// ignored: from a pane that is about to go away, there is nothing useful to do
+// if the socket is unreachable.
+func closeControlWorkspace(workspaceID string) {
+	if workspaceID == "" {
+		return
+	}
+	client, err := newHerdrClient()
+	if err != nil {
+		return
+	}
+	_ = client.workspaceClose(workspaceID)
+}

--- a/control.go
+++ b/control.go
@@ -131,7 +131,7 @@ func openProject(client *herdrClient, p Project, controlWS string) error {
 		return fmt.Errorf("create workspace: %w", err)
 	}
 
-	// pendingRun pairs a pane with the command it should run once all tabs exist.
+	// pendingRun pairs a pane with the command it should run once all panes exist.
 	type pendingRun struct {
 		pane    string
 		command string
@@ -140,21 +140,34 @@ func openProject(client *herdrClient, p Project, controlWS string) error {
 
 	// Create every tab in the project's order. tab[0] reuses the workspace's root
 	// tab (renamed); each later tab is created without focus so the first tab
-	// stays in front while the rest spin up.
+	// stays in front while the rest spin up. Within a tab, the first pane is the
+	// tab's root and each later pane is split off the previous one.
 	for i, t := range p.Tabs {
-		pane := rootPane
+		tabRoot := rootPane
 		if i == 0 {
 			if err := client.tabRename(rootTab, t.Name); err != nil {
 				return fmt.Errorf("rename root tab: %w", err)
 			}
 		} else {
-			_, pane, err = client.tabCreate(ws, t.Name, false)
+			_, tabRoot, err = client.tabCreate(ws, t.Name, false)
 			if err != nil {
 				return fmt.Errorf("create tab %q: %w", t.Name, err)
 			}
 		}
-		if strings.TrimSpace(t.Command) != "" {
-			runs = append(runs, pendingRun{pane: pane, command: t.Command})
+
+		prev := tabRoot
+		for j, pane := range t.effectivePanes() {
+			paneID := tabRoot
+			if j > 0 {
+				paneID, err = client.paneSplit(prev, pane.Split, false)
+				if err != nil {
+					return fmt.Errorf("split pane %d in tab %q: %w", j+1, t.Name, err)
+				}
+			}
+			if strings.TrimSpace(pane.Command) != "" {
+				runs = append(runs, pendingRun{pane: paneID, command: pane.Command})
+			}
+			prev = paneID
 		}
 	}
 

--- a/controlmodel.go
+++ b/controlmodel.go
@@ -205,12 +205,13 @@ func (m controlModel) detailBar(w int) string {
 
 	dirLine := dirIconStyle.Render("📁 ") + pathStyle.Render(truncate(p.expandedWorkingDir(), inner-3))
 
-	names := p.tabNames()
-	for i, n := range names {
-		names[i] = tabNameStyle.Render(n)
+	labels := p.tabLabels()
+	styled := make([]string, len(labels))
+	for i, n := range labels {
+		styled[i] = tabNameStyle.Render(n)
 	}
-	tabsLine := strings.Join(names, dotStyle.Render(" · "))
-	tabsLine = truncateStyled(tabsLine, p.tabNames(), inner)
+	tabsLine := strings.Join(styled, dotStyle.Render(" · "))
+	tabsLine = truncateStyled(tabsLine, labels, inner)
 
 	return box.Render(dirLine + "\n" + tabsLine)
 }

--- a/controlmodel.go
+++ b/controlmodel.go
@@ -1,0 +1,340 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// docsURL is where the empty-state points for "more documentation". Full docs
+// will live elsewhere later; for now the repo is the home of everything.
+const docsURL = "https://github.com/cloudmanic/herdr-plus"
+
+// Control-mode styles. These build on the shared palette declared in picker.go
+// (titleStyle, nameStyle, descStyle, footerStyle, …); here we add the few extra
+// pieces the full-screen projects browser needs.
+var (
+	// headerBarStyle is the full-width purple title bar across the top.
+	headerBarStyle = titleStyle
+
+	// detailBoxStyle frames the bottom bar that previews the highlighted project.
+	detailBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#A78BFA")).
+			Padding(0, 1)
+
+	// dirIconStyle / pathStyle render the "📁 <working dir>" line of the detail bar.
+	dirIconStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA"))
+	pathStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
+	tabNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#C4B5FD"))
+	dotStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
+
+	// Empty-state styles: a centered onboarding card.
+	cardStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#A78BFA")).
+			Padding(1, 3)
+	cardTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Bold(true)
+	bodyStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
+	pathHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#F2A900")).Bold(true)
+	codeStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
+	linkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#67E8F9")).Underline(true)
+)
+
+// controlModel is the full-screen projects browser shown in the "Herdr Plus"
+// control workspace. It is a thin shell around the shared fuzzyList: arrow or
+// type to find a project, enter to open it, esc to back out. When there are no
+// projects it renders an onboarding card instead of the list.
+type controlModel struct {
+	projects    []Project
+	list        fuzzyList
+	projectsDir string
+
+	width  int
+	height int
+
+	// chosen is the project to open, read back after the program exits; nil when
+	// the user cancelled.
+	chosen   *Project
+	quitting bool
+}
+
+// newControlModel builds the initial TUI state over the loaded projects.
+// projectsDir is shown in the empty-state so the user knows where to add files.
+func newControlModel(projects []Project, projectsDir string) controlModel {
+	items := make([]listItem, len(projects))
+	for i, p := range projects {
+		items[i] = listItem{name: p.Name, desc: p.Description, selectable: true, ref: i}
+	}
+	return controlModel{
+		projects:    projects,
+		list:        newFuzzyList("Type to filter projects…", items),
+		projectsDir: projectsDir,
+	}
+}
+
+// Init implements tea.Model and starts the cursor blinking.
+func (m controlModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Update routes key presses; everything else (window sizes, the blink tick) is
+// forwarded to the query box so the cursor keeps blinking and text keeps flowing.
+func (m controlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		// With no projects, the screen is just an onboarding card: any exit key
+		// closes it.
+		if len(m.projects) == 0 {
+			switch msg.String() {
+			case "ctrl+c", "esc", "q", "enter":
+				m.quitting = true
+				return m, tea.Quit
+			}
+			return m, nil
+		}
+
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			m.quitting = true
+			return m, tea.Quit
+		case "up", "ctrl+p":
+			m.list.moveUp()
+			return m, nil
+		case "down", "ctrl+n":
+			m.list.moveDown()
+			return m, nil
+		case "enter":
+			idx := m.list.selectedIndex()
+			if idx < 0 {
+				return m, nil
+			}
+			p := m.projects[idx]
+			m.chosen = &p
+			return m, tea.Quit
+		}
+
+		cmd := m.list.editQuery(msg)
+		return m, cmd
+	}
+
+	// Non-key messages (e.g. the blink tick) keep the input alive.
+	cmd := m.list.editQuery(msg)
+	return m, cmd
+}
+
+// View renders the screen for the current state: the onboarding card when there
+// are no projects, otherwise the header / list / detail-bar / footer layout.
+func (m controlModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	// Fall back to a sane size until the first WindowSizeMsg arrives.
+	w, h := m.width, m.height
+	if w <= 0 {
+		w = 80
+	}
+	if h <= 0 {
+		h = 24
+	}
+
+	if len(m.projects) == 0 {
+		return m.emptyView(w, h)
+	}
+	return m.browserView(w, h)
+}
+
+// browserView lays out the populated projects browser: a full-width title bar up
+// top, the fuzzy list below it, and the highlighted project's detail bar pinned
+// just above the footer at the bottom of the screen.
+func (m controlModel) browserView(w, h int) string {
+	header := headerBarStyle.Width(w).Render(ModeControl.Title)
+
+	body := m.list.view("no matching projects")
+
+	detail := m.detailBar(w)
+	footer := footerStyle.Render("  ↑/↓ move · type to filter · enter open · esc quit")
+
+	top := header + "\n\n" + body
+	bottom := detail + "\n" + footer
+
+	// Pin the detail bar + footer to the bottom by padding the space between.
+	gap := h - lipgloss.Height(top) - lipgloss.Height(bottom)
+	if gap < 1 {
+		gap = 1
+	}
+	return top + strings.Repeat("\n", gap) + bottom
+}
+
+// detailBar renders the bordered preview of the currently highlighted project:
+// its working directory and the ordered list of tab names. It updates live as
+// the cursor moves.
+func (m controlModel) detailBar(w int) string {
+	// lipgloss Width counts content+padding; the 1-col border is added outside,
+	// so Width(w-2) makes the box span (almost) the full screen width.
+	box := detailBoxStyle.Width(w - 2)
+
+	idx := m.list.selectedIndex()
+	if idx < 0 {
+		return box.Render(descStyle.Render("no matching project"))
+	}
+	p := m.projects[idx]
+
+	// inner is the usable text width inside the box; keep a couple columns of
+	// slack under the true content width so a long line never soft-wraps and
+	// breaks the fixed two-line box.
+	inner := w - 7
+	if inner < 10 {
+		inner = 10
+	}
+
+	dirLine := dirIconStyle.Render("📁 ") + pathStyle.Render(truncate(p.expandedWorkingDir(), inner-3))
+
+	names := p.tabNames()
+	for i, n := range names {
+		names[i] = tabNameStyle.Render(n)
+	}
+	tabsLine := strings.Join(names, dotStyle.Render(" · "))
+	tabsLine = truncateStyled(tabsLine, p.tabNames(), inner)
+
+	return box.Render(dirLine + "\n" + tabsLine)
+}
+
+// emptyView renders the onboarding card shown the first time, before any project
+// files exist: what projects are, where to put them, a copy-paste example, and a
+// docs link. It is centered in the full screen.
+func (m controlModel) emptyView(w, h int) string {
+	var b strings.Builder
+
+	b.WriteString(cardTitleStyle.Render("Welcome to Herdr Plus · Projects"))
+	b.WriteString("\n\n")
+	b.WriteString(bodyStyle.Render("A project is a saved herdr workspace: a working directory and an"))
+	b.WriteString("\n")
+	b.WriteString(bodyStyle.Render("ordered set of tabs, each with a command to run on startup. Pick one"))
+	b.WriteString("\n")
+	b.WriteString(bodyStyle.Render("here and herdr-plus spins up the whole workspace for you."))
+	b.WriteString("\n\n")
+	b.WriteString(bodyStyle.Render("Create your first project — drop a .toml file in:"))
+	b.WriteString("\n")
+	b.WriteString(pathHintStyle.Render("  " + m.projectsDir))
+	b.WriteString("\n\n")
+	b.WriteString(descStyle.Render("Example (" + exampleFileName + "):"))
+	b.WriteString("\n")
+	b.WriteString(codeStyle.Render(indent(exampleProjectSnippet(), "  ")))
+	b.WriteString("\n\n")
+	b.WriteString(descStyle.Render("Docs: "))
+	b.WriteString(linkStyle.Render(docsURL))
+
+	card := cardStyle.Render(b.String())
+
+	footer := footerStyle.Render("esc to close")
+	content := lipgloss.JoinVertical(lipgloss.Center, card, "", footer)
+
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, content)
+}
+
+// exampleFileName / exampleProjectTOML expose the bundled sample project so the
+// empty-state and the repo share one source of truth (it is embedded by the
+// //go:embed directive in config.go).
+const exampleFileName = "options-cafe.toml"
+
+func exampleProjectTOML() string {
+	b, err := embeddedExamples.ReadFile("examples/projects/example.toml")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(string(b), "\n")
+}
+
+// exampleProjectSnippet is the example trimmed for the empty-state card: full-line
+// comments are dropped and runs of blank lines collapsed, so the card stays
+// compact enough for shorter terminals while still derived from the one embedded
+// source of truth. Inline comments (after a value) are kept — they teach.
+func exampleProjectSnippet() string {
+	var out []string
+	blank := false
+	for _, line := range strings.Split(exampleProjectTOML(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == "" {
+			if blank || len(out) == 0 {
+				continue // collapse consecutive blanks and skip a leading blank
+			}
+			blank = true
+			out = append(out, "")
+			continue
+		}
+		blank = false
+		out = append(out, line)
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+// indent prefixes every line of s with prefix, used to inset the example block.
+func indent(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+// truncate shortens a plain (unstyled) string to max display columns, ending it
+// with an ellipsis when it had to cut. Used for the working-dir path.
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= max {
+		return s
+	}
+	r := []rune(s)
+	for len(r) > 0 && lipgloss.Width(string(r))+1 > max {
+		r = r[:len(r)-1]
+	}
+	return string(r) + "…"
+}
+
+// truncateStyled keeps the styled tab-names line from overflowing the detail box.
+// Styling makes display width hard to measure directly, so it falls back to the
+// plain names: if they fit, the styled line is returned untouched; if not, it
+// re-renders only as many names as fit, plus a "+N" tail.
+func truncateStyled(styled string, names []string, max int) string {
+	plain := strings.Join(names, " · ")
+	if lipgloss.Width(plain) <= max {
+		return styled
+	}
+
+	var shown []string
+	width := 0
+	for _, n := range names {
+		add := lipgloss.Width(n)
+		if len(shown) > 0 {
+			add += 3 // " · "
+		}
+		if width+add > max-6 { // leave room for the "+N more" tail
+			break
+		}
+		width += add
+		shown = append(shown, tabNameStyle.Render(n))
+	}
+	tail := dotStyle.Render(" +" + strconv.Itoa(len(names)-len(shown)) + " more")
+	return strings.Join(shown, dotStyle.Render(" · ")) + tail
+}

--- a/controlmodel_test.go
+++ b/controlmodel_test.go
@@ -1,0 +1,127 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// sampleProjects returns two pre-sorted projects for the model tests.
+func sampleProjects() []Project {
+	return []Project{
+		{Name: "Alpha", Description: "first one", WorkingDir: "/srv/alpha", Tabs: []ProjectTab{{Name: "run", Command: "make serve"}}},
+		{Name: "Bravo", Description: "second one", WorkingDir: "/srv/bravo", Tabs: []ProjectTab{{Name: "edit", Command: "vim"}, {Name: "shell"}}},
+	}
+}
+
+// step feeds one message to the model and returns the updated controlModel.
+func step(t *testing.T, m controlModel, msg tea.Msg) controlModel {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	cm, ok := updated.(controlModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want controlModel", updated)
+	}
+	return cm
+}
+
+// TestNewControlModelItems confirms each project becomes a selectable list row
+// carrying its name, description, and original index.
+func TestNewControlModelItems(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	if len(m.list.items) != 2 {
+		t.Fatalf("got %d list items, want 2", len(m.list.items))
+	}
+	if !m.list.items[0].selectable || m.list.items[0].name != "Alpha" || m.list.items[0].desc != "first one" || m.list.items[0].ref != 0 {
+		t.Fatalf("item0 = %+v", m.list.items[0])
+	}
+	if m.list.items[1].ref != 1 {
+		t.Fatalf("item1 ref = %d, want 1", m.list.items[1].ref)
+	}
+}
+
+// TestControlModelEnterSelects confirms pressing enter records the highlighted
+// project (the first, since the cursor starts at the top) and signals a quit.
+func TestControlModelEnterSelects(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyDown}) // move to Bravo
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.chosen == nil {
+		t.Fatal("expected a chosen project, got nil")
+	}
+	if m.chosen.Name != "Bravo" {
+		t.Fatalf("chosen = %q, want Bravo", m.chosen.Name)
+	}
+}
+
+// TestControlModelEscCancels confirms esc records no selection.
+func TestControlModelEscCancels(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.chosen != nil {
+		t.Fatalf("esc should not choose a project, got %q", m.chosen.Name)
+	}
+	if !m.quitting {
+		t.Fatal("esc should set quitting")
+	}
+}
+
+// TestControlModelFilterThenSelect confirms typing narrows the list and enter
+// then opens the single remaining match.
+func TestControlModelFilterThenSelect(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("brav")})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.chosen == nil || m.chosen.Name != "Bravo" {
+		t.Fatalf("after filtering to 'brav', chosen = %v, want Bravo", m.chosen)
+	}
+}
+
+// TestControlModelBrowserView confirms the populated view shows the header, the
+// project names, and the highlighted project's working directory in the detail
+// bar.
+func TestControlModelBrowserView(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	view := m.View()
+
+	for _, want := range []string{"Alpha", "Bravo", "/srv/alpha"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("browser view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// TestControlModelEmptyState confirms that with no projects the onboarding card
+// renders (with the config path and docs link) and any exit key closes it.
+func TestControlModelEmptyState(t *testing.T) {
+	m := newControlModel(nil, "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	view := m.View()
+
+	for _, want := range []string{"Welcome to Herdr Plus", "/cfg/projects", docsURL} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("empty-state view missing %q:\n%s", want, view)
+		}
+	}
+
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.quitting {
+		t.Fatal("empty-state should quit on a key press")
+	}
+	if m.chosen != nil {
+		t.Fatal("empty-state must never choose a project")
+	}
+}

--- a/examples/projects/example.toml
+++ b/examples/projects/example.toml
@@ -1,0 +1,30 @@
+# A project is a herdr workspace template. Save one *.toml file per project in
+# ~/.config/herdr-plus/projects/ — the file name does not matter.
+#
+# Picking a project in control mode (prefix+up) opens a new herdr workspace
+# rooted at `working_dir`, labeled `name`, with one tab per [[tabs]] entry (in
+# order). Each tab runs its `command` on startup; omit `command` for an empty
+# terminal.
+
+name = "Options Cafe"
+description = "The main options.cafe monorepo"
+working_dir = "~/Development/options-cafe/options.cafe"   # ~ and $VARS expand
+
+[[tabs]]
+name = "claude"
+command = "claude --dangerously-skip-permissions --chrome"
+
+[[tabs]]
+name = "lazygit"
+command = "lazygit"
+
+[[tabs]]
+name = "editor"
+command = "spiceedit"
+
+[[tabs]]
+name = "server"
+command = "make serve"
+
+[[tabs]]
+name = "terminal"   # no command — just an empty shell

--- a/examples/projects/example.toml
+++ b/examples/projects/example.toml
@@ -22,9 +22,18 @@ command = "lazygit"
 name = "editor"
 command = "spiceedit"
 
+# A tab can be split into up to 4 panes. Instead of a single `command`, give it
+# [[tabs.panes]]. Each pane after the first sets `split = "down"` (stacked) or
+# "right" (side by side) — how it splits off the previous pane (default "down").
 [[tabs]]
 name = "server"
-command = "make serve"
+
+[[tabs.panes]]
+command = "php artisan serve"
+
+[[tabs.panes]]
+command = "npm run dev"
+split = "down"
 
 [[tabs]]
 name = "terminal"   # no command — just an empty shell

--- a/herdr.go
+++ b/herdr.go
@@ -84,10 +84,11 @@ func (c *herdrClient) call(method string, params map[string]any, out any) error 
 	return nil
 }
 
-// splitDown splits the target pane horizontally, creating a new pane beneath it,
-// and returns the new pane's id. When focus is true the new pane becomes the
-// focused pane (the socket API does not focus new panes by default).
-func (c *herdrClient) splitDown(targetPaneID string, focus bool) (string, error) {
+// paneSplit splits the target pane in the given direction ("down" for a new pane
+// beneath it, "right" for one beside it), creating a new pane, and returns the
+// new pane's id. When focus is true the new pane becomes the focused pane (the
+// socket API does not focus new panes by default).
+func (c *herdrClient) paneSplit(targetPaneID, direction string, focus bool) (string, error) {
 	var out struct {
 		Pane struct {
 			PaneID string `json:"pane_id"`
@@ -95,7 +96,7 @@ func (c *herdrClient) splitDown(targetPaneID string, focus bool) (string, error)
 	}
 	err := c.call("pane.split", map[string]any{
 		"target_pane_id": targetPaneID,
-		"direction":      "down",
+		"direction":      direction,
 		"focus":          focus,
 	}, &out)
 	if err != nil {

--- a/herdr.go
+++ b/herdr.go
@@ -198,3 +198,75 @@ func (c *herdrClient) workspaceGet(workspaceID string) (workspaceInfo, error) {
 	err := c.call("workspace.get", map[string]any{"workspace_id": workspaceID}, &out)
 	return out.Workspace, err
 }
+
+// workspaceCreate makes a brand-new workspace rooted at cwd with the given
+// label, and returns the ids of the new workspace, its single root tab, and
+// that tab's root pane. When focus is true the workspace becomes the active one
+// (the user is switched to it); pass false to create it in the background.
+// Control mode uses this both to open its own "Herdr Plus" workspace and to
+// build a project's workspace.
+func (c *herdrClient) workspaceCreate(cwd, label string, focus bool) (workspaceID, tabID, paneID string, err error) {
+	var out struct {
+		Workspace struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"workspace"`
+		Tab struct {
+			TabID string `json:"tab_id"`
+		} `json:"tab"`
+		RootPane struct {
+			PaneID string `json:"pane_id"`
+		} `json:"root_pane"`
+	}
+	err = c.call("workspace.create", map[string]any{
+		"cwd":   cwd,
+		"label": label,
+		"focus": focus,
+	}, &out)
+	if err != nil {
+		return "", "", "", err
+	}
+	return out.Workspace.WorkspaceID, out.Tab.TabID, out.RootPane.PaneID, nil
+}
+
+// tabCreate adds a tab to an existing workspace and returns the new tab's id and
+// its root pane's id. focus controls whether the new tab is brought to the front
+// — we create a project's later tabs with focus=false so the first tab stays
+// active while the rest spin up behind it.
+func (c *herdrClient) tabCreate(workspaceID, label string, focus bool) (tabID, paneID string, err error) {
+	var out struct {
+		Tab struct {
+			TabID string `json:"tab_id"`
+		} `json:"tab"`
+		RootPane struct {
+			PaneID string `json:"pane_id"`
+		} `json:"root_pane"`
+	}
+	err = c.call("tab.create", map[string]any{
+		"workspace_id": workspaceID,
+		"label":        label,
+		"focus":        focus,
+	}, &out)
+	if err != nil {
+		return "", "", err
+	}
+	return out.Tab.TabID, out.RootPane.PaneID, nil
+}
+
+// tabRename changes a tab's human label. A freshly created workspace's root tab
+// is named "1"; we rename it to the project's first tab name (or "projects" for
+// the control workspace itself).
+func (c *herdrClient) tabRename(tabID, label string) error {
+	return c.call("tab.rename", map[string]any{
+		"tab_id": tabID,
+		"label":  label,
+	}, nil)
+}
+
+// workspaceClose tears down a whole workspace and all of its tabs and panes.
+// Control mode calls this on its own ephemeral "Herdr Plus" workspace once a
+// project has been opened (or the picker is cancelled).
+func (c *herdrClient) workspaceClose(workspaceID string) error {
+	return c.call("workspace.close", map[string]any{
+		"workspace_id": workspaceID,
+	}, nil)
+}

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -1,0 +1,62 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLiveSocketWorkspaceLifecycle exercises the real workspace/tab socket
+// methods (the exact calls openProject makes) against a running herdr instance.
+// It is skipped unless HERDR_PLUS_LIVE=1 and a socket is present, so ordinary
+// `go test` and CI never touch herdr. Everything is created in the background
+// (focus=false) and torn down at the end, so it never disturbs the user's view.
+func TestLiveSocketWorkspaceLifecycle(t *testing.T) {
+	if os.Getenv("HERDR_PLUS_LIVE") != "1" || os.Getenv("HERDR_SOCKET_PATH") == "" {
+		t.Skip("live herdr socket test; set HERDR_PLUS_LIVE=1 inside herdr to run")
+	}
+
+	client, err := newHerdrClient()
+	if err != nil {
+		t.Fatalf("newHerdrClient: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+
+	ws, rootTab, rootPane, err := client.workspaceCreate(home, "herdr-plus-verify", false)
+	if err != nil {
+		t.Fatalf("workspaceCreate: %v", err)
+	}
+	// Always clean up, even if a later step fails.
+	defer func() {
+		if err := client.workspaceClose(ws); err != nil {
+			t.Errorf("workspaceClose: %v", err)
+		}
+	}()
+
+	if ws == "" || rootTab == "" || rootPane == "" {
+		t.Fatalf("workspaceCreate returned empty ids: ws=%q tab=%q pane=%q", ws, rootTab, rootPane)
+	}
+
+	if err := client.tabRename(rootTab, "first"); err != nil {
+		t.Fatalf("tabRename: %v", err)
+	}
+
+	_, pane2, err := client.tabCreate(ws, "second", false)
+	if err != nil {
+		t.Fatalf("tabCreate: %v", err)
+	}
+	if pane2 == "" {
+		t.Fatal("tabCreate returned empty pane id")
+	}
+
+	// Run a harmless command in the new pane the same way openProject does.
+	if err := client.sendInput(pane2, "true\n"); err != nil {
+		t.Fatalf("sendInput: %v", err)
+	}
+}

--- a/install.go
+++ b/install.go
@@ -31,13 +31,19 @@ type keybinding struct {
 // binding and refuses to clobber a key already taken by something else.
 func runInstallCmd(args []string) {
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
-	key := fs.String("key", "prefix+down", "herdr keybinding to bind (e.g. prefix+down)")
-	modeSlug := fs.String("mode", "", "which herdr-plus mode the keybinding launches (default: quick-actions)")
+	key := fs.String("key", "", "herdr keybinding to bind (default: the mode's own key, e.g. prefix+up for control)")
+	modeSlug := fs.String("mode", "", "which herdr-plus mode the keybinding launches (default: control)")
 	_ = fs.Parse(args)
 
 	mode, err := lookupMode(*modeSlug)
 	if err != nil {
 		errExit(err)
+	}
+
+	// With no explicit --key, bind the mode's own default key so each mode lands
+	// on its conventional binding (control → prefix+up, quick-actions → prefix+down).
+	if *key == "" {
+		*key = mode.DefaultKey
 	}
 
 	// The absolute path of this very binary — what the keybinding will run.
@@ -57,19 +63,21 @@ func runInstallCmd(args []string) {
 	// Read existing bindings (a missing file just means "none yet").
 	existing, _ := readKeybindings(cfgPath)
 
-	// Idempotent: if herdr-plus is already bound, report where and stop.
-	if b, ok := existingBinding(existing, self); ok {
+	// Idempotent per mode: if THIS mode is already bound, report where and stop.
+	// Other modes share the binary but differ by --mode, so installing control
+	// does not trip over an existing quick-actions binding.
+	if b, ok := existingBinding(existing, command); ok {
 		if b.Key == *key {
-			fmt.Printf("herdr-plus: already installed — %s launches herdr-plus.\n", b.Key)
+			fmt.Printf("herdr-plus: %s already installed — press %s to launch it.\n", mode.Slug, b.Key)
 		} else {
-			fmt.Printf("herdr-plus: already installed at %s. Remove that binding in %s to rebind to %s.\n", b.Key, cfgPath, *key)
+			fmt.Printf("herdr-plus: %s already installed at %s. Remove that binding in %s to rebind to %s.\n", mode.Slug, b.Key, cfgPath, *key)
 		}
 		return
 	}
 
-	// Don't clobber a key someone else is using.
-	if b, ok := conflictBinding(existing, *key, self); ok {
-		errExit(fmt.Sprintf("key %q is already bound to: %s\nChoose a different key with --key (e.g. --key=prefix+up or --key=prefix+a).", *key, b.Command))
+	// Don't clobber a key already used by anything else (including the other mode).
+	if b, ok := conflictBinding(existing, *key, command); ok {
+		errExit(fmt.Sprintf("key %q is already bound to: %s\nChoose a different key with --key (e.g. --key=prefix+a).", *key, b.Command))
 	}
 
 	if err := appendToFile(cfgPath, keybindBlock(*key, command, description)); err != nil {
@@ -131,22 +139,25 @@ func readKeybindings(path string) ([]keybinding, error) {
 	return out, nil
 }
 
-// existingBinding finds the binding that already launches the given binary path,
-// identified by the absolute path appearing anywhere in its command.
-func existingBinding(bindings []keybinding, selfPath string) (keybinding, bool) {
+// existingBinding finds a binding that already runs this exact herdr-plus
+// command — same binary and same --mode. Because each mode's command carries its
+// own --mode flag, two herdr-plus modes never match each other here, so
+// installing one mode is idempotent without disturbing the other.
+func existingBinding(bindings []keybinding, command string) (keybinding, bool) {
 	for _, b := range bindings {
-		if strings.Contains(b.Command, selfPath) {
+		if b.Command == command {
 			return b, true
 		}
 	}
 	return keybinding{}, false
 }
 
-// conflictBinding finds a binding that occupies key but is not our own
-// herdr-plus binding.
-func conflictBinding(bindings []keybinding, key, selfPath string) (keybinding, bool) {
+// conflictBinding finds a binding that occupies key with a different command —
+// anything other than this mode's own binding (including herdr-plus's other
+// mode). That is a real conflict we must not clobber.
+func conflictBinding(bindings []keybinding, key, command string) (keybinding, bool) {
 	for _, b := range bindings {
-		if b.Key == key && !strings.Contains(b.Command, selfPath) {
+		if b.Key == key && b.Command != command {
 			return b, true
 		}
 	}

--- a/install_test.go
+++ b/install_test.go
@@ -78,33 +78,40 @@ command = "/abs/herdr-plus --mode=quick-actions"
 	}
 }
 
-// TestExistingAndConflictBinding checks the idempotency and conflict detection
-// used by install.
+// TestExistingAndConflictBinding checks the per-mode idempotency and conflict
+// detection used by install: a binding matches only when both the binary and the
+// --mode match, so the two modes can be installed side by side.
 func TestExistingAndConflictBinding(t *testing.T) {
-	self := "/abs/herdr-plus"
+	quickCmd := "/abs/herdr-plus --mode=quick-actions"
+	controlCmd := "/abs/herdr-plus --mode=control"
 	bindings := []keybinding{
 		{Key: "prefix+u", Command: "$HOME/bin/setup.sh"},
-		{Key: "prefix+j", Command: "/abs/herdr-plus --mode=quick-actions"},
+		{Key: "prefix+down", Command: quickCmd},
 	}
 
-	// Our binding is found regardless of the key it sits on.
-	if b, ok := existingBinding(bindings, self); !ok || b.Key != "prefix+j" {
-		t.Fatalf("existingBinding = %+v, %v; want prefix+j", b, ok)
+	// The quick-actions binding is found by its exact command.
+	if b, ok := existingBinding(bindings, quickCmd); !ok || b.Key != "prefix+down" {
+		t.Fatalf("existingBinding(quick-actions) = %+v, %v; want prefix+down", b, ok)
 	}
 
-	// prefix+u is taken by something that is not us -> conflict.
-	if b, ok := conflictBinding(bindings, "prefix+u", self); !ok || b.Command != "$HOME/bin/setup.sh" {
-		t.Fatalf("conflictBinding(prefix+u) = %+v, %v; want a conflict", b, ok)
+	// Control mode is NOT installed yet: same binary, different --mode.
+	if b, ok := existingBinding(bindings, controlCmd); ok {
+		t.Fatalf("existingBinding(control) = %+v; want not found (different mode)", b)
 	}
 
-	// prefix+j is ours, so it is not reported as a conflict.
-	if _, ok := conflictBinding(bindings, "prefix+j", self); ok {
-		t.Fatal("conflictBinding(prefix+j) reported a conflict for our own binding")
+	// Installing control on prefix+down would clobber quick-actions -> conflict.
+	if b, ok := conflictBinding(bindings, "prefix+down", controlCmd); !ok || b.Command != quickCmd {
+		t.Fatalf("conflictBinding(prefix+down, control) = %+v, %v; want the quick-actions conflict", b, ok)
 	}
 
-	// A free key has no conflict.
-	if _, ok := conflictBinding(bindings, "prefix+down", self); ok {
-		t.Fatal("conflictBinding(prefix+down) reported a conflict for a free key")
+	// prefix+down holds quick-actions' own command, so it is not a self-conflict.
+	if _, ok := conflictBinding(bindings, "prefix+down", quickCmd); ok {
+		t.Fatal("conflictBinding(prefix+down, quick-actions) reported a conflict for its own binding")
+	}
+
+	// A free key (prefix+up) has no conflict for control.
+	if _, ok := conflictBinding(bindings, "prefix+up", controlCmd); ok {
+		t.Fatal("conflictBinding(prefix+up, control) reported a conflict for a free key")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ import (
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
+		case "control":
+			runControlCmd(os.Args[2:])
+			return
 		case "picker":
 			runPickerCmd(os.Args[2:])
 			return
@@ -81,24 +84,37 @@ func runPickerCmd(args []string) {
 	runPicker(mode, ctx, selfPane)
 }
 
-// runLauncher splits the current herdr pane downward, focuses the new pane, and
-// launches this same binary in picker mode inside it. Before splitting it
-// gathers the run context (working directory and herdr session metadata) from
-// the pane it was invoked in — the only pane that knows the user's real working
-// directory — and hands it to the picker so the chosen action sees it. The
-// launcher then returns immediately so the original shell prompt comes back.
+// runLauncher dispatches to the right launch behavior for the mode. Modes differ
+// in how they present themselves: quick-actions opens a small split beneath the
+// current pane, while control mode opens a brand-new full-screen workspace.
 func runLauncher(mode Mode) {
 	client, err := newHerdrClient()
 	if err != nil {
 		errExit(err)
 	}
 
+	switch mode.Slug {
+	case ModeControl.Slug:
+		launchControl(client)
+	default:
+		launchPicker(client, mode)
+	}
+}
+
+// launchPicker splits the current herdr pane downward, focuses the new pane, and
+// launches this same binary in picker mode inside it. Before splitting it
+// gathers the run context (working directory and herdr session metadata) from
+// the pane it was invoked in — the only pane that knows the user's real working
+// directory — and hands it to the picker so the chosen action sees it. It then
+// returns immediately so the original shell prompt comes back.
+func launchPicker(client *herdrClient, mode Mode) {
 	// HERDR_PANE_ID identifies the pane we are launched from; it is the pane we
 	// split to create the picker beneath it. It is set in a pane's own shell but
 	// not for a keybinding (which runs server-side), so fall back to the focused
 	// pane in that case.
 	paneID := os.Getenv("HERDR_PANE_ID")
 	if paneID == "" {
+		var err error
 		paneID, err = client.focusedPaneID()
 		if err != nil || paneID == "" {
 			errExit("could not determine the focused pane; are you running inside herdr?")

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func launchPicker(client *herdrClient, mode Mode) {
 
 	// Create the picker pane beneath the current one and focus it so keystrokes
 	// flow to the picker.
-	newPane, err := client.splitDown(paneID, true)
+	newPane, err := client.paneSplit(paneID, "down", true)
 	if err != nil {
 		errExit("split failed:", err)
 	}

--- a/mode.go
+++ b/mode.go
@@ -11,25 +11,37 @@ import "fmt"
 // Mode identifies which herdr-plus behavior to run. herdr-plus is an add-on
 // platform for herdr: the same binary can be invoked many times in different
 // herdr panes, and a --mode flag tells each invocation what to do when it talks
-// to herdr. We expect this list to grow; for now quick-actions is the only mode.
+// to herdr. We expect this list to grow.
 type Mode struct {
 	// Slug is the stable identifier used on the command line (--mode=<slug>) and
 	// as the per-mode configuration subdirectory name under ~/.config/herdr-plus.
 	Slug string
-	// Title is the human-facing heading shown at the top of the mode's picker.
+	// Title is the human-facing heading shown at the top of the mode's UI.
 	Title string
+	// DefaultKey is the herdr keybinding `herdr-plus install` binds for this mode
+	// when the user does not pass --key. Each mode claims its own key so the two
+	// modes can coexist (quick-actions on prefix+down, control on prefix+up).
+	DefaultKey string
 }
 
-// ModeQuickActions is the fuzzy launcher: pick an action from your config and
-// run it. This is the original (and currently only) herdr-plus behavior.
-var ModeQuickActions = Mode{Slug: "quick-actions", Title: "⚡ Quick Actions"}
+// ModeControl is herdr-plus's home base: a full-screen workspace ("Herdr Plus")
+// from which you drive herdr. Its first feature is Projects — declarative
+// workspace templates you fuzzy-pick to spin up a fully laid-out workspace. It
+// is the default mode, so the bare binary lands here.
+var ModeControl = Mode{Slug: "control", Title: "Herdr Plus · Control · Projects", DefaultKey: "prefix+up"}
 
-// defaultMode is the mode used when --mode is omitted, so the bare binary keeps
-// working the way it always has.
-var defaultMode = ModeQuickActions
+// ModeQuickActions is the fuzzy launcher: pick an action from your config and
+// run it in a split beneath the pane you launched from. This was herdr-plus's
+// original behavior.
+var ModeQuickActions = Mode{Slug: "quick-actions", Title: "⚡ Quick Actions", DefaultKey: "prefix+down"}
+
+// defaultMode is the mode used when --mode is omitted. Control mode is the
+// front door of herdr-plus, so the bare binary opens it.
+var defaultMode = ModeControl
 
 // modes is every mode herdr-plus knows about, keyed by slug. Add new modes here.
 var modes = map[string]Mode{
+	ModeControl.Slug:      ModeControl,
 	ModeQuickActions.Slug: ModeQuickActions,
 }
 

--- a/mode_test.go
+++ b/mode_test.go
@@ -1,0 +1,41 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import "testing"
+
+// TestLookupModeDefaultIsControl confirms the bare binary (empty --mode) resolves
+// to control mode, while explicit slugs resolve to their modes and typos error.
+func TestLookupModeDefaultIsControl(t *testing.T) {
+	if defaultMode.Slug != ModeControl.Slug {
+		t.Fatalf("default mode = %q, want control", defaultMode.Slug)
+	}
+
+	m, err := lookupMode("")
+	if err != nil || m.Slug != ModeControl.Slug {
+		t.Fatalf("lookupMode(\"\") = %q, %v; want control", m.Slug, err)
+	}
+
+	if m, err := lookupMode("quick-actions"); err != nil || m.Slug != ModeQuickActions.Slug {
+		t.Fatalf("lookupMode(quick-actions) = %q, %v", m.Slug, err)
+	}
+
+	if _, err := lookupMode("nope"); err == nil {
+		t.Fatal("lookupMode(nope) should error on an unknown slug")
+	}
+}
+
+// TestModeDefaultKeys pins each mode to its conventional keybinding so the two
+// modes can be installed side by side without colliding.
+func TestModeDefaultKeys(t *testing.T) {
+	if ModeControl.DefaultKey != "prefix+up" {
+		t.Fatalf("control default key = %q, want prefix+up", ModeControl.DefaultKey)
+	}
+	if ModeQuickActions.DefaultKey != "prefix+down" {
+		t.Fatalf("quick-actions default key = %q, want prefix+down", ModeQuickActions.DefaultKey)
+	}
+}

--- a/project.go
+++ b/project.go
@@ -1,0 +1,162 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ProjectTab is one tab in a project's workspace, in the order it should be
+// created. Name is the tab's label; Command, when set, is run in the tab's pane
+// on startup (via the herdr socket, as if typed at the shell). A tab with no
+// command is just an empty terminal.
+type ProjectTab struct {
+	Name    string `toml:"name"`
+	Command string `toml:"command"`
+}
+
+// Project is a declarative herdr workspace template, loaded from one TOML file in
+// ~/.config/herdr-plus/projects. Picking a project in control mode opens a new
+// herdr workspace rooted at WorkingDir, labeled Name, with one tab per entry in
+// Tabs (in order) running each tab's startup command. Projects replace the
+// hand-written herdr-workspaces shell scripts.
+type Project struct {
+	Name        string       `toml:"name"`
+	Description string       `toml:"description"`
+	WorkingDir  string       `toml:"working_dir"`
+	Tabs        []ProjectTab `toml:"tabs"`
+
+	// source is the file the project was loaded from, used only for error
+	// messages. It is not part of the on-disk format.
+	source string
+}
+
+// projectsConfigDir returns the directory that holds project files,
+// ~/.config/herdr-plus/projects. It hangs directly off the herdr-plus config
+// root (not under a mode slug) because projects are a first-class concept that
+// could one day be driven by more than one mode.
+func projectsConfigDir() (string, error) {
+	base, err := configBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "projects"), nil
+}
+
+// ensureProjectsDir makes sure the projects directory exists and returns its
+// path. Unlike a mode's action directory, it is never seeded with examples: an
+// empty directory is meaningful — it triggers control mode's onboarding
+// empty-state — so we only create the (empty) folder for the user to drop files
+// into.
+func ensureProjectsDir() (string, error) {
+	dir, err := projectsConfigDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// loadProjects reads, parses, and validates every *.toml project in the projects
+// directory, returning them sorted by name. A malformed or invalid file fails
+// the whole load with a message naming the offending files, so config mistakes
+// surface loudly instead of a project silently going missing. An empty directory
+// returns an empty slice (not an error) so the caller can show the empty-state.
+func loadProjects() ([]Project, error) {
+	dir, err := ensureProjectsDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var projects []Project
+	var problems []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+
+		var p Project
+		if _, err := toml.DecodeFile(path, &p); err != nil {
+			problems = append(problems, fmt.Sprintf("  %s: %v", e.Name(), err))
+			continue
+		}
+		p.source = e.Name()
+		if err := p.validate(); err != nil {
+			problems = append(problems, "  "+err.Error())
+			continue
+		}
+		projects = append(projects, p)
+	}
+
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("invalid project files in %s:\n%s", dir, strings.Join(problems, "\n"))
+	}
+
+	sort.Slice(projects, func(i, j int) bool { return projects[i].Name < projects[j].Name })
+	return projects, nil
+}
+
+// validate checks that a project is internally consistent before we ever try to
+// open it, turning config mistakes into clear errors at load time. The working
+// directory is intentionally not checked for existence here — that is a per-open
+// concern (the dir might exist on one machine but not another), reported when
+// the project is actually opened.
+func (p Project) validate() error {
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("project %s: name is required", p.source)
+	}
+	if len(p.Tabs) == 0 {
+		return fmt.Errorf("project %q (%s): needs at least one [[tabs]] entry", p.Name, p.source)
+	}
+	for i, t := range p.Tabs {
+		if strings.TrimSpace(t.Name) == "" {
+			return fmt.Errorf("project %q (%s): tab %d is missing a name", p.Name, p.source, i+1)
+		}
+	}
+	return nil
+}
+
+// expandedWorkingDir resolves the project's working directory to an absolute
+// path, expanding a leading ~ to the home directory and any $VARS in the path.
+// An empty working_dir defaults to the user's home directory, so a minimal
+// project still opens somewhere sensible.
+func (p Project) expandedWorkingDir() string {
+	dir := strings.TrimSpace(p.WorkingDir)
+	home, _ := os.UserHomeDir()
+
+	if dir == "" || dir == "~" {
+		return home
+	}
+	if strings.HasPrefix(dir, "~/") {
+		dir = filepath.Join(home, dir[2:])
+	}
+	return os.ExpandEnv(dir)
+}
+
+// tabNames returns just the tab labels in order, for the one-line layout summary
+// shown in the control TUI's detail bar.
+func (p Project) tabNames() []string {
+	names := make([]string, len(p.Tabs))
+	for i, t := range p.Tabs {
+		names[i] = t.Name
+	}
+	return names
+}

--- a/project.go
+++ b/project.go
@@ -16,13 +16,57 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// ProjectTab is one tab in a project's workspace, in the order it should be
-// created. Name is the tab's label; Command, when set, is run in the tab's pane
-// on startup (via the herdr socket, as if typed at the shell). A tab with no
-// command is just an empty terminal.
-type ProjectTab struct {
-	Name    string `toml:"name"`
+// Split directions herdr's pane.split understands. "down" stacks the new pane
+// below the previous one (top/bottom); "right" puts it beside (side by side).
+const (
+	SplitDown  = "down"
+	SplitRight = "right"
+)
+
+// maxPanesPerTab caps how many panes a single tab may declare. A tab is split
+// into at most this many panes.
+const maxPanesPerTab = 4
+
+// ProjectPane is one pane within a tab. Command, when set, runs in the pane on
+// startup. Split is how the pane is created relative to the previous pane in the
+// tab — "down" or "right"; it is ignored for the first pane (the tab's root) and
+// defaults to "down" when omitted.
+type ProjectPane struct {
 	Command string `toml:"command"`
+	Split   string `toml:"split"`
+}
+
+// ProjectTab is one tab in a project's workspace, in the order it should be
+// created. Name is the tab's label. A tab is authored in one of two forms: the
+// single-pane shorthand sets Command directly; a split tab instead lists
+// [[tabs.panes]] (up to maxPanesPerTab of them). A tab with neither is an empty
+// terminal.
+type ProjectTab struct {
+	Name    string        `toml:"name"`
+	Command string        `toml:"command"`
+	Panes   []ProjectPane `toml:"panes"`
+}
+
+// effectivePanes returns the tab's panes in creation order, normalizing the two
+// authoring forms into one list. The first pane is the tab's root (its split is
+// cleared); each later pane carries the direction it splits off the previous
+// one, defaulting to "down".
+func (t ProjectTab) effectivePanes() []ProjectPane {
+	if len(t.Panes) == 0 {
+		return []ProjectPane{{Command: t.Command}}
+	}
+	panes := make([]ProjectPane, len(t.Panes))
+	for i, p := range t.Panes {
+		panes[i] = p
+		if i == 0 {
+			panes[i].Split = ""
+			continue
+		}
+		if panes[i].Split == "" {
+			panes[i].Split = SplitDown
+		}
+	}
+	return panes
 }
 
 // Project is a declarative herdr workspace template, loaded from one TOML file in
@@ -130,6 +174,23 @@ func (p Project) validate() error {
 		if strings.TrimSpace(t.Name) == "" {
 			return fmt.Errorf("project %q (%s): tab %d is missing a name", p.Name, p.source, i+1)
 		}
+		if len(t.Panes) > 0 && strings.TrimSpace(t.Command) != "" {
+			return fmt.Errorf("project %q (%s): tab %q sets both command and [[tabs.panes]]; use one or the other", p.Name, p.source, t.Name)
+		}
+		if len(t.Panes) > maxPanesPerTab {
+			return fmt.Errorf("project %q (%s): tab %q has %d panes; at most %d are allowed", p.Name, p.source, t.Name, len(t.Panes), maxPanesPerTab)
+		}
+		for j, pane := range t.Panes {
+			if j == 0 {
+				continue // the first pane is the tab's root; its split is ignored
+			}
+			switch pane.Split {
+			case "", SplitDown, SplitRight:
+				// ok — an empty split defaults to "down"
+			default:
+				return fmt.Errorf("project %q (%s): tab %q pane %d has split %q; must be %q or %q", p.Name, p.source, t.Name, j+1, pane.Split, SplitDown, SplitRight)
+			}
+		}
 	}
 	return nil
 }
@@ -151,12 +212,17 @@ func (p Project) expandedWorkingDir() string {
 	return os.ExpandEnv(dir)
 }
 
-// tabNames returns just the tab labels in order, for the one-line layout summary
-// shown in the control TUI's detail bar.
-func (p Project) tabNames() []string {
-	names := make([]string, len(p.Tabs))
+// tabLabels returns the tab names in order for the control TUI's detail bar,
+// annotating split tabs with a "×N" pane count so the layout is visible at a
+// glance (e.g. "server ×2").
+func (p Project) tabLabels() []string {
+	labels := make([]string, len(p.Tabs))
 	for i, t := range p.Tabs {
-		names[i] = t.Name
+		if n := len(t.effectivePanes()); n > 1 {
+			labels[i] = fmt.Sprintf("%s ×%d", t.Name, n)
+		} else {
+			labels[i] = t.Name
+		}
 	}
-	return names
+	return labels
 }

--- a/project_test.go
+++ b/project_test.go
@@ -1,0 +1,155 @@
+//
+// Date: 2026-06-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// projectsDirIn returns the projects directory under a temp XDG config root and
+// makes sure it exists, mirroring how the real config layout is rooted.
+func projectsDirIn(t *testing.T, tmp string) string {
+	t.Helper()
+	dir := filepath.Join(tmp, "herdr-plus", "projects")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+	return dir
+}
+
+// TestLoadProjectsParsesAndSorts confirms valid project files are parsed, sorted
+// by name, and have their tabs preserved in file order.
+func TestLoadProjectsParsesAndSorts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := projectsDirIn(t, tmp)
+
+	bravo := `name = "Bravo"
+description = "second alphabetically"
+working_dir = "~/code/bravo"
+
+[[tabs]]
+name = "edit"
+command = "vim"
+
+[[tabs]]
+name = "shell"
+`
+	alpha := `name = "Alpha"
+working_dir = "/srv/alpha"
+
+[[tabs]]
+name = "run"
+command = "make serve"
+`
+	if err := os.WriteFile(filepath.Join(dir, "bravo.toml"), []byte(bravo), 0o644); err != nil {
+		t.Fatalf("write bravo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "alpha.toml"), []byte(alpha), 0o644); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+
+	projects, err := loadProjects()
+	if err != nil {
+		t.Fatalf("loadProjects: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("got %d projects, want 2", len(projects))
+	}
+	if projects[0].Name != "Alpha" || projects[1].Name != "Bravo" {
+		t.Fatalf("projects not sorted by name: %q, %q", projects[0].Name, projects[1].Name)
+	}
+
+	b := projects[1]
+	if len(b.Tabs) != 2 || b.Tabs[0].Name != "edit" || b.Tabs[0].Command != "vim" {
+		t.Fatalf("bravo tabs wrong: %+v", b.Tabs)
+	}
+	if b.Tabs[1].Command != "" {
+		t.Fatalf("bravo second tab should have no command, got %q", b.Tabs[1].Command)
+	}
+}
+
+// TestLoadProjectsEmptyDirIsNotAnError confirms an empty projects directory
+// yields no projects (and no error), so the caller can show the empty-state.
+func TestLoadProjectsEmptyDirIsNotAnError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	projectsDirIn(t, tmp)
+
+	projects, err := loadProjects()
+	if err != nil {
+		t.Fatalf("loadProjects on empty dir: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("expected no projects, got %d", len(projects))
+	}
+}
+
+// TestLoadProjectsRejectsInvalidFile confirms a structurally-invalid project
+// (here: no tabs) fails the load loudly rather than silently disappearing.
+func TestLoadProjectsRejectsInvalidFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := projectsDirIn(t, tmp)
+
+	noTabs := "name = \"No Tabs\"\nworking_dir = \"/tmp\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "notabs.toml"), []byte(noTabs), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := loadProjects(); err == nil {
+		t.Fatal("expected error for project with no tabs, got nil")
+	}
+}
+
+// TestProjectValidate exercises each validation rule directly.
+func TestProjectValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		project Project
+		wantErr bool
+	}{
+		{"ok", Project{Name: "A", Tabs: []ProjectTab{{Name: "t"}}}, false},
+		{"missing name", Project{Tabs: []ProjectTab{{Name: "t"}}}, true},
+		{"no tabs", Project{Name: "A"}, true},
+		{"tab missing name", Project{Name: "A", Tabs: []ProjectTab{{Command: "ls"}}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.project.validate()
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validate() err = %v, wantErr = %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestExpandedWorkingDir confirms ~, $VARS, absolute paths, and an empty value
+// all resolve sensibly relative to the home directory.
+func TestExpandedWorkingDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", home},
+		{"~", home},
+		{"~/code/x", filepath.Join(home, "code", "x")},
+		{"$HOME/code/y", filepath.Join(home, "code", "y")},
+		{"/srv/abs", "/srv/abs"},
+	}
+	for _, c := range cases {
+		got := Project{WorkingDir: c.in}.expandedWorkingDir()
+		if got != c.want {
+			t.Fatalf("expandedWorkingDir(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/project_test.go
+++ b/project_test.go
@@ -75,6 +75,54 @@ command = "make serve"
 	}
 }
 
+// TestLoadProjectsParsesSplitPanes confirms a tab authored with [[tabs.panes]]
+// loads with its panes, commands, and split directions intact.
+func TestLoadProjectsParsesSplitPanes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := projectsDirIn(t, tmp)
+
+	content := `name = "Rental Notice"
+working_dir = "/srv/rental"
+
+[[tabs]]
+name = "claude"
+command = "claude"
+
+[[tabs]]
+name = "server"
+
+[[tabs.panes]]
+command = "php artisan serve"
+
+[[tabs.panes]]
+command = "npm run dev"
+split = "down"
+`
+	if err := os.WriteFile(filepath.Join(dir, "rental.toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	projects, err := loadProjects()
+	if err != nil {
+		t.Fatalf("loadProjects: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("got %d projects, want 1", len(projects))
+	}
+
+	server := projects[0].Tabs[1]
+	if len(server.Panes) != 2 {
+		t.Fatalf("server panes = %d, want 2", len(server.Panes))
+	}
+	if server.Panes[0].Command != "php artisan serve" || server.Panes[1].Command != "npm run dev" {
+		t.Fatalf("pane commands wrong: %+v", server.Panes)
+	}
+	if server.Panes[1].Split != "down" {
+		t.Fatalf("pane 2 split = %q, want down", server.Panes[1].Split)
+	}
+}
+
 // TestLoadProjectsEmptyDirIsNotAnError confirms an empty projects directory
 // yields no projects (and no error), so the caller can show the empty-state.
 func TestLoadProjectsEmptyDirIsNotAnError(t *testing.T) {
@@ -110,6 +158,8 @@ func TestLoadProjectsRejectsInvalidFile(t *testing.T) {
 
 // TestProjectValidate exercises each validation rule directly.
 func TestProjectValidate(t *testing.T) {
+	twoPanes := []ProjectPane{{Command: "a"}, {Command: "b", Split: "down"}}
+	fivePanes := []ProjectPane{{}, {}, {}, {}, {}}
 	cases := []struct {
 		name    string
 		project Project
@@ -119,6 +169,11 @@ func TestProjectValidate(t *testing.T) {
 		{"missing name", Project{Tabs: []ProjectTab{{Name: "t"}}}, true},
 		{"no tabs", Project{Name: "A"}, true},
 		{"tab missing name", Project{Name: "A", Tabs: []ProjectTab{{Command: "ls"}}}, true},
+		{"ok multi-pane", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: twoPanes}}}, false},
+		{"command and panes", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Command: "ls", Panes: twoPanes}}}, true},
+		{"too many panes", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: fivePanes}}}, true},
+		{"bad split", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Split: "sideways"}}}}}, true},
+		{"first pane split ignored", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{Split: "sideways"}}}}}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -127,6 +182,50 @@ func TestProjectValidate(t *testing.T) {
 				t.Fatalf("validate() err = %v, wantErr = %v", err, c.wantErr)
 			}
 		})
+	}
+}
+
+// TestEffectivePanes confirms the two authoring forms normalize correctly: a
+// single-pane tab yields one pane, and a multi-pane tab clears the first pane's
+// split while defaulting later panes to "down".
+func TestEffectivePanes(t *testing.T) {
+	single := ProjectTab{Name: "claude", Command: "claude"}.effectivePanes()
+	if len(single) != 1 || single[0].Command != "claude" || single[0].Split != "" {
+		t.Fatalf("single-pane = %+v", single)
+	}
+
+	multi := ProjectTab{Name: "server", Panes: []ProjectPane{
+		{Command: "php artisan serve", Split: "right"}, // split on root is ignored
+		{Command: "npm run dev"},                       // omitted split defaults to down
+		{Command: "tail -f log", Split: "right"},
+	}}.effectivePanes()
+	if len(multi) != 3 {
+		t.Fatalf("got %d panes, want 3", len(multi))
+	}
+	if multi[0].Split != "" {
+		t.Fatalf("root pane split = %q, want empty", multi[0].Split)
+	}
+	if multi[1].Split != SplitDown {
+		t.Fatalf("pane 2 split = %q, want down (default)", multi[1].Split)
+	}
+	if multi[2].Split != SplitRight {
+		t.Fatalf("pane 3 split = %q, want right", multi[2].Split)
+	}
+}
+
+// TestTabLabels confirms split tabs are annotated with a "×N" pane count while
+// single-pane tabs show just their name.
+func TestTabLabels(t *testing.T) {
+	p := Project{Tabs: []ProjectTab{
+		{Name: "claude", Command: "claude"},
+		{Name: "server", Panes: []ProjectPane{{Command: "a"}, {Command: "b"}}},
+	}}
+	got := p.tabLabels()
+	if got[0] != "claude" {
+		t.Fatalf("label[0] = %q, want claude", got[0])
+	}
+	if got[1] != "server ×2" {
+		t.Fatalf("label[1] = %q, want \"server ×2\"", got[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a second herdr-plus mode, **control**, bound to `prefix+up` and now the **default** mode (bare `herdr-plus` runs it). Unlike quick-actions (a cramped bottom split), control mode opens a brand-new **full-screen workspace** titled "Herdr Plus" with a `projects` tab and runs its TUI there — its home base for driving herdr.

Its first feature is **Projects**: declarative herdr workspace templates that replace hand-written `herdr-workspaces` shell scripts.

## How it works

`prefix+up` → opens an ephemeral "Herdr Plus" workspace → fuzzy-find a project → `enter` spins up that project's workspace (every tab created, every startup command running), then tears down the control workspace. `esc` just closes it. Because it's ephemeral, repeated presses never pile up empty workspaces.

A **project** is one TOML file in `~/.config/herdr-plus/projects/`:

```toml
name = "Options Cafe"
description = "The main options.cafe monorepo"
working_dir = "~/Development/options-cafe/options.cafe"   # ~ and $VARS expand

[[tabs]]
name = "claude"
command = "claude --dangerously-skip-permissions --chrome"

[[tabs]]
name = "terminal"   # no command -> empty shell
```

Tabs open in file order (the first reuses the workspace root tab, the rest are created behind it). With no project files yet, control mode shows an onboarding screen explaining the format and linking to the repo.

## Changes

- **mode.go** — `ModeControl` + per-mode `DefaultKey`; control is now the default mode
- **main.go** — dispatch `runLauncher` by mode; new `control` subcommand
- **herdr.go** — `workspaceCreate` / `tabCreate` / `tabRename` / `workspaceClose` socket methods
- **project.go** — `Project` model, loader, validation, `~`/`$VAR` expansion
- **controlmodel.go** — full-screen TUI (header bar, fuzzy list, live detail bar, onboarding empty-state), reusing the shared `fuzzyList` and lipgloss palette
- **control.go** — launch flow + project-open (builds a workspace from a project)
- **install.go** — `--key` defaults to the mode's own key so control (`prefix+up`) and quick-actions (`prefix+down`) coexist; idempotency/conflict checks are now mode-aware
- **examples/projects/example.toml** — bundled sample, rendered in the empty-state
- Tests for project loading, the control model, mode defaults, mode-aware install, plus a guarded live-socket integration test (skipped unless `HERDR_PLUS_LIVE=1` inside herdr)

## Testing

- `go vet`, `gofmt`, and `go test ./...` all green
- Live socket round-trip of the exact create/tab/rename/run/close calls verified against running herdr (created in the background, cleaned up)
- TUI rendering (browser + empty-state) verified at real terminal sizes
- Keybinding install verified: both mode bindings coexist, herdr config reloaded