### PR TITLE
Add per-project quick actions via .herdr-plus directories

### DIFF
--- a/.herdr-plus/quick-actions/make-build.toml
+++ b/.herdr-plus/quick-actions/make-build.toml
@@ -1,0 +1,11 @@
+# A project-local quick action. Files under .herdr-plus/quick-actions/ in a repo
+# show up in the quick-actions picker — grouped under a "Project" heading — but
+# only when you launch herdr-plus from inside that repo. They use the exact same
+# format as your global actions in ~/.config/herdr-plus/quick-actions/.
+#
+# The command runs in the directory you launched from (the repo root here, where
+# the Makefile lives).
+
+name = "make build"
+description = "Build the herdr-plus binary (make build)"
+command = "make build"

--- a/.herdr-plus/quick-actions/make-build.toml
+++ b/.herdr-plus/quick-actions/make-build.toml
@@ -5,7 +5,11 @@
 #
 # The command runs in the directory you launched from (the repo root here, where
 # the Makefile lives).
+#
+# The trailing `read -t … </dev/tty` holds the pane open until you press Enter
+# (or 30s passes) so you can read build output before the picker pane closes.
+# See make-test.toml for the other keep-open options (plain read, or sleep).
 
 name = "make build"
 description = "Build the herdr-plus binary (make build)"
-command = "make build"
+command = 'make build; printf "\n— done · press Enter to close (auto-closes in 30s) —\n"; read -t 30 _ </dev/tty || true'

--- a/.herdr-plus/quick-actions/make-test.toml
+++ b/.herdr-plus/quick-actions/make-test.toml
@@ -1,0 +1,6 @@
+# A second project-local action, to show more than one project entry grouped
+# together. Same format as the global actions; runs in the repo root.
+
+name = "make test"
+description = "Run the herdr-plus test suite (make test)"
+command = "make test"

--- a/.herdr-plus/quick-actions/make-test.toml
+++ b/.herdr-plus/quick-actions/make-test.toml
@@ -1,6 +1,17 @@
 # A second project-local action, to show more than one project entry grouped
 # together. Same format as the global actions; runs in the repo root.
+#
+# Keeping the pane open: after the command finishes, herdr-plus closes the
+# picker's pane — so a quick command's output would flash by. To hold the pane
+# until you've read it, end the command with a "wait". The action's stdin is
+# /dev/null, so the wait must read the terminal directly via </dev/tty:
+#
+#   read _ </dev/tty            # wait for Enter, then close
+#   read -t 30 _ </dev/tty      # ...but auto-close after 30s if you walk away
+#   sleep 5                     # simplest: just linger N seconds, then close
+#
+# The `|| true` keeps a read timeout (or a missing tty) from looking like an error.
 
 name = "make test"
 description = "Run the herdr-plus test suite (make test)"
-command = "make test"
+command = 'make test; printf "\n— done · press Enter to close (auto-closes in 30s) —\n"; read -t 30 _ </dev/tty || true'

--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ project and the directory starts empty — control mode's onboarding screen expl
 how to add your first one. In both cases: add a file to add an entry, delete a file
 to remove it.
 
+### Per-project quick actions
+
+A repo can ship its own quick actions. Add a `.herdr-plus/` directory at the repo
+root that mirrors the global layout, and drop one `*.toml` per action into its
+`quick-actions/` subdirectory — same format as your global actions:
+
+```
+your-repo/
+  .herdr-plus/
+    quick-actions/
+      make-build.toml
+      make-test.toml
+```
+
+When you launch the quick-actions picker from inside that repo, its project
+actions appear **grouped under a `Project` heading**, above your `Global` ones, so
+it is always clear which is which. (Start typing to filter and the two groups
+merge into a single ranked list.) Launch from a repo with no `.herdr-plus`
+directory and the picker looks exactly as before — a single, ungrouped list. The
+directory is read-only and never auto-created: it shows up only when a repo
+actually provides it. This repo ships one as a live example (`make build` /
+`make test`).
+
 ## Actions
 
 An action has a `name`, a `description`, a `command`, and a `type`. The command

--- a/action.go
+++ b/action.go
@@ -58,6 +58,21 @@ func (o Option) resolvedValue() string {
 	return o.Label
 }
 
+// actionOrigin records where an action was loaded from. The picker uses it to
+// group project-local actions separately from the user's global actions so it is
+// always clear which is which.
+type actionOrigin int
+
+const (
+	// originGlobal is an action from the user's global config dir
+	// (~/.config/herdr-plus/<mode>/). It is the zero value, so any Action built
+	// without an explicit origin is treated as global.
+	originGlobal actionOrigin = iota
+	// originProject is an action from a repo's own .herdr-plus/<mode>/ directory,
+	// available only when herdr-plus is launched from inside that repo.
+	originProject
+)
+
 // FormConfig customizes the text field shown for a "form" action.
 type FormConfig struct {
 	// Prompt is the label rendered above the input field.
@@ -82,6 +97,10 @@ type Action struct {
 	// source is the file the action was loaded from, used only for error
 	// messages. It is not part of the on-disk format.
 	source string
+
+	// origin marks whether the action came from the global config or a project's
+	// .herdr-plus directory. Set at load time; not part of the on-disk format.
+	origin actionOrigin
 }
 
 // effectiveType returns the action's type, defaulting to TypeCommand when the

--- a/config.go
+++ b/config.go
@@ -50,6 +50,22 @@ func modeConfigDir(mode Mode) (string, error) {
 	return filepath.Join(base, mode.Slug), nil
 }
 
+// projectConfigDirName is the directory a repo adds at its root to ship its own
+// herdr-plus config. It mirrors the global config layout: actions for a mode live
+// in <repo>/.herdr-plus/<mode-slug>/.
+const projectConfigDirName = ".herdr-plus"
+
+// projectConfigDir returns the project-local config directory for a mode within
+// workDir, e.g. <workDir>/.herdr-plus/quick-actions. It returns "" when workDir
+// is unknown. Unlike the global dir, it is never created or seeded: project
+// config is opt-in and read only when the repo actually provides it.
+func projectConfigDir(mode Mode, workDir string) string {
+	if workDir == "" {
+		return ""
+	}
+	return filepath.Join(workDir, projectConfigDirName, mode.Slug)
+}
+
 // ensureModeConfig makes sure a mode's config directory exists and returns its
 // path. The very first time (when the directory does not yet exist) it seeds the
 // directory with the embedded example actions. Once the directory exists it is
@@ -100,17 +116,33 @@ func seedExamples(mode Mode, destDir string) error {
 }
 
 // loadActions reads, parses, and validates every *.toml action in the mode's
-// config directory, returning them sorted by name. A malformed or invalid file
-// fails the whole load with a message naming the offending files, so config
-// mistakes surface loudly instead of an action silently going missing.
+// global config directory, returning them sorted by name and tagged as global. A
+// malformed or invalid file fails the whole load with a message naming the
+// offending files, so config mistakes surface loudly instead of an action
+// silently going missing.
 func loadActions(mode Mode) ([]Action, error) {
 	dir, err := ensureModeConfig(mode)
 	if err != nil {
 		return nil, err
 	}
+	return loadActionsFromDir(dir, originGlobal)
+}
+
+// loadActionsFromDir reads, parses, and validates every *.toml action in dir,
+// tagging each with origin and returning them sorted by name. A directory that
+// does not exist yields no actions and no error, so an absent project config dir
+// simply contributes nothing. A malformed or invalid file fails the whole load
+// with a message naming the offending files and their directory.
+func loadActionsFromDir(dir string, origin actionOrigin) ([]Action, error) {
+	if dir == "" {
+		return nil, nil
+	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -128,6 +160,7 @@ func loadActions(mode Mode) ([]Action, error) {
 			continue
 		}
 		a.source = e.Name()
+		a.origin = origin
 		if err := a.validate(); err != nil {
 			problems = append(problems, "  "+err.Error())
 			continue
@@ -141,4 +174,23 @@ func loadActions(mode Mode) ([]Action, error) {
 
 	sort.Slice(actions, func(i, j int) bool { return actions[i].Name < actions[j].Name })
 	return actions, nil
+}
+
+// loadPickerActions loads the actions to show in the picker: the mode's global
+// actions plus any project-local actions found in workDir's .herdr-plus/<mode>/
+// directory. Project actions come first and are tagged originProject, globals
+// originGlobal, so the picker can group them. A repo without a .herdr-plus dir
+// just yields the global set, exactly as before this feature existed.
+func loadPickerActions(mode Mode, workDir string) ([]Action, error) {
+	global, err := loadActions(mode)
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := loadActionsFromDir(projectConfigDir(mode, workDir), originProject)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(project, global...), nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -94,3 +94,108 @@ func TestSeedingIsNotRepeatedOnExistingDir(t *testing.T) {
 		t.Fatalf("expected existing dir left empty, found %d files", len(entries))
 	}
 }
+
+// TestProjectConfigDir confirms the project dir mirrors the global per-mode
+// layout (<repo>/.herdr-plus/<slug>) and that an unknown working directory yields
+// no path.
+func TestProjectConfigDir(t *testing.T) {
+	got := projectConfigDir(ModeQuickActions, "/repo")
+	want := filepath.Join("/repo", ".herdr-plus", ModeQuickActions.Slug)
+	if got != want {
+		t.Fatalf("projectConfigDir = %q, want %q", got, want)
+	}
+	if got := projectConfigDir(ModeQuickActions, ""); got != "" {
+		t.Fatalf("projectConfigDir(\"\") = %q, want empty", got)
+	}
+}
+
+// TestLoadActionsFromDirMissingIsEmpty confirms a non-existent directory yields no
+// actions and no error, so an absent project config is simply ignored rather than
+// failing the picker.
+func TestLoadActionsFromDirMissingIsEmpty(t *testing.T) {
+	actions, err := loadActionsFromDir(filepath.Join(t.TempDir(), "nope"), originProject)
+	if err != nil {
+		t.Fatalf("loadActionsFromDir on missing dir: %v", err)
+	}
+	if actions != nil {
+		t.Fatalf("expected nil actions for missing dir, got %v", actions)
+	}
+}
+
+// TestLoadPickerActionsCombinesGlobalAndProject confirms loadPickerActions returns
+// the seeded global actions tagged global, that an absent .herdr-plus contributes
+// nothing, and that a project action added under .herdr-plus/quick-actions then
+// appears tagged project.
+func TestLoadPickerActionsCombinesGlobalAndProject(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	work := t.TempDir()
+
+	// No .herdr-plus yet: only the seeded globals come back, all tagged global.
+	globalOnly, err := loadPickerActions(ModeQuickActions, work)
+	if err != nil {
+		t.Fatalf("loadPickerActions (no project): %v", err)
+	}
+	if len(globalOnly) == 0 {
+		t.Fatal("expected seeded global actions, got none")
+	}
+	for _, a := range globalOnly {
+		if a.origin != originGlobal {
+			t.Fatalf("action %q has origin %v, want global", a.Name, a.origin)
+		}
+	}
+
+	// Add a project action and confirm it now appears, tagged project.
+	projDir := filepath.Join(work, projectConfigDirName, ModeQuickActions.Slug)
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	actionTOML := "name = \"make build\"\ncommand = \"make build\"\n"
+	if err := os.WriteFile(filepath.Join(projDir, "make-build.toml"), []byte(actionTOML), 0o644); err != nil {
+		t.Fatalf("write project action: %v", err)
+	}
+
+	combined, err := loadPickerActions(ModeQuickActions, work)
+	if err != nil {
+		t.Fatalf("loadPickerActions (with project): %v", err)
+	}
+	if len(combined) != len(globalOnly)+1 {
+		t.Fatalf("got %d actions, want %d", len(combined), len(globalOnly)+1)
+	}
+
+	var found *Action
+	for i := range combined {
+		if combined[i].Name == "make build" {
+			found = &combined[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("project action \"make build\" missing from combined set")
+	}
+	if found.origin != originProject {
+		t.Fatalf("project action origin = %v, want project", found.origin)
+	}
+}
+
+// TestLoadPickerActionsRejectsBadProjectFile confirms a malformed project action
+// fails the load just like a malformed global one, instead of silently dropping.
+func TestLoadPickerActionsRejectsBadProjectFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	work := t.TempDir()
+	projDir := filepath.Join(work, projectConfigDirName, ModeQuickActions.Slug)
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A select action with no options is invalid.
+	bad := "name = \"Broken\"\ntype = \"select\"\ncommand = \"echo {{.Value}}\"\n"
+	if err := os.WriteFile(filepath.Join(projDir, "broken.toml"), []byte(bad), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := loadPickerActions(ModeQuickActions, work); err == nil {
+		t.Fatal("expected error for invalid project action file, got nil")
+	}
+}

--- a/picker.go
+++ b/picker.go
@@ -75,19 +75,59 @@ type pickerModel struct {
 	quitting bool
 }
 
-// newPickerModel builds the initial TUI state showing every action.
+// newPickerModel builds the initial TUI state showing every action. Actions are
+// partitioned by origin so project-local actions sort and render ahead of the
+// global ones; m.actions is stored in that same project-then-global order so each
+// list row's ref indexes straight back into it.
 func newPickerModel(mode Mode, ctx RunContext, actions []Action) pickerModel {
-	items := make([]listItem, len(actions))
-	for i, a := range actions {
-		items[i] = listItem{name: a.Name, desc: a.Description, selectable: true, ref: i}
+	var project, global []Action
+	for _, a := range actions {
+		if a.origin == originProject {
+			project = append(project, a)
+		} else {
+			global = append(global, a)
+		}
 	}
+
+	ordered := make([]Action, 0, len(actions))
+	ordered = append(ordered, project...)
+	ordered = append(ordered, global...)
+
 	return pickerModel{
 		mode:       mode,
 		ctx:        ctx,
 		stage:      stageActions,
-		actions:    actions,
-		actionList: newFuzzyList("Type to filter…", items),
+		actions:    ordered,
+		actionList: newFuzzyList("Type to filter…", actionListItems(project, global)),
 	}
+}
+
+// actionListItems turns the project and global actions into picker rows. When
+// both groups are present it brackets each with a non-selectable "Project" /
+// "Global" heading so the origin of every action is clear; when only one group
+// exists it emits a plain, ungrouped list so a repo without project actions looks
+// exactly as it did before. Each selectable row's ref is its index into the
+// concatenated project++global slice, matching the order newPickerModel stores in
+// m.actions.
+func actionListItems(project, global []Action) []listItem {
+	grouped := len(project) > 0 && len(global) > 0
+	items := make([]listItem, 0, len(project)+len(global)+2)
+
+	if grouped {
+		items = append(items, listItem{name: "Project"})
+	}
+	for i, a := range project {
+		items = append(items, listItem{name: a.Name, desc: a.Description, selectable: true, ref: i})
+	}
+
+	if grouped {
+		items = append(items, listItem{name: "Global"})
+	}
+	for j, a := range global {
+		items = append(items, listItem{name: a.Name, desc: a.Description, selectable: true, ref: len(project) + j})
+	}
+
+	return items
 }
 
 // Init implements tea.Model and starts the cursor blinking.
@@ -304,7 +344,7 @@ func newFormInput(form FormConfig) textinput.Model {
 // focus returns to the pane it was launched from. selfPane is the pane id to
 // close on exit.
 func runPicker(mode Mode, ctx RunContext, selfPane string) {
-	actions, err := loadActions(mode)
+	actions, err := loadPickerActions(mode, ctx.WorkDir)
 	if err != nil {
 		// Leave the pane open so the user can read the config error.
 		errExit(err)

--- a/picker_test.go
+++ b/picker_test.go
@@ -41,3 +41,48 @@ func TestOptionItems(t *testing.T) {
 		t.Fatalf("item4 = %+v, want blank spacer", items[4])
 	}
 }
+
+// TestActionListItems confirms project and global actions are grouped under
+// "Project"/"Global" headings when both are present — with each selectable row's
+// ref pointing into the concatenated project++global order — and that a
+// global-only set renders as a plain, ungrouped list (no headings), preserving
+// the pre-feature look for repos without a .herdr-plus directory.
+func TestActionListItems(t *testing.T) {
+	project := []Action{
+		{Name: "make build", Description: "Build", origin: originProject},
+		{Name: "make test", Description: "Test", origin: originProject},
+	}
+	global := []Action{
+		{Name: "GitHub", Description: "Open GitHub", origin: originGlobal},
+	}
+
+	items := actionListItems(project, global)
+	// Project heading, 2 project rows, Global heading, 1 global row.
+	if len(items) != 5 {
+		t.Fatalf("got %d items, want 5: %+v", len(items), items)
+	}
+	if items[0].selectable || items[0].name != "Project" {
+		t.Fatalf("item0 = %+v, want non-selectable Project heading", items[0])
+	}
+	if !items[1].selectable || items[1].name != "make build" || items[1].ref != 0 {
+		t.Fatalf("item1 = %+v, want make build with ref 0", items[1])
+	}
+	if !items[2].selectable || items[2].name != "make test" || items[2].ref != 1 {
+		t.Fatalf("item2 = %+v, want make test with ref 1", items[2])
+	}
+	if items[3].selectable || items[3].name != "Global" {
+		t.Fatalf("item3 = %+v, want non-selectable Global heading", items[3])
+	}
+	if !items[4].selectable || items[4].name != "GitHub" || items[4].ref != 2 {
+		t.Fatalf("item4 = %+v, want GitHub with ref 2 (index into project++global)", items[4])
+	}
+
+	// Global-only: no headings, refs start at 0.
+	only := actionListItems(nil, global)
+	if len(only) != 1 {
+		t.Fatalf("got %d items for global-only, want 1 (no headings): %+v", len(only), only)
+	}
+	if !only[0].selectable || only[0].name != "GitHub" || only[0].ref != 0 {
+		t.Fatalf("global-only item = %+v, want GitHub ref 0 with no heading", only[0])
+	}
+}


### PR DESCRIPTION
## What

Quick actions can now be shipped **per-repo**. Drop a `.herdr-plus/quick-actions/` directory in a codebase and any `*.toml` actions there appear in the quick-actions picker — **only when you launch herdr-plus from inside that repo** — alongside your global actions, using the exact same TOML format.

The layout mirrors the global config, so a project dir is a drop-in mirror of `~/.config/herdr-plus/`:

```
your-repo/
  .herdr-plus/
    quick-actions/
      make-build.toml
      make-test.toml
```

## TUI: project vs global

The picker groups rows under **`Project`** and **`Global`** headings so it's always clear which is which:

```
⚡ Quick Actions

❯ Type to filter…        6/6

Project
▌ make build    Build the herdr-plus binary (make build)
  make test     Run the herdr-plus test suite (make test)

Global
  GitHub        Open https://github.com
  Google        Open google.com
```

Headings only appear when a repo actually has project actions — launch from a repo with no `.herdr-plus` and the list looks exactly as it did before (single, ungrouped). Start typing and the two groups merge into one ranked list (the picker drops headings while filtering).

## Design decisions

- **Layout:** `.herdr-plus/<mode-slug>/` mirrors the global per-mode structure.
- **Discovery:** exact working directory only (no walking up the tree).
- **Collisions:** if a project and global action share a name, both show (one per group) — no overriding.
- **Read-only & opt-in:** the project dir is never auto-created or seeded; it's read only when a repo provides it.

The launcher already gathers the invoking pane's working directory into `RunContext.WorkDir`, so no launcher changes were needed — the picker just consults `ctx.WorkDir`.

## Changes

- `action.go` — tag each `Action` with an `origin` (global vs project).
- `config.go` — extract `loadActionsFromDir(dir, origin)`; add `projectConfigDir` and `loadPickerActions` (a missing project dir contributes nothing; a malformed one fails loudly, same as global).
- `picker.go` — `actionListItems(project, global)` builds the grouped rows; `runPicker` now calls `loadPickerActions(mode, ctx.WorkDir)`.
- `.herdr-plus/quick-actions/{make-build,make-test}.toml` — ships this repo's own actions as a live example.
- Tests for the new loading + grouping paths, plus a README section.

## Verification

- `gofmt`, `go vet ./...`, `make build` clean.
- `go test ./...` passes (new + existing).
- Manual: from this repo, the quick-actions picker shows `make build` / `make test` under a **Project** heading above the globals; from a repo without `.herdr-plus`, the list is unchanged.