### PR TITLE
Add mouse click-to-run and wheel scrolling to both modes

### DIFF
--- a/control.go
+++ b/control.go
@@ -91,7 +91,10 @@ func runControl(controlWS string) {
 
 	dir, _ := projectsConfigDir()
 
-	p := tea.NewProgram(newControlModel(projects, dir), tea.WithAltScreen())
+	// WithMouseCellMotion enables click/release/wheel events so a project can be
+	// opened with the mouse. herdr forwards these to us once we ask for them;
+	// until then it keeps the mouse for its own pane focus/selection.
+	p := tea.NewProgram(newControlModel(projects, dir), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	result, err := p.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "herdr-plus:", err)

--- a/controlmodel.go
+++ b/controlmodel.go
@@ -19,6 +19,11 @@ import (
 // will live elsewhere later; for now the repo is the home of everything.
 const docsURL = "https://github.com/cloudmanic/herdr-plus"
 
+// controlHeaderLines is how many screen lines precede the embedded fuzzyList in
+// the projects browser: the full-width title bar and the blank line under it. A
+// mouse click's screen row minus this offset is the list-local line for clickRow.
+const controlHeaderLines = 2
+
 // Control-mode styles. These build on the shared palette declared in picker.go
 // (titleStyle, nameStyle, descStyle, footerStyle, …); here we add the few extra
 // pieces the full-screen projects browser needs.
@@ -119,22 +124,48 @@ func (m controlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.list.moveDown()
 			return m, nil
 		case "enter":
-			idx := m.list.selectedIndex()
-			if idx < 0 {
-				return m, nil
-			}
-			p := m.projects[idx]
-			m.chosen = &p
-			return m, tea.Quit
+			return m.activateProject()
 		}
 
 		cmd := m.list.editQuery(msg)
 		return m, cmd
+
+	case tea.MouseMsg:
+		// The onboarding card (no projects) has nothing to click.
+		if len(m.projects) == 0 {
+			return m, nil
+		}
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.list.moveUp()
+		case tea.MouseButtonWheelDown:
+			m.list.moveDown()
+		case tea.MouseButtonLeft:
+			// Move the highlight to the clicked row, opening it on release — the
+			// natural completion of a click.
+			if m.list.clickRow(msg.Y-controlHeaderLines) && msg.Action == tea.MouseActionRelease {
+				return m.activateProject()
+			}
+		}
+		return m, nil
 	}
 
 	// Non-key messages (e.g. the blink tick) keep the input alive.
 	cmd := m.list.editQuery(msg)
 	return m, cmd
+}
+
+// activateProject records the highlighted project as the chosen one and signals
+// a quit so its workspace gets built. Shared by the enter key and a left-click;
+// activating with nothing selectable is a no-op.
+func (m controlModel) activateProject() (tea.Model, tea.Cmd) {
+	idx := m.list.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	p := m.projects[idx]
+	m.chosen = &p
+	return m, tea.Quit
 }
 
 // View renders the screen for the current state: the onboarding card when there
@@ -168,7 +199,7 @@ func (m controlModel) browserView(w, h int) string {
 	body := m.list.view("no matching projects")
 
 	detail := m.detailBar(w)
-	footer := footerStyle.Render("  ↑/↓ move · type to filter · enter open · esc quit")
+	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · esc quit")
 
 	top := header + "\n\n" + body
 	bottom := detail + "\n" + footer

--- a/controlmodel_test.go
+++ b/controlmodel_test.go
@@ -89,6 +89,38 @@ func TestControlModelFilterThenSelect(t *testing.T) {
 	}
 }
 
+// TestControlModelMouseClickOpens confirms a left-button release over a project
+// row opens it — the click counterpart to enter. With the title bar and query
+// line above, the two projects sit at screen rows 4 (Alpha) and 5 (Bravo).
+func TestControlModelMouseClickOpens(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.MouseMsg{
+		Action: tea.MouseActionRelease,
+		Button: tea.MouseButtonLeft,
+		Y:      5,
+	})
+
+	if m.chosen == nil || m.chosen.Name != "Bravo" {
+		t.Fatalf("clicking the Bravo row chose %v, want Bravo", m.chosen)
+	}
+}
+
+// TestControlModelMouseWheelMoves confirms the scroll wheel walks the highlight
+// without opening anything.
+func TestControlModelMouseWheelMoves(t *testing.T) {
+	m := newControlModel(sampleProjects(), "/cfg/projects")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+
+	if m.chosen != nil {
+		t.Fatal("the wheel should not open a project")
+	}
+	if got := m.list.selectedIndex(); got != 1 {
+		t.Fatalf("after wheel down selected ref = %d, want 1 (Bravo)", got)
+	}
+}
+
 // TestControlModelBrowserView confirms the populated view shows the header, the
 // project names, and the highlighted project's working directory in the detail
 // bar.

--- a/fuzzylist.go
+++ b/fuzzylist.go
@@ -163,6 +163,48 @@ func (l *fuzzyList) selectedIndex() int {
 	return it.ref
 }
 
+// listPromptLines is how many lines view() renders before the first result row:
+// the query/prompt line and the blank spacer beneath it. rowIndexAt and view()
+// share it, so the two must always agree about the list's layout.
+const listPromptLines = 2
+
+// rowIndexAt maps a view-local screen line (line 0 is the query/prompt line) to
+// the index into filtered of the selectable row drawn there, or -1 when the line
+// is the prompt, a blank spacer, a separator/heading, or past the end of the
+// list. It mirrors view()'s exact line accounting — the prompt line, the blank
+// spacer, then one line per selectable row and a blank (plus an optional heading
+// line) per separator — so this and view() must change together.
+func (l *fuzzyList) rowIndexAt(y int) int {
+	line := listPromptLines
+	for i, s := range l.filtered {
+		if !s.item.selectable {
+			line++ // the separator's leading blank line
+			if s.item.name != "" {
+				line++ // its heading line
+			}
+			continue
+		}
+		if line == y {
+			return i
+		}
+		line++
+	}
+	return -1
+}
+
+// clickRow moves the highlight to the selectable row at view-local line y,
+// reporting whether y landed on one. It is the mouse counterpart to moveUp /
+// moveDown: the caller subtracts its own header height from the click's screen
+// row before calling, so y is measured from the top of view()'s own output.
+func (l *fuzzyList) clickRow(y int) bool {
+	idx := l.rowIndexAt(y)
+	if idx < 0 {
+		return false
+	}
+	l.cursor = idx
+	return true
+}
+
 // editQuery feeds a message to the query box and re-filters. Non-key messages
 // (such as the cursor blink tick) pass through harmlessly.
 func (l *fuzzyList) editQuery(msg tea.Msg) tea.Cmd {

--- a/fuzzylist_test.go
+++ b/fuzzylist_test.go
@@ -87,3 +87,75 @@ func TestFuzzyListViewCountExcludesSeparators(t *testing.T) {
 		t.Fatalf("view count should be 2/2 (separators excluded); got:\n%s", got)
 	}
 }
+
+// TestFuzzyListRowIndexAtMatchesView confirms rowIndexAt's line accounting agrees
+// with what view() actually renders — including the blank line and heading a
+// separator consumes — by finding each row's real screen line in the rendered
+// output and asking rowIndexAt to map it back to the right row. This guards the
+// "rowIndexAt and view() must change together" invariant.
+func TestFuzzyListRowIndexAtMatchesView(t *testing.T) {
+	items := []listItem{
+		{name: "alpha", selectable: true, ref: 0},
+		{name: "Group", selectable: false}, // blank + heading between the rows
+		{name: "bravo", selectable: true, ref: 2},
+		{name: "charlie", selectable: true, ref: 3},
+	}
+	l := newFuzzyList("", items)
+	lines := strings.Split(l.view("none"), "\n")
+
+	for _, tc := range []struct {
+		name string
+		ref  int
+	}{{"alpha", 0}, {"bravo", 2}, {"charlie", 3}} {
+		y := -1
+		for i, line := range lines {
+			if strings.Contains(line, tc.name) {
+				y = i
+				break
+			}
+		}
+		if y < 0 {
+			t.Fatalf("row %q not found in rendered view:\n%s", tc.name, l.view("none"))
+		}
+		idx := l.rowIndexAt(y)
+		if idx < 0 {
+			t.Fatalf("rowIndexAt(%d) for %q = -1, want a selectable row", y, tc.name)
+		}
+		if got := l.filtered[idx].item.ref; got != tc.ref {
+			t.Fatalf("rowIndexAt(%d) -> ref %d, want %d (%q)", y, got, tc.ref, tc.name)
+		}
+	}
+
+	// The blank spacer under the prompt and a line past the end are not rows.
+	if got := l.rowIndexAt(1); got != -1 {
+		t.Fatalf("rowIndexAt(1) = %d, want -1 (blank spacer under the prompt)", got)
+	}
+	if got := l.rowIndexAt(len(lines) + 5); got != -1 {
+		t.Fatalf("rowIndexAt past the end = %d, want -1", got)
+	}
+}
+
+// TestFuzzyListClickRow confirms clicking a row's line moves the highlight there
+// and reports success, while clicking a non-row line is a no-op that leaves the
+// cursor put.
+func TestFuzzyListClickRow(t *testing.T) {
+	items := []listItem{
+		{name: "alpha", selectable: true, ref: 0}, // view line 2
+		{name: "bravo", selectable: true, ref: 1}, // view line 3
+	}
+	l := newFuzzyList("", items)
+
+	if !l.clickRow(3) {
+		t.Fatal("clickRow(3) should land on bravo")
+	}
+	if got := l.selectedIndex(); got != 1 {
+		t.Fatalf("after clickRow(3) selected ref = %d, want 1 (bravo)", got)
+	}
+
+	if l.clickRow(1) { // the blank spacer line
+		t.Fatal("clickRow on a blank line should report no hit")
+	}
+	if got := l.selectedIndex(); got != 1 {
+		t.Fatalf("a missed click moved the cursor: ref = %d, want 1", got)
+	}
+}

--- a/picker.go
+++ b/picker.go
@@ -37,6 +37,11 @@ var (
 	headingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#8B5CF6")).Bold(true)
 )
 
+// pickerHeaderLines is how many screen lines precede the embedded fuzzyList in
+// every picker stage: the title bar and the blank line under it. A mouse click's
+// screen row minus this offset is the list-local line passed to clickRow.
+const pickerHeaderLines = 2
+
 // stage is which screen the picker is currently showing.
 type stage int
 
@@ -144,6 +149,9 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		return m, nil
 
+	case tea.MouseMsg:
+		return m.updateMouse(msg)
+
 	case tea.KeyMsg:
 		switch m.stage {
 		case stageActions:
@@ -156,6 +164,41 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m.forwardToInput(msg)
+}
+
+// updateMouse turns mouse input into list navigation: the wheel moves the
+// highlight, and the left button selects the row under the pointer — running it
+// on release, the natural completion of a click. The text-only form stage has no
+// list, so it ignores the mouse. This works only because herdr forwards mouse
+// events to the focused pane's program once that program enables mouse reporting
+// (which runPicker now does via tea.WithMouseCellMotion); otherwise herdr would
+// keep the clicks for its own pane focus/selection.
+func (m pickerModel) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	switch m.stage {
+	case stageActions:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.actionList.moveUp()
+		case tea.MouseButtonWheelDown:
+			m.actionList.moveDown()
+		case tea.MouseButtonLeft:
+			if m.actionList.clickRow(msg.Y-pickerHeaderLines) && msg.Action == tea.MouseActionRelease {
+				return m.activateAction()
+			}
+		}
+	case stageSelect:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.optionList.moveUp()
+		case tea.MouseButtonWheelDown:
+			m.optionList.moveDown()
+		case tea.MouseButtonLeft:
+			if m.optionList.clickRow(msg.Y-pickerHeaderLines) && msg.Action == tea.MouseActionRelease {
+				return m.activateOption()
+			}
+		}
+	}
+	return m, nil
 }
 
 // updateActions handles keys while choosing an action. Selecting a plain command
@@ -173,30 +216,37 @@ func (m pickerModel) updateActions(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.actionList.moveDown()
 		return m, nil
 	case "enter":
-		idx := m.actionList.selectedIndex()
-		if idx < 0 {
-			return m, nil
-		}
-		a := m.actions[idx]
-		switch a.effectiveType() {
-		case TypeSelect:
-			m.current = &a
-			m.optionList = newFuzzyList("Pick an option…", optionItems(a.Options))
-			m.stage = stageSelect
-			return m, textinput.Blink
-		case TypeForm:
-			m.current = &a
-			m.formInput = newFormInput(a.Form)
-			m.stage = stageForm
-			return m, textinput.Blink
-		default: // TypeCommand
-			m.chosen = &a
-			return m, tea.Quit
-		}
+		return m.activateAction()
 	}
 
 	cmd := m.actionList.editQuery(msg)
 	return m, cmd
+}
+
+// activateAction runs the highlighted action: a plain command quits so it can
+// run, while a select/form action advances to its input stage. It is shared by
+// the enter key and a left-click; activating with nothing selectable is a no-op.
+func (m pickerModel) activateAction() (tea.Model, tea.Cmd) {
+	idx := m.actionList.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	a := m.actions[idx]
+	switch a.effectiveType() {
+	case TypeSelect:
+		m.current = &a
+		m.optionList = newFuzzyList("Pick an option…", optionItems(a.Options))
+		m.stage = stageSelect
+		return m, textinput.Blink
+	case TypeForm:
+		m.current = &a
+		m.formInput = newFormInput(a.Form)
+		m.stage = stageForm
+		return m, textinput.Blink
+	default: // TypeCommand
+		m.chosen = &a
+		return m, tea.Quit
+	}
 }
 
 // updateSelect handles keys while choosing an option for a select action. esc
@@ -217,17 +267,24 @@ func (m pickerModel) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.optionList.moveDown()
 		return m, nil
 	case "enter":
-		idx := m.optionList.selectedIndex()
-		if idx < 0 {
-			return m, nil
-		}
-		m.value = m.current.Options[idx].resolvedValue()
-		m.chosen = m.current
-		return m, tea.Quit
+		return m.activateOption()
 	}
 
 	cmd := m.optionList.editQuery(msg)
 	return m, cmd
+}
+
+// activateOption records the highlighted option's value as the chosen action's
+// value and quits so the action runs. Shared by the enter key and a left-click;
+// activating with nothing selectable is a no-op.
+func (m pickerModel) activateOption() (tea.Model, tea.Cmd) {
+	idx := m.optionList.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	m.value = m.current.Options[idx].resolvedValue()
+	m.chosen = m.current
+	return m, tea.Quit
 }
 
 // updateForm handles keys while entering text for a form action. esc returns to
@@ -281,7 +338,7 @@ func (m pickerModel) View() string {
 		b.WriteString("\n\n")
 		b.WriteString(m.optionList.view("no matching options"))
 		b.WriteString("\n")
-		b.WriteString(footerStyle.Render("↑/↓ move • enter select • esc back"))
+		b.WriteString(footerStyle.Render("↑/↓ move • click/enter select • esc back"))
 
 	case stageForm:
 		b.WriteString(titleStyle.Render(m.current.Name))
@@ -302,7 +359,7 @@ func (m pickerModel) View() string {
 		b.WriteString("\n\n")
 		b.WriteString(m.actionList.view("no matching actions"))
 		b.WriteString("\n")
-		b.WriteString(footerStyle.Render("↑/↓ move • enter run • esc cancel"))
+		b.WriteString(footerStyle.Render("↑/↓ move • click/enter run • esc cancel"))
 	}
 
 	return b.String()
@@ -357,7 +414,10 @@ func runPicker(mode Mode, ctx RunContext, selfPane string) {
 		return
 	}
 
-	p := tea.NewProgram(newPickerModel(mode, ctx, actions), tea.WithAltScreen())
+	// WithMouseCellMotion enables click/release/wheel events so a row can be run
+	// with the mouse. herdr forwards these to us once we ask for them; until then
+	// it keeps the mouse for its own pane focus/selection.
+	p := tea.NewProgram(newPickerModel(mode, ctx, actions), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	result, err := p.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "herdr-plus:", err)

--- a/picker_test.go
+++ b/picker_test.go
@@ -6,7 +6,11 @@
 
 package main
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 // TestOptionItems confirms select options render their label plus optional
 // description (never the raw value), that separators become non-selectable
@@ -84,5 +88,49 @@ func TestActionListItems(t *testing.T) {
 	}
 	if !only[0].selectable || only[0].name != "GitHub" || only[0].ref != 0 {
 		t.Fatalf("global-only item = %+v, want GitHub ref 0 with no heading", only[0])
+	}
+}
+
+// TestPickerMouseClickRunsAction confirms a left-button release over a command
+// row selects that action and quits so it runs — the click counterpart to enter.
+// With a global-only list (no headings) the rows sit just below the title bar and
+// query line: "build" at screen row 4, "test" at row 5.
+func TestPickerMouseClickRunsAction(t *testing.T) {
+	actions := []Action{
+		{Name: "build", Command: "make build", origin: originGlobal},
+		{Name: "test", Command: "make test", origin: originGlobal},
+	}
+	m := newPickerModel(ModeQuickActions, RunContext{}, actions)
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Action: tea.MouseActionRelease,
+		Button: tea.MouseButtonLeft,
+		Y:      5,
+	})
+	pm, ok := updated.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated)
+	}
+	if pm.chosen == nil || pm.chosen.Name != "test" {
+		t.Fatalf("clicking the 'test' row chose %v, want test", pm.chosen)
+	}
+}
+
+// TestPickerMouseWheelMoves confirms the scroll wheel walks the highlight without
+// running anything.
+func TestPickerMouseWheelMoves(t *testing.T) {
+	actions := []Action{
+		{Name: "build", Command: "make build", origin: originGlobal},
+		{Name: "test", Command: "make test", origin: originGlobal},
+	}
+	m := newPickerModel(ModeQuickActions, RunContext{}, actions)
+
+	updated, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	pm := updated.(pickerModel)
+	if pm.chosen != nil {
+		t.Fatal("the wheel should not run an action")
+	}
+	if got := pm.actionList.selectedIndex(); got != 1 {
+		t.Fatalf("after wheel down selected ref = %d, want 1 (test)", got)
 	}
 }


### PR DESCRIPTION
## What

Makes the mouse work in both herdr-plus modes: click a project or action to run it, and use the scroll wheel to move the highlight. Previously neither mode requested the mouse, so clicks fell through to herdr's own pane focus/selection and felt broken.

## How it works

Both TUIs now start with `tea.WithMouseCellMotion()`. herdr forwards mouse events to a pane's program *only once that program enables mouse reporting* (`forward_pane_mouse_button` in herdr's input handling), so this cleanly claims the mouse for herdr-plus while it runs and yields it back on exit — the same path lazygit/htop use inside herdr. No herdr-side change, no conflict.

- **`fuzzyList`** gains `rowIndexAt` / `clickRow`: map a click's screen line to the selectable row drawn there (mirroring `view()`'s exact line accounting — prompt, blank spacer, one line per row, and the blank/heading a separator consumes) and move the highlight. Both modes share it.
- **Left click** moves the highlight on press and runs/opens on **release** (so a press-drag-away cancels). **Wheel** up/down walks the highlight.
- The form text field and the empty onboarding card ignore the mouse.
- Each `enter` path is refactored into a shared `activateAction` / `activateOption` / `activateProject` so key and click run identical code.
- Footers now advertise `click/enter`.

## The one tradeoff

While mouse reporting is on, a plain click-drag inside the pane goes to herdr-plus instead of triggering herdr's drag-to-select/copy — fine for a launcher, and how every mouse TUI behaves in a multiplexer. herdr's own chrome (tabs, borders, sidebar, scrollbars) is outside the pane's inner rect, so it's unaffected.

## Tests

`go build`, `go vet`, `go test ./...` all pass. Added: `rowIndexAt` cross-checked against real `view()` output (guards the "must change together" invariant), `clickRow`, plus click-runs and wheel-moves tests for both the picker and control models.