### PR TITLE
Make bare `herdr-plus install` bind both modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ picker there. Choose an action, and the pane closes itself when the action runs.
 ## Install the keybinding
 
 ```bash
-herdr-plus install                      # binds prefix+up -> control (the default mode)
-herdr-plus install --mode=quick-actions # binds prefix+down -> quick-actions
-herdr-plus install --key=prefix+a       # override the key for any mode
+herdr-plus install                      # binds BOTH modes: prefix+up -> control, prefix+down -> quick-actions
+herdr-plus install --mode=quick-actions # bind just quick-actions (prefix+down)
+herdr-plus install --key=prefix+a       # override the key for a single mode
 ```
 
-Each mode has its own default key (control → `prefix+up`, quick-actions →
-`prefix+down`), so the two can be installed side by side. Pass `--key` to override.
+A bare `herdr-plus install` wires up every mode on its own default key (control →
+`prefix+up`, quick-actions → `prefix+down`) in one shot. Pass `--mode` to install
+just one, and `--key` to override that mode's key.
 
 `install` adds a `[[keys.command]]` entry to herdr's `config.toml` that runs the
 **absolute path** of the binary you invoked, then reloads the running herdr

--- a/install.go
+++ b/install.go
@@ -24,29 +24,24 @@ type keybinding struct {
 	Command string
 }
 
-// runInstallCmd wires herdr-plus into herdr's config.toml as a keybinding so a
-// single keypress launches it. The bound command uses the absolute path of the
-// running binary, so it works no matter where herdr-plus lives or what the
-// current directory is. Re-running is safe: it detects an existing herdr-plus
-// binding and refuses to clobber a key already taken by something else.
+// runInstallCmd wires herdr-plus into herdr's config.toml as one or more
+// keybindings so a single keypress launches it. The bound command uses the
+// absolute path of the running binary, so it works no matter where herdr-plus
+// lives or what the current directory is. Re-running is safe: it detects an
+// existing herdr-plus binding and refuses to clobber a key already taken by
+// something else.
+//
+// With neither --mode nor --key, it installs EVERY mode on its own default key
+// (control → prefix+up, quick-actions → prefix+down) — the common case where a
+// bare `herdr-plus install` should wire up the whole add-on in one shot. An
+// explicit --mode (optionally with --key) installs just that single mode.
 func runInstallCmd(args []string) {
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
 	key := fs.String("key", "", "herdr keybinding to bind (default: the mode's own key, e.g. prefix+up for control)")
-	modeSlug := fs.String("mode", "", "which herdr-plus mode the keybinding launches (default: control)")
+	modeSlug := fs.String("mode", "", "which herdr-plus mode the keybinding launches (default: install every mode on its own key)")
 	_ = fs.Parse(args)
 
-	mode, err := lookupMode(*modeSlug)
-	if err != nil {
-		errExit(err)
-	}
-
-	// With no explicit --key, bind the mode's own default key so each mode lands
-	// on its conventional binding (control → prefix+up, quick-actions → prefix+down).
-	if *key == "" {
-		*key = mode.DefaultKey
-	}
-
-	// The absolute path of this very binary — what the keybinding will run.
+	// The absolute path of this very binary — what every keybinding will run.
 	self, err := selfBinaryPath()
 	if err != nil {
 		errExit(err)
@@ -57,6 +52,53 @@ func runInstallCmd(args []string) {
 		errExit(err)
 	}
 
+	// Bare install: bind each mode to its own default key in one pass, then
+	// reload once. A conflict on one mode is reported but does not stop the
+	// others, so installing both is as forgiving as possible.
+	if *modeSlug == "" && *key == "" {
+		wroteAny := false
+		for _, m := range orderedModes {
+			if wrote, _ := installMode(m, m.DefaultKey, self, cfgPath); wrote {
+				wroteAny = true
+			}
+		}
+		if wroteAny {
+			reloadHerdrConfig("")
+		}
+		return
+	}
+
+	// Single-mode install: resolve the requested mode and bind it on its own
+	// default key unless --key overrides.
+	mode, err := lookupMode(*modeSlug)
+	if err != nil {
+		errExit(err)
+	}
+	k := *key
+	if k == "" {
+		k = mode.DefaultKey
+	}
+
+	wrote, conflict := installMode(mode, k, self, cfgPath)
+	if conflict {
+		// installMode already explained the clash on stderr; exit non-zero so
+		// scripts notice the explicit install did not take.
+		os.Exit(1)
+	}
+	if wrote {
+		reloadHerdrConfig(k)
+	}
+}
+
+// installMode binds a single herdr-plus mode to key in herdr's config.toml. It
+// is idempotent per mode (each mode's command carries its own --mode, so two
+// modes never match each other) and never clobbers a key already taken by
+// something else. It returns wrote=true when it actually appended a new binding
+// — telling the caller the config needs a reload — and conflict=true when key
+// was already occupied by an unrelated command. It reads the file fresh on each
+// call, so looping over modes correctly sees bindings written earlier in the
+// same run.
+func installMode(mode Mode, key, self, cfgPath string) (wrote bool, conflict bool) {
 	command := shellQuote(self) + " --mode=" + mode.Slug
 	description := "herdr-plus: " + mode.Slug
 
@@ -64,32 +106,42 @@ func runInstallCmd(args []string) {
 	existing, _ := readKeybindings(cfgPath)
 
 	// Idempotent per mode: if THIS mode is already bound, report where and stop.
-	// Other modes share the binary but differ by --mode, so installing control
-	// does not trip over an existing quick-actions binding.
 	if b, ok := existingBinding(existing, command); ok {
-		if b.Key == *key {
+		if b.Key == key {
 			fmt.Printf("herdr-plus: %s already installed — press %s to launch it.\n", mode.Slug, b.Key)
 		} else {
-			fmt.Printf("herdr-plus: %s already installed at %s. Remove that binding in %s to rebind to %s.\n", mode.Slug, b.Key, cfgPath, *key)
+			fmt.Printf("herdr-plus: %s already installed at %s. Remove that binding in %s to rebind to %s.\n", mode.Slug, b.Key, cfgPath, key)
 		}
-		return
+		return false, false
 	}
 
 	// Don't clobber a key already used by anything else (including the other mode).
-	if b, ok := conflictBinding(existing, *key, command); ok {
-		errExit(fmt.Sprintf("key %q is already bound to: %s\nChoose a different key with --key (e.g. --key=prefix+a).", *key, b.Command))
+	if b, ok := conflictBinding(existing, key, command); ok {
+		fmt.Fprintf(os.Stderr, "herdr-plus: %s not installed: key %q is already bound to: %s\n  Choose a different key with --key (e.g. --key=prefix+a).\n", mode.Slug, key, b.Command)
+		return false, true
 	}
 
-	if err := appendToFile(cfgPath, keybindBlock(*key, command, description)); err != nil {
+	if err := appendToFile(cfgPath, keybindBlock(key, command, description)); err != nil {
 		errExit("could not write to", cfgPath+":", err)
 	}
-	fmt.Printf("herdr-plus: bound %s -> %s\n  in %s\n", *key, command, cfgPath)
+	fmt.Printf("herdr-plus: bound %s -> %s\n  in %s\n", key, command, cfgPath)
+	return true, false
+}
 
-	// Best effort: reload the running server so the binding is live immediately.
+// reloadHerdrConfig asks the running herdr server to reload its config so any
+// freshly added binding is live without a restart. It is best effort: a failure
+// just prints how to reload manually. keyHint, when non-empty, names the single
+// key to press in the success message; empty means several were bound, so the
+// message stays generic.
+func reloadHerdrConfig(keyHint string) {
 	if out, err := exec.Command("herdr", "server", "reload-config").CombinedOutput(); err != nil {
 		fmt.Printf("herdr-plus: saved, but reload failed (%v). Run `herdr server reload-config` or restart herdr.\n", strings.TrimSpace(string(out)))
+		return
+	}
+	if keyHint != "" {
+		fmt.Printf("herdr-plus: reloaded herdr config. Press your prefix, then %s, to launch.\n", strings.TrimPrefix(keyHint, "prefix+"))
 	} else {
-		fmt.Printf("herdr-plus: reloaded herdr config. Press your prefix, then %s, to launch.\n", strings.TrimPrefix(*key, "prefix+"))
+		fmt.Println("herdr-plus: reloaded herdr config. Press your prefix, then a bound key (e.g. up or down), to launch.")
 	}
 }
 

--- a/mode.go
+++ b/mode.go
@@ -39,11 +39,20 @@ var ModeQuickActions = Mode{Slug: "quick-actions", Title: "⚡ Quick Actions", D
 // front door of herdr-plus, so the bare binary opens it.
 var defaultMode = ModeControl
 
-// modes is every mode herdr-plus knows about, keyed by slug. Add new modes here.
-var modes = map[string]Mode{
-	ModeControl.Slug:      ModeControl,
-	ModeQuickActions.Slug: ModeQuickActions,
-}
+// orderedModes lists every mode herdr-plus knows about, in install order. A bare
+// `herdr-plus install` walks this slice so each mode lands on its conventional
+// key (control → prefix+up, quick-actions → prefix+down). Add new modes here.
+var orderedModes = []Mode{ModeControl, ModeQuickActions}
+
+// modes is every mode keyed by slug, derived from orderedModes so the lookup
+// table and the install order can never drift apart.
+var modes = func() map[string]Mode {
+	m := make(map[string]Mode, len(orderedModes))
+	for _, mode := range orderedModes {
+		m[mode.Slug] = mode
+	}
+	return m
+}()
 
 // lookupMode resolves a --mode slug to its Mode. An empty slug selects the
 // default mode; an unrecognized slug is an error so typos fail loudly instead of

--- a/www/content/docs/keybindings.md
+++ b/www/content/docs/keybindings.md
@@ -5,13 +5,15 @@ weight: 30
 ---
 
 You launch herdr-plus by pressing a herdr keybinding. The `herdr-plus install`
-command wires that binding into herdr for you.
+command wires those bindings into herdr for you.
 
 ## What `herdr-plus install` does
 
-`install` adds a `[[keys.command]]` entry to herdr's `config.toml` and reloads
-the running herdr server so the binding is live immediately. The entry it writes
-looks like this:
+A bare `herdr-plus install` installs **every mode at once**, each on its own
+default key (control → `prefix+up`, quick-actions → `prefix+down`). For each one
+it adds a `[[keys.command]]` entry to herdr's `config.toml`, then reloads the
+running herdr server so the bindings are live immediately. Pass `--mode` to
+install just a single mode. One entry looks like this:
 
 ```toml
 # herdr-plus — added by `herdr-plus install`
@@ -60,16 +62,20 @@ side without conflicting:
 | Control | `control` | `prefix+up` |
 | Quick Actions | `quick-actions` | `prefix+down` |
 
-When you run `install` without `--key`, it uses the mode's default.
+When you run `install` for a single mode without `--key`, it uses that mode's
+default.
 
 ## Installing both, side by side
 
+A bare `install` does this in one shot — it walks every mode and binds each to
+its default key:
+
 ```bash
-herdr-plus install                       # prefix+up   -> control
-herdr-plus install --mode=quick-actions  # prefix+down -> quick-actions
+herdr-plus install   # prefix+up -> control AND prefix+down -> quick-actions
 ```
 
-Now `prefix+up` opens Control mode and `prefix+down` opens Quick Actions.
+Now `prefix+up` opens Control mode and `prefix+down` opens Quick Actions. (You
+can still install them one at a time with `--mode` if you only want one.)
 
 ## Overriding the key
 

--- a/www/content/docs/quick-start.md
+++ b/www/content/docs/quick-start.md
@@ -37,16 +37,18 @@ overrides, and how upgrades work.
 
 ## 3. Install the keybindings
 
-`herdr-plus install` wires herdr-plus into herdr's `config.toml` as a keybinding
-and reloads the running herdr server, so the binding is live immediately.
+`herdr-plus install` wires herdr-plus into herdr's `config.toml` as keybindings
+and reloads the running herdr server, so the bindings are live immediately. A
+bare install binds **every mode at once**, each on its own default key:
 
 ```bash
-herdr-plus install                       # binds prefix+up   -> control (default mode)
-herdr-plus install --mode=quick-actions  # binds prefix+down -> quick-actions
+herdr-plus install                       # binds prefix+up -> control AND prefix+down -> quick-actions
+herdr-plus install --mode=quick-actions  # bind just quick-actions (prefix+down)
 ```
 
-Each mode claims its own default key, so the two coexist. Override any key with
-`--key=prefix+a`. See [Keybindings](../keybindings/) for the full story.
+Each mode claims its own default key, so the two coexist. Override a single
+mode's key with `--key=prefix+a`. See [Keybindings](../keybindings/) for the full
+story.
 
 ## 4. Press your prefix, then the key
 


### PR DESCRIPTION
## Problem

Running `./herdr-plus install` only bound `prefix+up`. A bare install resolved to the **default mode** (control), so quick-actions (`prefix+down`) was never wired up — you had to know to run `herdr-plus install --mode=quick-actions` separately.

## Fix

A bare `herdr-plus install` (no `--mode`, no `--key`) now installs **every mode at once**, each on its own default key:

- control → `prefix+up`
- quick-actions → `prefix+down`

…then reloads herdr once. An explicit `--mode`/`--key` still installs a single mode exactly as before. A key conflict on one mode during a bare install is reported but no longer aborts the others.

### Changes

- **`install.go`** — split the per-mode logic into `installMode` (returns whether it wrote a binding / hit a conflict) and `reloadHerdrConfig`. `runInstallCmd` loops over modes for the bare case, single mode otherwise.
- **`mode.go`** — added `orderedModes` for a deterministic install order and derived the `modes` lookup map from it so the list and map can't drift.
- **Docs** — `README.md`, `www/.../keybindings.md`, `www/.../quick-start.md` updated to reflect that a bare install binds both keys.

## Verification

`go build`, `go vet`, and `go test ./...` all pass. End-to-end against a throwaway config:

```
herdr-plus: bound prefix+up   -> '…' --mode=control
herdr-plus: bound prefix+down -> '…' --mode=quick-actions
herdr-plus: reloaded herdr config. Press your prefix, then a bound key (e.g. up or down), to launch.
```

Re-running is still idempotent — both report as already installed rather than duplicating.