### PR TITLE
Run tab/launch commands with a real Enter key so apps actually start

### DIFF
--- a/control.go
+++ b/control.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -52,14 +51,12 @@ func launchControl(client *herdrClient) {
 	// keeps its default numbered name.
 	_ = client.tabRename(tab, controlProjectsTabLabel)
 
-	// Give the freshly spawned shell a brief moment to initialize before we send
-	// the command that starts the control UI.
-	time.Sleep(250 * time.Millisecond)
-
 	// Start the control UI in the new pane, handing it the control workspace id so
 	// it can tear the whole workspace down when the user picks a project or quits.
-	launch := fmt.Sprintf("%s control %s\n", shellQuote(exe), ws)
-	if err := client.sendInput(pane, launch); err != nil {
+	// runCommand waits for the new shell's prompt and submits with a real Enter
+	// key (not a trailing newline — see sendInput), so the UI starts reliably.
+	launch := fmt.Sprintf("%s control %s", shellQuote(exe), ws)
+	if err := client.runCommand(pane, launch); err != nil {
 		errExit("failed to start control UI:", err)
 	}
 }
@@ -174,14 +171,13 @@ func openProject(client *herdrClient, p Project, controlWS string) error {
 		}
 	}
 
-	// Let the freshly spawned shells initialize before we type into them, then
-	// run each tab's startup command (as if typed at the prompt).
-	if len(runs) > 0 {
-		time.Sleep(300 * time.Millisecond)
-		for _, r := range runs {
-			if err := client.sendInput(r.pane, r.command+"\n"); err != nil {
-				return fmt.Errorf("run command in pane %s: %w", r.pane, err)
-			}
+	// Run each tab's startup command. runCommand paces itself to each freshly
+	// spawned shell — waiting for its prompt, typing the command, then submitting
+	// with a real Enter key — so the apps (claude, lazygit, …) actually start
+	// instead of sitting unsubmitted at the prompt for the user to press Enter.
+	for _, r := range runs {
+		if err := client.runCommand(r.pane, r.command); err != nil {
+			return fmt.Errorf("run command in pane %s: %w", r.pane, err)
 		}
 	}
 

--- a/herdr.go
+++ b/herdr.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
+	"time"
 )
 
 // herdrClient talks to the running herdr instance over its unix domain socket.
@@ -105,13 +107,125 @@ func (c *herdrClient) paneSplit(targetPaneID, direction string, focus bool) (str
 	return out.Pane.PaneID, nil
 }
 
-// sendInput writes text into a pane as if it were typed at the keyboard.
-// Include a trailing newline to submit a shell command.
-func (c *herdrClient) sendInput(paneID, text string) error {
-	return c.call("pane.send_input", map[string]any{
+// sendInput types text into a pane and then presses the given keys, as if at the
+// keyboard. The keys are herdr key names (e.g. "Enter") delivered as real key
+// events. To RUN a shell command, pass the command as text and "Enter" as the
+// sole key — do not embed a trailing newline in text. herdr's send_input treats
+// text as a paste: once the shell's line editor (zsh ZLE) is active it inserts an
+// embedded "\n" literally instead of executing the line, so the command would
+// just sit at the prompt until the user pressed Enter by hand. A real Enter key
+// always submits, which is also how herdr's own `pane run` works. Pass no keys
+// for plain typing with no submission.
+func (c *herdrClient) sendInput(paneID, text string, keys ...string) error {
+	params := map[string]any{
 		"pane_id": paneID,
 		"text":    text,
-	}, nil)
+	}
+	if len(keys) > 0 {
+		params["keys"] = keys
+	}
+	return c.call("pane.send_input", params, nil)
+}
+
+// paneRead returns the text currently shown in a pane. source selects which slice
+// of the terminal to read ("visible" for the on-screen rows, "recent" for the
+// recent scrollback); lines caps how many trailing lines come back. It exists so
+// tests can confirm a command actually ran — its output appeared — rather than
+// merely being typed at the prompt.
+func (c *herdrClient) paneRead(paneID, source string, lines int) (string, error) {
+	var out struct {
+		Read struct {
+			Text string `json:"text"`
+		} `json:"read"`
+	}
+	err := c.call("pane.read", map[string]any{
+		"pane_id": paneID,
+		"source":  source,
+		"lines":   lines,
+	}, &out)
+	if err != nil {
+		return "", err
+	}
+	return out.Read.Text, nil
+}
+
+// runCommand types command into a freshly created pane and submits it, pacing
+// itself to the shell's startup so the command actually runs instead of sitting
+// unsubmitted at the prompt. There are two startup races it has to dodge:
+//
+//   - Typing too early: a pane created moments ago may not have an interactive
+//     shell yet; keystrokes sent into that gap are dropped. So we first wait for
+//     the shell to draw its prompt.
+//   - Submitting too early: even once typing lands, pressing Enter before the
+//     shell's line editor has the text races startup and the line is lost. So we
+//     wait until the command visibly echoes before pressing Enter.
+//
+// Submission is a real Enter key, never a trailing "\n" in the text — herdr pastes
+// text, and an embedded newline is inserted literally once zsh's line editor is
+// active rather than running the line (see sendInput). Every wait is best effort:
+// on timeout we proceed anyway, so a slow or unusual shell degrades to the old
+// blind behavior rather than hanging.
+func (c *herdrClient) runCommand(paneID, command string) error {
+	// 1. Wait for the shell to be ready to receive input (its prompt is drawn).
+	c.waitForPaneReady(paneID, 5*time.Second)
+
+	// 2. Type the command (no trailing newline).
+	if err := c.sendInput(paneID, command); err != nil {
+		return err
+	}
+
+	// 3. Wait until the command echoes back, proving the line editor accepted it.
+	c.waitForPaneText(paneID, commandEchoProbe(command), 5*time.Second)
+
+	// 4. Submit with a real Enter key.
+	return c.sendInput(paneID, "", "Enter")
+}
+
+// commandEchoProbe returns a short, stable fragment of a command to look for when
+// confirming it was typed at the prompt: the first line, capped to a few
+// characters so it stays on a single terminal row. A long command wraps across
+// rows, so matching the whole string against the rendered screen would fail; a
+// short leading fragment does not wrap and is specific enough on an otherwise
+// empty fresh pane.
+func commandEchoProbe(command string) string {
+	probe := command
+	if i := strings.IndexByte(probe, '\n'); i >= 0 {
+		probe = probe[:i]
+	}
+	if len(probe) > 12 {
+		probe = probe[:12]
+	}
+	return strings.TrimSpace(probe)
+}
+
+// waitForPaneReady blocks until the pane shows any non-blank content — its shell
+// prompt — or the timeout elapses. A fresh pane is blank until its shell starts
+// and prints a prompt, so non-blank content is a good "ready for input" signal.
+// Best effort: a timeout just means we stop waiting and proceed.
+func (c *herdrClient) waitForPaneReady(paneID string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if text, err := c.paneRead(paneID, "visible", 5); err == nil && strings.TrimSpace(text) != "" {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitForPaneText blocks until the pane's visible text contains probe or the
+// timeout elapses. An empty probe returns immediately. Best effort, like
+// waitForPaneReady: a timeout returns without error and the caller proceeds.
+func (c *herdrClient) waitForPaneText(paneID, probe string, timeout time.Duration) {
+	if probe == "" {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if text, err := c.paneRead(paneID, "visible", 20); err == nil && strings.Contains(text, probe) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // closePane terminates a pane and frees its terminal. Closing the focused pane

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -8,7 +8,9 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestLiveSocketWorkspaceLifecycle exercises the real workspace/tab socket
@@ -55,8 +57,26 @@ func TestLiveSocketWorkspaceLifecycle(t *testing.T) {
 		t.Fatal("tabCreate returned empty pane id")
 	}
 
-	// Run a harmless command in the new pane the same way openProject does.
-	if err := client.sendInput(pane2, "true\n"); err != nil {
-		t.Fatalf("sendInput: %v", err)
+	// Run a command in the new pane the exact way openProject does — through
+	// runCommand — and confirm it actually executed by reading back its output.
+	// This is the regression guard for the bug where the command was only typed at
+	// the prompt (a trailing "\n" never submitted), so the app never started until
+	// the user pressed Enter. runCommand owns the startup-race handling (wait for
+	// prompt, type, wait for echo, real Enter), so the test needs no manual delays.
+	const marker = "herdr_plus_run_marker_8842"
+	if err := client.runCommand(pane2, "echo "+marker); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+
+	// Give the shell a moment to run the command, then read the pane. The marker
+	// must appear twice: once as the typed command line and once as echo's output.
+	// A single occurrence means it was typed but never submitted — the bug.
+	time.Sleep(750 * time.Millisecond)
+	out, err := client.paneRead(pane2, "visible", 20)
+	if err != nil {
+		t.Fatalf("paneRead: %v", err)
+	}
+	if got := strings.Count(out, marker); got < 2 {
+		t.Fatalf("command did not run: marker %q appeared %d time(s), want >= 2 (echoed command + its output). pane:\n%s", marker, got, out)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/cloudmanic/herdr-plus/internal/version"
 )
@@ -142,14 +141,12 @@ func launchPicker(client *herdrClient, mode Mode) {
 		errExit("split failed:", err)
 	}
 
-	// Give the freshly spawned shell a brief moment to initialize before we send
-	// the command that starts the picker.
-	time.Sleep(250 * time.Millisecond)
-
 	// Start the picker in the new pane, handing it the mode, the encoded context,
-	// and the new pane's id so it can close itself when done.
-	launch := fmt.Sprintf("%s picker --mode=%s --ctx=%s %s\n", shellQuote(exe), mode.Slug, encoded, newPane)
-	if err := client.sendInput(newPane, launch); err != nil {
+	// and the new pane's id so it can close itself when done. runCommand waits for
+	// the new shell's prompt and submits with a real Enter key (not a trailing
+	// newline — see sendInput), so the picker starts reliably.
+	launch := fmt.Sprintf("%s picker --mode=%s --ctx=%s %s", shellQuote(exe), mode.Slug, encoded, newPane)
+	if err := client.runCommand(newPane, launch); err != nil {
 		errExit("failed to start picker:", err)
 	}
 }


### PR DESCRIPTION
## Problem

Opening a project laid out all its tabs, but the startup apps (claude, lazygit, editor, …) never ran — the command just sat typed at the prompt until you pressed **Enter** by hand. Reproduced on herdr 0.6.8 + herdr-plus 0.0.6 (brew).

## Root cause

The launch paths submitted commands by sending the text with a trailing newline (`command + "\n"`). herdr's `pane.send_input` treats the `text` field as a **paste**, so once the shell's line editor (zsh ZLE) is active an embedded `\n` is inserted **literally** instead of running the line. A real `Enter` **key** always submits — which is also how herdr's own `pane run` works.

This was confirmed empirically against the live socket: text-with-`\n` is typed but never executes; `keys:["Enter"]` runs it. It also explains why control-mode launch worked but project tabs didn't — the old `\n` happens to submit in a *fresh* shell's cooked mode, but is typed literally once ZLE has taken over (which it has by the time `openProject` finishes creating every tab).

## Fix

Add `herdrClient.runCommand`, which paces itself to a freshly spawned shell instead of guessing with fixed delays:

1. wait for the shell to draw its prompt (ready for input),
2. type the command,
3. wait until it echoes back (the line editor accepted it),
4. submit with a real `Enter` key.

Every wait is best-effort (proceeds on timeout), and there are no magic millisecond constants, so it adapts to slow and fast machines alike — which is what made this flaky across machines in the first place. `openProject`, `launchControl`, and `launchPicker` all route through it.

## Testing

- `go build` / `go vet` / `go test` clean.
- The live socket test (`HERDR_PLUS_LIVE=1`) now drives `runCommand` and asserts the command's output actually appears (regression guard for "typed but not submitted"). Ran it 6× back-to-back on a loaded machine: 6/6 pass.