### PR TITLE
Add product-tour video to the home page hero

### DIFF
--- a/www/hugo.toml
+++ b/www/hugo.toml
@@ -35,7 +35,7 @@ disableKinds = ["taxonomy", "term", "RSS"]
   # The product-tour video. Paste a YouTube/Vimeo *embed* URL here (e.g.
   # https://www.youtube.com/embed/XXXX) and the hero swaps the animated
   # terminal placeholder for the real video automatically. Empty = placeholder.
-  heroVideoUrl = ""
+  heroVideoUrl = "https://www.youtube.com/embed/G-_4QAA53s4"
 
   # External references — single source of truth, surfaced across templates.
   githubUrl       = "https://github.com/cloudmanic/herdr-plus"


### PR DESCRIPTION
Sets \`heroVideoUrl\` in \`www/hugo.toml\` to the published YouTube product tour, so the home page hero swaps the animated terminal placeholder for the real embedded video.

- Video: https://youtu.be/G-_4QAA53s4
- Embed URL used: \`https://www.youtube.com/embed/G-_4QAA53s4\`