### PR TITLE
Point the site at the herdrplus.com custom domain

### DIFF
--- a/www/hugo.toml
+++ b/www/hugo.toml
@@ -8,14 +8,15 @@
 # Configuration for the public herdr-plus site. Built by the GitHub Actions
 # workflow at .github/workflows/site.yml and deployed to GitHub Pages.
 #
-# baseURL note: until herdrplus.com is purchased and pointed here, the site
-# lives at the GitHub Pages *project* URL, which has a /herdr-plus/ path
-# prefix. Every asset/link in the templates uses Hugo's relURL/.RelPermalink
-# so it survives the subpath. When the custom domain is ready: change baseURL
-# to "https://herdrplus.com/", drop a CNAME file in static/, and redeploy.
+# baseURL: the site is served from the custom domain herdrplus.com via GitHub
+# Pages (with www → apex redirect). The custom domain is published by the
+# CNAME file at www/static/CNAME, which Hugo copies to the site root. Every
+# asset/link in the templates still uses Hugo's relURL/.RelPermalink, so the
+# build also works under the GitHub Pages *project* path
+# (cloudmanic.github.io/herdr-plus/) should the custom domain ever be removed.
 #
 
-baseURL          = "https://cloudmanic.github.io/herdr-plus/"
+baseURL          = "https://herdrplus.com/"
 locale           = "en-US"
 title            = "herdr plus"
 enableRobotsTXT  = true

--- a/www/static/CNAME
+++ b/www/static/CNAME
@@ -1,0 +1,1 @@
+herdrplus.com


### PR DESCRIPTION
Cuts the marketing/docs site over to the **herdrplus.com** custom domain on GitHub Pages.

- Set Hugo \`baseURL\` to \`https://herdrplus.com/\`.
- Add \`www/static/CNAME\` (\`herdrplus.com\`) so the Pages build publishes the custom domain. Hugo copies it to the site root.

DNS is already pointed at GitHub Pages at Porkbun (apex A/AAAA → Pages IPs, \`www\` CNAME → \`cloudmanic.github.io\`). Merging this triggers the \`Site\` workflow to build and deploy; the Pages custom domain + HTTPS are set on the repo after deploy.

Templates use \`relURL\`/\`.RelPermalink\`, so the build still works under the project path if the domain is ever removed.