### PR TITLE
Worktree auto-layout (worktree.created event)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,47 @@ split = "down"
 A tab uses *either* `command` *or* `[[tabs.panes]]`, not both. In the projects list,
 split tabs are shown with a `×N` pane count (e.g. `server ×2`).
 
+## Worktree auto-layout
+
+herdr-plus can lay a project-style tab layout into a git **worktree** the moment
+herdr creates it. When you run `herdr worktree create` (or open one), herdr makes a
+fresh workspace for the worktree and fires a `worktree.created` event; herdr-plus
+catches it, finds a layout matching the worktree's repo, and opens that layout's
+tabs and panes in the new workspace — every command running — with no keypress.
+This is the plugin system's `[[events]]` hook (declared in
+[`herdr-plugin.toml`](herdr-plugin.toml)) put to work.
+
+Layouts live in `~/.config/herdr-plus/worktrees/`, one TOML file per layout (the
+file name doesn't matter). A layout is a `repo` matcher plus the same `[[tabs]]`
+format projects use:
+
+```toml
+repo = "options-cafe"          # matches the worktree's repo name (case-insensitive)
+
+[[tabs]]
+name = "claude"
+command = "claude --dangerously-skip-permissions --chrome"
+
+[[tabs]]
+name = "lazygit"
+command = "lazygit"
+
+[[tabs]]
+name = "terminal"              # no command — just an empty shell
+```
+
+- **`repo`** (required) matches the new worktree's repository name — the repo's
+  basename, e.g. `options-cafe` — case-insensitively.
+- **`branch`** (optional) narrows a layout to worktrees created on exactly that
+  branch. When more than one layout matches, a branch-specific one wins over a
+  repo-only one.
+- **`[[tabs]]`** is identical to a project's tabs, including multi-pane
+  `[[tabs.panes]]` splits (see [Split panes within a tab](#split-panes-within-a-tab)).
+
+With no files in `worktrees/`, the feature is inert — every worktree fires the
+event, and herdr-plus does nothing when nothing matches. The handler's output
+shows up in `herdr plugin log list --plugin cloudmanic.herdr-plus`.
+
 ## Installing
 
 herdr-plus is a herdr plugin (requires **herdr ≥ 0.7.0**). Installing it registers

--- a/control.go
+++ b/control.go
@@ -131,21 +131,44 @@ func openProject(client *herdrClient, p Project, controlWS string) error {
 		return fmt.Errorf("create workspace: %w", err)
 	}
 
+	// Lay the project's tabs into the freshly created workspace.
+	if err := layoutTabs(client, ws, rootTab, rootPane, p.Tabs); err != nil {
+		return err
+	}
+
+	// Tear down the ephemeral control workspace. Focus is already on the new
+	// project workspace, so this only removes the launcher. This also closes the
+	// pane this process is running in, so it is the last thing we do.
+	if controlWS != "" {
+		_ = client.workspaceClose(controlWS)
+	}
+	return nil
+}
+
+// layoutTabs lays an ordered list of tabs — each with its panes and optional
+// startup commands — into an existing workspace whose root tab and root pane are
+// rootTab and rootPane. tab[0] reuses the root tab (renamed) and root pane; each
+// later tab is created without focus so the first stays in front while the rest
+// spin up. Within a tab the first pane is the tab's root and each later pane is
+// split off the previous one. Every startup command is run last, once all panes
+// exist, paced to its freshly spawned shell.
+//
+// It is shared by control mode — which creates the workspace first, then fills
+// it — and the worktree.created handler, where herdr has already made the
+// worktree's workspace and we only need to populate it.
+func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []ProjectTab) error {
 	// pendingRun pairs a pane with the command it should run once all panes exist.
 	type pendingRun struct {
 		pane    string
 		command string
 	}
 	var runs []pendingRun
+	var err error
 
-	// Create every tab in the project's order. tab[0] reuses the workspace's root
-	// tab (renamed); each later tab is created without focus so the first tab
-	// stays in front while the rest spin up. Within a tab, the first pane is the
-	// tab's root and each later pane is split off the previous one.
-	for i, t := range p.Tabs {
+	for i, t := range tabs {
 		tabRoot := rootPane
 		if i == 0 {
-			if err := client.tabRename(rootTab, t.Name); err != nil {
+			if err = client.tabRename(rootTab, t.Name); err != nil {
 				return fmt.Errorf("rename root tab: %w", err)
 			}
 		} else {
@@ -179,13 +202,6 @@ func openProject(client *herdrClient, p Project, controlWS string) error {
 		if err := client.runCommand(r.pane, r.command); err != nil {
 			return fmt.Errorf("run command in pane %s: %w", r.pane, err)
 		}
-	}
-
-	// Tear down the ephemeral control workspace. Focus is already on the new
-	// project workspace, so this only removes the launcher. This also closes the
-	// pane this process is running in, so it is the last thing we do.
-	if controlWS != "" {
-		_ = client.workspaceClose(controlWS)
 	}
 	return nil
 }

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -44,3 +44,11 @@ command = ["./bin/herdr-plus", "--mode=control"]
 id = "quick-actions"
 title = "Quick Actions"
 command = ["./bin/herdr-plus", "--mode=quick-actions"]
+
+# Worktree auto-layout — when herdr creates a git worktree, this fires and lays a
+# matching layout's tabs/panes into the worktree's workspace (herdr has already
+# created the workspace). Layouts live in ~/.config/herdr-plus/worktrees/ and
+# match by repo (and optionally branch); with none configured this is a no-op.
+[[events]]
+on = "worktree.created"
+command = ["./bin/herdr-plus", "on-worktree-created"]

--- a/main.go
+++ b/main.go
@@ -14,11 +14,13 @@ import (
 	"github.com/cloudmanic/herdr-plus/internal/version"
 )
 
-// main dispatches between the two modes of the binary. The bare binary
-// (optionally with --mode) is the launcher: it opens a bottom split and starts
-// the picker inside it. The hidden "picker" subcommand renders the fuzzy-finder
-// TUI and, on exit, closes its own pane. The launcher re-invokes itself in
-// picker mode, so end users only ever run the bare binary.
+// main dispatches between the binary's entry points. The bare binary (optionally
+// with --mode) is the launcher: it opens a bottom split and starts the picker
+// inside it. The hidden "picker" subcommand renders the fuzzy-finder TUI and, on
+// exit, closes its own pane; the launcher re-invokes itself in picker mode, so
+// end users only ever run the bare binary. The "on-worktree-created" subcommand
+// is herdr's worktree.created event handler — herdr runs it (via the [[events]]
+// entry in herdr-plugin.toml), not the user.
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -27,6 +29,9 @@ func main() {
 			return
 		case "picker":
 			runPickerCmd(os.Args[2:])
+			return
+		case "on-worktree-created":
+			runOnWorktreeCreated(os.Args[2:])
 			return
 		case "version", "--version", "-v", "-V":
 			fmt.Println("herdr-plus", version.Version)

--- a/project.go
+++ b/project.go
@@ -180,15 +180,24 @@ func (p Project) validate() error {
 	if len(p.Tabs) == 0 {
 		return fmt.Errorf("project %q (%s): needs at least one [[tabs]] entry", p.Name, p.source)
 	}
-	for i, t := range p.Tabs {
+	return validateTabs(p.Name, p.source, p.Tabs)
+}
+
+// validateTabs checks the per-tab rules shared by projects and worktree layouts:
+// every tab needs a name; a tab uses either a single command or [[tabs.panes]],
+// never both; a tab holds at most maxPanesPerTab panes; and every non-root pane's
+// split is "down" or "right". label and source identify the owning config in
+// error messages — a project's name or a layout's repo, and the file it came from.
+func validateTabs(label, source string, tabs []ProjectTab) error {
+	for i, t := range tabs {
 		if strings.TrimSpace(t.Name) == "" {
-			return fmt.Errorf("project %q (%s): tab %d is missing a name", p.Name, p.source, i+1)
+			return fmt.Errorf("%q (%s): tab %d is missing a name", label, source, i+1)
 		}
 		if len(t.Panes) > 0 && strings.TrimSpace(t.Command) != "" {
-			return fmt.Errorf("project %q (%s): tab %q sets both command and [[tabs.panes]]; use one or the other", p.Name, p.source, t.Name)
+			return fmt.Errorf("%q (%s): tab %q sets both command and [[tabs.panes]]; use one or the other", label, source, t.Name)
 		}
 		if len(t.Panes) > maxPanesPerTab {
-			return fmt.Errorf("project %q (%s): tab %q has %d panes; at most %d are allowed", p.Name, p.source, t.Name, len(t.Panes), maxPanesPerTab)
+			return fmt.Errorf("%q (%s): tab %q has %d panes; at most %d are allowed", label, source, t.Name, len(t.Panes), maxPanesPerTab)
 		}
 		for j, pane := range t.Panes {
 			if j == 0 {
@@ -198,7 +207,7 @@ func (p Project) validate() error {
 			case "", SplitDown, SplitRight:
 				// ok — an empty split defaults to "down"
 			default:
-				return fmt.Errorf("project %q (%s): tab %q pane %d has split %q; must be %q or %q", p.Name, p.source, t.Name, j+1, pane.Split, SplitDown, SplitRight)
+				return fmt.Errorf("%q (%s): tab %q pane %d has split %q; must be %q or %q", label, source, t.Name, j+1, pane.Split, SplitDown, SplitRight)
 			}
 		}
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -1,0 +1,268 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// WorktreeLayout is a declarative tab layout applied automatically when a herdr
+// git worktree is created. Where a Project is opened on demand and creates its
+// own workspace, a worktree layout reacts to herdr's `worktree.created` event:
+// herdr has already made the worktree's workspace, so the layout just fills it
+// with tabs. It reuses the same ProjectTab model, so worktree layouts get the
+// full single-command / split-pane vocabulary that projects have.
+//
+// Layouts live in ~/.config/herdr-plus/worktrees/, one TOML file per layout (the
+// file name does not matter). With no files there, the feature is simply inert.
+type WorktreeLayout struct {
+	// Repo selects which worktrees this layout applies to, matched
+	// case-insensitively against the new worktree's repo name (the repository's
+	// basename, e.g. "options-cafe"). Required.
+	Repo string `toml:"repo"`
+
+	// Branch, when set, narrows the layout to worktrees created on exactly this
+	// branch (case-insensitive). Empty applies to every branch of the repo, and a
+	// branch-specific layout is preferred over a repo-only one when both match.
+	Branch string `toml:"branch"`
+
+	// Tabs is the ordered list of tabs to open in the worktree's workspace,
+	// identical in shape to a Project's tabs (a single `command`, or multiple
+	// [[tabs.panes]] splits).
+	Tabs []ProjectTab `toml:"tabs"`
+
+	// source is the file the layout was loaded from, used only for error and log
+	// messages. It is not part of the on-disk format.
+	source string
+}
+
+// validate checks that a layout is internally consistent before we ever act on a
+// worktree event, turning config mistakes into clear errors at load time.
+func (l WorktreeLayout) validate() error {
+	if strings.TrimSpace(l.Repo) == "" {
+		return fmt.Errorf("worktree layout %s: repo is required", l.source)
+	}
+	if len(l.Tabs) == 0 {
+		return fmt.Errorf("worktree layout %q (%s): needs at least one [[tabs]] entry", l.Repo, l.source)
+	}
+	return validateTabs(l.Repo, l.source, l.Tabs)
+}
+
+// matches reports whether this layout applies to the given worktree event. The
+// repo must match (against either the repo name or the basename of the repo
+// root, case-insensitively); a layout with a Branch additionally requires the
+// worktree's branch to match.
+func (l WorktreeLayout) matches(ev worktreeEvent) bool {
+	repo := strings.TrimSpace(l.Repo)
+	if !strings.EqualFold(repo, ev.RepoName) && !strings.EqualFold(repo, filepath.Base(ev.RepoRoot)) {
+		return false
+	}
+	if l.Branch != "" && !strings.EqualFold(strings.TrimSpace(l.Branch), ev.Branch) {
+		return false
+	}
+	return true
+}
+
+// worktreesConfigDir returns the directory that holds worktree layout files,
+// ~/.config/herdr-plus/worktrees. Like projects, it hangs directly off the
+// herdr-plus config root rather than under a mode slug.
+func worktreesConfigDir() (string, error) {
+	base, err := configBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "worktrees"), nil
+}
+
+// loadWorktreeLayouts reads, parses, and validates every *.toml layout in the
+// worktrees directory, returning them sorted by file name. A missing directory
+// yields no layouts and no error, so the feature is opt-in: with nothing there,
+// the worktree handler is a no-op. A malformed or invalid file fails the whole
+// load with a message naming the offending files, so config mistakes surface in
+// the plugin log instead of a layout silently going missing.
+func loadWorktreeLayouts() ([]WorktreeLayout, error) {
+	dir, err := worktreesConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var layouts []WorktreeLayout
+	var problems []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+
+		var l WorktreeLayout
+		if _, err := toml.DecodeFile(path, &l); err != nil {
+			problems = append(problems, fmt.Sprintf("  %s: %v", e.Name(), err))
+			continue
+		}
+		l.source = e.Name()
+		if err := l.validate(); err != nil {
+			problems = append(problems, "  "+err.Error())
+			continue
+		}
+		layouts = append(layouts, l)
+	}
+
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("invalid worktree layout files in %s:\n%s", dir, strings.Join(problems, "\n"))
+	}
+
+	sort.Slice(layouts, func(i, j int) bool { return layouts[i].source < layouts[j].source })
+	return layouts, nil
+}
+
+// matchWorktreeLayout returns the best layout for an event, if any. Among all
+// matching layouts a branch-specific one wins over a repo-only one (it is more
+// specific); ties break by file name, which loadWorktreeLayouts already sorts by.
+func matchWorktreeLayout(layouts []WorktreeLayout, ev worktreeEvent) (WorktreeLayout, bool) {
+	var best WorktreeLayout
+	found := false
+	for _, l := range layouts {
+		if !l.matches(ev) {
+			continue
+		}
+		if !found {
+			best, found = l, true
+			continue
+		}
+		// A branch-specific match beats the repo-only match we already have.
+		if best.Branch == "" && l.Branch != "" {
+			best = l
+		}
+	}
+	return best, found
+}
+
+// worktreeEvent is the subset of the `worktree.created` payload herdr-plus acts
+// on: the repo and branch (for matching a layout) plus the ids of the workspace,
+// root tab, and root pane herdr already created for the worktree (to lay the
+// layout into).
+type worktreeEvent struct {
+	WorkspaceID  string
+	RootTabID    string
+	RootPaneID   string
+	RepoName     string
+	RepoRoot     string
+	Branch       string
+	CheckoutPath string
+}
+
+// worktreeCreatedPayload mirrors the JSON herdr puts in HERDR_PLUGIN_EVENT_JSON
+// for a `worktree.created` event. Only the fields we use are declared.
+type worktreeCreatedPayload struct {
+	Data struct {
+		Workspace struct {
+			WorkspaceID string `json:"workspace_id"`
+			ActiveTabID string `json:"active_tab_id"`
+			Worktree    struct {
+				RepoName     string `json:"repo_name"`
+				RepoRoot     string `json:"repo_root"`
+				CheckoutPath string `json:"checkout_path"`
+			} `json:"worktree"`
+		} `json:"workspace"`
+		Worktree struct {
+			Path   string `json:"path"`
+			Branch string `json:"branch"`
+		} `json:"worktree"`
+	} `json:"data"`
+}
+
+// parseWorktreeEvent builds a worktreeEvent from the event JSON and the plugin
+// environment. herdr provides the workspace/tab/pane ids both as HERDR_* env vars
+// and (for workspace and tab) inside the payload; we prefer the env vars and fall
+// back to the payload. The root pane id comes only from HERDR_PANE_ID. getenv is
+// injected so the parsing is unit-testable without touching the real environment.
+func parseWorktreeEvent(eventJSON string, getenv func(string) string) (worktreeEvent, error) {
+	var p worktreeCreatedPayload
+	if strings.TrimSpace(eventJSON) != "" {
+		if err := json.Unmarshal([]byte(eventJSON), &p); err != nil {
+			return worktreeEvent{}, fmt.Errorf("parse HERDR_PLUGIN_EVENT_JSON: %w", err)
+		}
+	}
+	return worktreeEvent{
+		WorkspaceID:  firstNonEmpty(getenv("HERDR_WORKSPACE_ID"), p.Data.Workspace.WorkspaceID),
+		RootTabID:    firstNonEmpty(getenv("HERDR_TAB_ID"), p.Data.Workspace.ActiveTabID),
+		RootPaneID:   getenv("HERDR_PANE_ID"),
+		RepoName:     p.Data.Workspace.Worktree.RepoName,
+		RepoRoot:     p.Data.Workspace.Worktree.RepoRoot,
+		Branch:       p.Data.Worktree.Branch,
+		CheckoutPath: firstNonEmpty(p.Data.Worktree.Path, p.Data.Workspace.Worktree.CheckoutPath),
+	}, nil
+}
+
+// firstNonEmpty returns the first argument that is not the empty string, or ""
+// when all are empty.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// runOnWorktreeCreated is the `worktree.created` event handler herdr invokes (via
+// the [[events]] entry in herdr-plugin.toml). It finds the layout that matches the
+// new worktree and lays its tabs into the workspace herdr already created. With no
+// matching layout it does nothing — every worktree fires this, so a quiet no-op is
+// the common, correct case. Output goes to stdout/stderr, which herdr captures in
+// the plugin log (`herdr plugin log list --plugin cloudmanic.herdr-plus`).
+func runOnWorktreeCreated(_ []string) {
+	ev, err := parseWorktreeEvent(os.Getenv("HERDR_PLUGIN_EVENT_JSON"), os.Getenv)
+	if err != nil {
+		errExit("worktree event:", err)
+	}
+
+	layouts, err := loadWorktreeLayouts()
+	if err != nil {
+		errExit(err)
+	}
+
+	layout, ok := matchWorktreeLayout(layouts, ev)
+	if !ok {
+		// No layout for this repo/branch — the expected case for most worktrees.
+		fmt.Printf("herdr-plus: no worktree layout matches repo %q (branch %q); nothing to do.\n", ev.RepoName, ev.Branch)
+		return
+	}
+
+	// We need the workspace herdr made for the worktree and its root tab/pane to
+	// build on. They should always be present for a worktree.created event; bail
+	// loudly if not so the failure is visible in the plugin log.
+	if ev.WorkspaceID == "" || ev.RootTabID == "" || ev.RootPaneID == "" {
+		errExit(fmt.Sprintf("worktree event missing ids (workspace=%q tab=%q pane=%q)", ev.WorkspaceID, ev.RootTabID, ev.RootPaneID))
+	}
+
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+
+	if err := layoutTabs(client, ev.WorkspaceID, ev.RootTabID, ev.RootPaneID, layout.Tabs); err != nil {
+		errExit("apply worktree layout:", err)
+	}
+
+	fmt.Printf("herdr-plus: applied worktree layout %q to repo %q (branch %q): %d tab(s).\n", layout.source, ev.RepoName, ev.Branch, len(layout.Tabs))
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1,0 +1,199 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// realEventJSON is a verbatim HERDR_PLUGIN_EVENT_JSON payload captured from herdr
+// 0.7.0 for a worktree.created event. Parsing the real thing (not a hand-made
+// approximation) is what keeps parseWorktreeEvent honest against herdr's wire
+// format.
+const realEventJSON = `{"event":"worktree_created","data":{"type":"worktree_created","workspace":{"workspace_id":"w5","number":11,"label":"WT Probe","focused":false,"pane_count":1,"tab_count":1,"active_tab_id":"w5:t1","agent_status":"unknown","worktree":{"repo_key":"/private/tmp/wt-probe-repo/.git","repo_name":"wt-probe-repo","repo_root":"/tmp/wt-probe-repo","checkout_path":"/tmp/wt-probe-repo-wt","is_linked_worktree":true}},"worktree":{"path":"/tmp/wt-probe-repo-wt","branch":"probe-wt","is_bare":false,"is_detached":false,"is_prunable":false,"is_linked_worktree":true,"open_workspace_id":"w5","label":"wt-probe-repo"}}}`
+
+// mapEnv turns a map into a getenv-style lookup for injecting a fake environment.
+func mapEnv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// TestParseWorktreeEventReal parses the real payload plus the HERDR_* env vars
+// herdr sets, and confirms every field herdr-plus relies on is extracted.
+func TestParseWorktreeEventReal(t *testing.T) {
+	env := mapEnv(map[string]string{
+		"HERDR_WORKSPACE_ID": "w5",
+		"HERDR_TAB_ID":       "w5:t1",
+		"HERDR_PANE_ID":      "w5:p1",
+	})
+
+	ev, err := parseWorktreeEvent(realEventJSON, env)
+	if err != nil {
+		t.Fatalf("parseWorktreeEvent: %v", err)
+	}
+
+	for _, c := range []struct{ name, got, want string }{
+		{"WorkspaceID", ev.WorkspaceID, "w5"},
+		{"RootTabID", ev.RootTabID, "w5:t1"},
+		{"RootPaneID", ev.RootPaneID, "w5:p1"},
+		{"RepoName", ev.RepoName, "wt-probe-repo"},
+		{"RepoRoot", ev.RepoRoot, "/tmp/wt-probe-repo"},
+		{"Branch", ev.Branch, "probe-wt"},
+		{"CheckoutPath", ev.CheckoutPath, "/tmp/wt-probe-repo-wt"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestParseWorktreeEventEnvFallback confirms the workspace and tab ids fall back
+// to the payload when the env vars are absent (the root pane id has no payload
+// fallback, so it stays empty).
+func TestParseWorktreeEventEnvFallback(t *testing.T) {
+	ev, err := parseWorktreeEvent(realEventJSON, mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseWorktreeEvent: %v", err)
+	}
+	if ev.WorkspaceID != "w5" || ev.RootTabID != "w5:t1" {
+		t.Fatalf("fallback ids = %q/%q, want w5/w5:t1", ev.WorkspaceID, ev.RootTabID)
+	}
+	if ev.RootPaneID != "" {
+		t.Fatalf("RootPaneID = %q, want empty (no payload fallback)", ev.RootPaneID)
+	}
+}
+
+// TestParseWorktreeEventBadJSON confirms malformed event JSON is a clear error,
+// while an empty payload parses to a zero event (so the handler degrades to a
+// no-op rather than crashing).
+func TestParseWorktreeEventBadJSON(t *testing.T) {
+	if _, err := parseWorktreeEvent("{not json", mapEnv(nil)); err == nil {
+		t.Fatal("expected an error for malformed event JSON")
+	}
+	if ev, err := parseWorktreeEvent("", mapEnv(nil)); err != nil || ev.RepoName != "" {
+		t.Fatalf("empty payload = %+v, %v; want zero event, no error", ev, err)
+	}
+}
+
+// TestMatchWorktreeLayout covers the matching rules: repo match wins, a
+// branch-specific layout beats a repo-only one, case is ignored, the repo can be
+// matched against the repo-root basename, and a non-match yields nothing.
+func TestMatchWorktreeLayout(t *testing.T) {
+	repoOnly := WorktreeLayout{Repo: "wt-probe-repo", Tabs: []ProjectTab{{Name: "x"}}, source: "a.toml"}
+	branchy := WorktreeLayout{Repo: "WT-Probe-Repo", Branch: "probe-wt", Tabs: []ProjectTab{{Name: "y"}}, source: "b.toml"}
+	other := WorktreeLayout{Repo: "something-else", Tabs: []ProjectTab{{Name: "z"}}, source: "c.toml"}
+
+	ev, err := parseWorktreeEvent(realEventJSON, mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseWorktreeEvent: %v", err)
+	}
+
+	// Branch-specific layout is preferred over the repo-only one (order-independent).
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{repoOnly, branchy, other}, ev); !ok || got.source != "b.toml" {
+		t.Fatalf("match = %q, %v; want b.toml (branch-specific wins)", got.source, ok)
+	}
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{branchy, repoOnly}, ev); !ok || got.source != "b.toml" {
+		t.Fatalf("match (reordered) = %q, %v; want b.toml", got.source, ok)
+	}
+
+	// Repo-only match when no branch-specific layout is present.
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{repoOnly, other}, ev); !ok || got.source != "a.toml" {
+		t.Fatalf("match = %q, %v; want a.toml", got.source, ok)
+	}
+
+	// No match for an unrelated repo.
+	if _, ok := matchWorktreeLayout([]WorktreeLayout{other}, ev); ok {
+		t.Fatal("expected no match for an unrelated repo")
+	}
+
+	// Branch-specific layout does NOT match a different branch.
+	otherBranch := WorktreeLayout{Repo: "wt-probe-repo", Branch: "main", Tabs: []ProjectTab{{Name: "y"}}, source: "d.toml"}
+	if _, ok := matchWorktreeLayout([]WorktreeLayout{otherBranch}, ev); ok {
+		t.Fatal("branch-specific layout should not match a different branch")
+	}
+
+	// Repo matched via the basename of repo_root when repo_name is empty.
+	byRoot := worktreeEvent{RepoRoot: "/Users/me/Development/options-cafe", Branch: "main"}
+	if _, ok := matchWorktreeLayout([]WorktreeLayout{{Repo: "options-cafe", Tabs: []ProjectTab{{Name: "x"}}}}, byRoot); !ok {
+		t.Fatal("expected a match against the repo-root basename")
+	}
+}
+
+// TestWorktreeLayoutValidate confirms a layout needs a repo and at least one tab,
+// and that it inherits the shared per-tab validation (a bad split is rejected).
+func TestWorktreeLayoutValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		layout  WorktreeLayout
+		wantErr bool
+	}{
+		{"valid", WorktreeLayout{Repo: "r", Tabs: []ProjectTab{{Name: "t", Command: "ls"}}}, false},
+		{"no repo", WorktreeLayout{Tabs: []ProjectTab{{Name: "t"}}}, true},
+		{"no tabs", WorktreeLayout{Repo: "r"}, true},
+		{"bad split", WorktreeLayout{Repo: "r", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Split: "sideways"}}}}}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.layout.validate(); (err != nil) != c.wantErr {
+				t.Fatalf("validate() err = %v, wantErr = %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadWorktreeLayouts round-trips real files through the loader: a missing
+// directory yields nothing (the feature is opt-in), and a valid layout loads with
+// its tabs intact.
+func TestLoadWorktreeLayouts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// No worktrees directory yet → no layouts, no error.
+	got, err := loadWorktreeLayouts()
+	if err != nil || got != nil {
+		t.Fatalf("loadWorktreeLayouts (no dir) = %v, %v; want nil, nil", got, err)
+	}
+
+	dir := filepath.Join(tmp, "herdr-plus", "worktrees")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	layout := `repo = "options-cafe"
+branch = "main"
+
+[[tabs]]
+name = "claude"
+command = "claude"
+
+[[tabs]]
+name = "lazygit"
+command = "lazygit"
+`
+	if err := os.WriteFile(filepath.Join(dir, "options-cafe.toml"), []byte(layout), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = loadWorktreeLayouts()
+	if err != nil {
+		t.Fatalf("loadWorktreeLayouts: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d layouts, want 1", len(got))
+	}
+	if got[0].Repo != "options-cafe" || got[0].Branch != "main" || len(got[0].Tabs) != 2 {
+		t.Fatalf("loaded layout = %+v, want options-cafe/main with 2 tabs", got[0])
+	}
+
+	// A malformed file fails the whole load with a naming error.
+	if err := os.WriteFile(filepath.Join(dir, "bad.toml"), []byte("repo = "), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadWorktreeLayouts(); err == nil {
+		t.Fatal("expected an error from a malformed layout file")
+	}
+}

--- a/www/content/docs/_index.md
+++ b/www/content/docs/_index.md
@@ -39,6 +39,8 @@ recommended keys differ, so the two coexist side by side.
   spin up a whole herdr workspace of tabs and panes.
 - **[Quick Actions](quick-actions/)** — the fuzzy launcher and per-project
   actions.
+- **[Worktree Auto-Layout](worktrees/)** — auto-open a tab layout whenever herdr
+  creates a matching git worktree.
 
 If you just want the reference, jump to
 [Keybindings](keybindings/), [Modes](modes/), the

--- a/www/content/docs/configuration.md
+++ b/www/content/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-description: "The herdr-plus config directory layout: projects/, quick-actions/, the file-per-entry model, per-repo overrides, and XDG_CONFIG_HOME."
+description: "The herdr-plus config directory layout: projects/, quick-actions/, worktrees/, the file-per-entry model, per-repo overrides, and XDG_CONFIG_HOME."
 weight: 90
 ---
 
@@ -20,6 +20,9 @@ entry.
     github.toml
     google.toml
     ...
+  worktrees/         # one *.toml per worktree auto-layout
+    options-cafe.toml
+    ...
 ```
 
 - **`projects/`** holds your [project templates](../projects/) for control mode.
@@ -28,10 +31,13 @@ entry.
 - **`quick-actions/`** holds your [quick actions](../quick-actions/). Each
   `*.toml` defines one action. This directory is **seeded with editable
   examples** the first time you run the mode.
+- **`worktrees/`** holds your [worktree auto-layouts](../worktrees/). Each
+  `*.toml` defines one layout that fires when herdr creates a matching git
+  worktree. This directory is never created or seeded — add it yourself to opt in.
 
 The per-mode subdirectory name is the mode's slug (`quick-actions`), so future
-modes get their own folder. Projects hang directly off the config root (not under
-a mode slug) because they're a first-class concept.
+modes get their own folder. `projects/` and `worktrees/` hang directly off the
+config root (not under a mode slug) because they're first-class concepts.
 
 ## The file-per-entry model
 

--- a/www/content/docs/worktrees.md
+++ b/www/content/docs/worktrees.md
@@ -1,0 +1,105 @@
+---
+title: "Worktree Auto-Layout"
+description: "Automatically lay a project-style tab layout into a git worktree the moment herdr creates it, driven by the plugin's worktree.created event."
+weight: 65
+---
+
+herdr-plus can open a project-style tab layout **automatically** when herdr
+creates a git worktree — no keypress, no picker. It's the plugin system's
+[`[[events]]`](https://herdr.dev/docs/plugins/) hook put to work: herdr-plus
+subscribes to the `worktree.created` event and fills the new worktree's workspace
+for you.
+
+## How it works
+
+When you run `herdr worktree create` (or `herdr worktree open`), herdr:
+
+1. Creates the git worktree.
+2. Makes a fresh herdr **workspace** for it, rooted at the worktree's directory.
+3. Fires a `worktree.created` event.
+
+herdr-plus catches that event, looks at the worktree's **repo** (and branch),
+finds a matching layout, and opens that layout's tabs and panes in the workspace
+herdr just made — running every startup command. Because herdr has already
+created the workspace and its first tab, herdr-plus only has to fill it in.
+
+This reuses the exact same tab/pane model as [Projects](../projects/), so a
+worktree layout can do everything a project tab can, including multi-pane splits.
+
+## Configuring a layout
+
+Layouts live in `~/.config/herdr-plus/worktrees/` (honoring `$XDG_CONFIG_HOME`),
+one TOML file per layout — the file name doesn't matter. A layout is a `repo`
+matcher plus an ordered list of `[[tabs]]`:
+
+```toml
+repo = "options-cafe"          # matches the worktree's repo name (case-insensitive)
+
+[[tabs]]
+name = "claude"
+command = "claude --dangerously-skip-permissions --chrome"
+
+[[tabs]]
+name = "lazygit"
+command = "lazygit"
+
+[[tabs]]
+name = "terminal"              # no command — just an empty shell
+```
+
+Create a worktree of `options-cafe` and you land in a workspace with three tabs —
+`claude` running, `lazygit` running, and an empty `terminal` — every time.
+
+## Matching rules
+
+- **`repo`** (required) is matched case-insensitively against the new worktree's
+  repository name (the repo's basename, e.g. `options-cafe`). It also matches the
+  basename of the repo's root path, so it works regardless of how the worktree was
+  created.
+- **`branch`** (optional) narrows a layout to worktrees created on exactly that
+  branch (case-insensitive). Leave it off to apply to every branch of the repo.
+- When **more than one layout matches** the same worktree, a branch-specific
+  layout wins over a repo-only one; otherwise the first by file name is used.
+
+```toml
+# A branch-specific layout: only worktrees on the "release" branch get this one.
+repo = "options-cafe"
+branch = "release"
+
+[[tabs]]
+name = "deploy"
+command = "./scripts/release.sh"
+```
+
+## Tabs and split panes
+
+The `[[tabs]]` format is identical to a project's. A tab can run a single
+`command`, or hold up to four panes via `[[tabs.panes]]` with `split = "down"` or
+`"right"`. See [Split panes within a tab](../projects/#split-panes-within-a-tab)
+for the full vocabulary.
+
+## When nothing matches
+
+Every worktree creation fires the event, but if no layout matches the repo,
+herdr-plus does nothing — the feature is opt-in and silent until you add a layout.
+With no `worktrees/` directory at all, it's simply inert.
+
+## Where it runs
+
+The handler is the plugin's `worktree.created` event, declared in
+`herdr-plugin.toml`. herdr runs it for you (you never invoke it by hand), and its
+output is captured in the plugin log:
+
+```bash
+herdr plugin log list --plugin cloudmanic.herdr-plus
+```
+
+A line like `applied worktree layout "options-cafe.toml" to repo "options-cafe"`
+confirms a layout fired; `no worktree layout matches repo …` means nothing did.
+
+## See also
+
+- [Control Mode & Projects](../projects/) — the on-demand cousin: pick a project
+  and spin up its workspace by hand.
+- [Configuration](../configuration/) — where herdr-plus config lives.
+- [Troubleshooting](../troubleshooting/) — what to check when a layout doesn't fire.


### PR DESCRIPTION
## What

The first net-new capability the plugin system unlocks: **automatically lay a tab layout into a git worktree the moment herdr creates it.** When you `herdr worktree create`, herdr makes a workspace for the worktree and fires a `worktree.created` event; herdr-plus catches it, matches the worktree's repo to a layout, and opens that layout's tabs/panes in the new workspace — no keypress.

This extends the Projects concept (declarative tab layouts) with event-driven automation, and reuses the same `[[tabs]]`/`[[tabs.panes]]` model.

## How it's wired

- **`herdr-plugin.toml`** — new `[[events]]` entry: `on = "worktree.created"` → `./bin/herdr-plus on-worktree-created`.
- **`worktree.go`** (new) — `WorktreeLayout` config (a `repo` + optional `branch` matcher, reusing `ProjectTab`), a loader for `~/.config/herdr-plus/worktrees/*.toml`, parsing of the event payload, layout matching (a branch-specific layout beats a repo-only one), and the handler. With nothing configured it's a silent no-op.
- **`control.go`** — extracted `layoutTabs` from `openProject`; control mode and the worktree handler now share the tab/pane-building + shell-startup-pacing logic.
- **`project.go`** — extracted `validateTabs`, shared by `Project` and `WorktreeLayout`.
- **`main.go`** — dispatches the hidden `on-worktree-created` subcommand (herdr runs it, not the user).

## Config example

`~/.config/herdr-plus/worktrees/options-cafe.toml`:
```toml
repo = "options-cafe"   # matched case-insensitively against the worktree's repo name
# branch = "release"    # optional: narrow to one branch

[[tabs]]
name = "claude"
command = "claude --dangerously-skip-permissions --chrome"

[[tabs]]
name = "lazygit"
command = "lazygit"
```

## Test plan

- `go vet` / `go build` / `go test` — pass. Unit tests parse a **real captured `worktree.created` payload** from herdr 0.7.0 and cover matching, validation, and loading.
- **End-to-end against live herdr 0.7.0**: wrote a test layout, ran `herdr worktree create`, and confirmed the handler fired (plugin log: `applied worktree layout … : 2 tab(s)`) and the worktree's workspace came up with the two configured tabs. All test artifacts cleaned up afterward.
- `hugo` build of `www/` — succeeds.

## Note: stacked on #12

This branch is stacked on `plugin-support` (PR #12), so it's targeted at that branch and the diff shows only the worktree feature. Once #12 merges to `main`, I'll rebase this onto `main` and it'll retarget automatically.