### PR TITLE
Quick Actions: fuzzy launcher (command/select/form)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # herdr-plus
 
 herdr-plus is an add-on for [herdr](https://herdr.dev), built as a first-class
-[herdr plugin](https://herdr.dev/docs/plugins/). Its flagship feature is
-**Projects**: declarative herdr-workspace templates you fuzzy-pick to spin up a
-whole workspace — every tab and pane created, every startup command running — in
-one keypress.
+[herdr plugin](https://herdr.dev/docs/plugins/). It adds two things:
+
+- **[Projects](#projects)** — declarative herdr-workspace templates you fuzzy-pick
+  to spin up a whole workspace (every tab and pane, every startup command) in one
+  keypress.
+- **[Quick Actions](#quick-actions)** — a fuzzy launcher for one-off
+  actions/scripts, run in the directory you launched from.
 
 > This is a clean, plugin-first rebuild. The previous standalone-binary
 > implementation lives under [`old/`](old/) as reference and is not built.
@@ -89,11 +92,55 @@ split = "down"
 
 A tab uses *either* `command` *or* `[[tabs.panes]]`, not both.
 
+## Quick Actions
+
+A fuzzy launcher for one-off commands. Trigger it (action
+`cloudmanic.herdr-plus.quick-actions`), fuzzy-pick an action, and it runs in the
+directory you launched from. Actions are TOML files in
+`~/.config/herdr-plus/quick-actions/` (seeded with editable examples on first
+run). A repo can also ship its own in `<repo>/.herdr-plus/quick-actions/`, shown
+under a **Project** heading above your **Global** ones.
+
+There are three action types:
+
+```toml
+# command (default) — runs immediately
+name = "GitHub"
+command = "open https://github.com"
+```
+
+```toml
+# select — pick from a second fuzzy list; the choice becomes {{.Value}}
+name = "Open Repo"
+type = "select"
+command = "open https://github.com/cloudmanic/{{.Value}}"
+
+[[options]]
+label = "Herdr Plus"
+value = "herdr-plus"
+```
+
+```toml
+# form — type a value that becomes {{.Value}}
+name = "Search Google"
+type = "form"
+command = "open 'https://www.google.com/search?q={{.Value | urlquery}}'"
+
+[form]
+prompt = "Search Google for"
+```
+
+The `command` is a [Go template](https://pkg.go.dev/text/template) rendered against
+the launch context: `{{.WorkDir}}` (where you launched from), `{{.SessionTitle}}`
+(the workspace label), `{{.Value}}` (select/form input), and more — also exported
+as `HERDR_PLUS_*` environment variables. If a command doesn't reference
+`{{.Value}}`, the value is appended as a final shell-quoted argument.
+
 ## Binding a key
 
-Binding a key to the Projects action is an optional, one-time edit to **your**
-herdr `config.toml` (`~/.config/herdr/config.toml`). Add a `[[keys.command]]`
-entry with `type = "plugin_action"` whose `command` is the action id:
+Binding keys to the actions is an optional, one-time edit to **your** herdr
+`config.toml` (`~/.config/herdr/config.toml`). Add `[[keys.command]]` entries with
+`type = "plugin_action"` whose `command` is the action id:
 
 ```toml
 [[keys.command]]
@@ -101,6 +148,12 @@ key = "prefix+up"
 type = "plugin_action"
 command = "cloudmanic.herdr-plus.projects"
 description = "herdr-plus: projects"
+
+[[keys.command]]
+key = "prefix+down"
+type = "plugin_action"
+command = "cloudmanic.herdr-plus.quick-actions"
+description = "herdr-plus: quick actions"
 ```
 
 Then `herdr server reload-config` (or restart herdr) and press your herdr prefix

--- a/action.go
+++ b/action.go
@@ -1,0 +1,185 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+// Action types. An action's Type decides what happens between selecting it in
+// the picker and running its command.
+const (
+	// TypeCommand runs the command immediately with no further input.
+	TypeCommand = "command"
+	// TypeSelect shows a list of Options; the chosen option's Value becomes the
+	// action's Value (available to the command as {{.Value}}).
+	TypeSelect = "select"
+	// TypeForm shows a single text field; the entered string becomes the action's
+	// Value.
+	TypeForm = "form"
+)
+
+// Option is one choice in a "select" action. Label is what the user sees in the
+// list; Value is what gets handed to the command. When Value is empty the Label
+// is used as the value too. Description, when set, is shown as dim text next to
+// the label — useful when the label alone isn't self-explanatory, or to keep a
+// long value out of the list.
+//
+// An option with no Label is a non-selectable separator used to visually group
+// the choices: with a Heading it renders as a dim group title (preceded by a
+// blank line); without one it renders as a plain blank spacer.
+type Option struct {
+	Label       string `toml:"label"`
+	Value       string `toml:"value"`
+	Description string `toml:"description"`
+	Heading     string `toml:"heading"`
+}
+
+// isSeparator reports whether the option is a non-selectable spacer/heading
+// rather than a real choice. An option needs a label to be selectable.
+func (o Option) isSeparator() bool {
+	return o.Label == ""
+}
+
+// resolvedValue returns the value to hand to the command for this option.
+func (o Option) resolvedValue() string {
+	if o.Value != "" {
+		return o.Value
+	}
+	return o.Label
+}
+
+// actionOrigin records where an action was loaded from. The picker uses it to
+// group project-local actions separately from the user's global actions so it is
+// always clear which is which.
+type actionOrigin int
+
+const (
+	// originGlobal is an action from the user's global config dir
+	// (~/.config/herdr-plus/quick-actions/). It is the zero value, so any Action
+	// built without an explicit origin is treated as global.
+	originGlobal actionOrigin = iota
+	// originProject is an action from a repo's own .herdr-plus/quick-actions/
+	// directory, available only when herdr-plus is launched from inside that repo.
+	originProject
+)
+
+// FormConfig customizes the text field shown for a "form" action.
+type FormConfig struct {
+	// Prompt is the label rendered above the input field.
+	Prompt string `toml:"prompt"`
+	// Placeholder is the greyed-out hint shown in the empty field.
+	Placeholder string `toml:"placeholder"`
+}
+
+// Action is one entry in the quick-action picker, loaded from a TOML file in the
+// quick-actions config directory. Name and Description are shown in the list;
+// Command is the shell command run when the action completes. Command is a Go
+// text/template rendered against a RunContext, so it can reference {{.Value}},
+// {{.WorkDir}}, {{.SessionTitle}}, and the other context fields.
+type Action struct {
+	Name        string     `toml:"name"`
+	Description string     `toml:"description"`
+	Type        string     `toml:"type"`
+	Command     string     `toml:"command"`
+	Options     []Option   `toml:"options"`
+	Form        FormConfig `toml:"form"`
+
+	// source is the file the action was loaded from, used only for error
+	// messages. It is not part of the on-disk format.
+	source string
+
+	// origin marks whether the action came from the global config or a project's
+	// .herdr-plus directory. Set at load time; not part of the on-disk format.
+	origin actionOrigin
+}
+
+// effectiveType returns the action's type, defaulting to TypeCommand when the
+// file omits it so the simplest actions need only a name and a command.
+func (a Action) effectiveType() string {
+	if a.Type == "" {
+		return TypeCommand
+	}
+	return a.Type
+}
+
+// validate checks that an action is internally consistent before we ever try to
+// run it, turning config mistakes into clear errors at load time.
+func (a Action) validate() error {
+	if a.Name == "" {
+		return fmt.Errorf("action %s: name is required", a.source)
+	}
+	if strings.TrimSpace(a.Command) == "" {
+		return fmt.Errorf("action %q (%s): command is required", a.Name, a.source)
+	}
+	switch a.effectiveType() {
+	case TypeCommand, TypeForm:
+		// nothing extra to check
+	case TypeSelect:
+		selectable := 0
+		for _, o := range a.Options {
+			if !o.isSeparator() {
+				selectable++
+			}
+		}
+		if selectable == 0 {
+			return fmt.Errorf("action %q (%s): select actions need at least one selectable option (one with a label)", a.Name, a.source)
+		}
+	default:
+		return fmt.Errorf("action %q (%s): unknown type %q (want command, select, or form)", a.Name, a.source, a.Type)
+	}
+	return nil
+}
+
+// render turns the action's command template into the final shell command. The
+// chosen Value (option value or form input) is placed in ctx.Value. When the
+// template does not explicitly reference .Value but a value is present, the
+// value is appended as a single shell-quoted argument — so a command can either
+// position the value precisely with {{.Value}} or just receive it as its last
+// argument.
+func (a Action) render(ctx RunContext) (string, error) {
+	tmpl, err := template.New(a.Name).Parse(a.Command)
+	if err != nil {
+		return "", fmt.Errorf("parse command for %q: %w", a.Name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		return "", fmt.Errorf("render command for %q: %w", a.Name, err)
+	}
+	cmdline := buf.String()
+
+	if ctx.Value != "" && !strings.Contains(a.Command, ".Value") {
+		cmdline += " " + shellQuote(ctx.Value)
+	}
+	return cmdline, nil
+}
+
+// run renders and executes the action's command through the shell, in the
+// invoking pane's working directory and with the context exported as
+// HERDR_PLUS_* environment variables. Running through "sh -c" lets commands use
+// pipes, arguments, and full scripts.
+func (a Action) run(ctx RunContext) error {
+	cmdline, err := a.render(ctx)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("sh", "-c", cmdline)
+	if ctx.WorkDir != "" {
+		cmd.Dir = ctx.WorkDir
+	}
+	cmd.Env = append(os.Environ(), ctx.envPairs()...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/action_test.go
+++ b/action_test.go
@@ -1,0 +1,139 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestActionRender exercises command template rendering: explicit {{.Value}}
+// placement, context variables, the urlquery helper, and the auto-append of a
+// value when the template does not reference it.
+func TestActionRender(t *testing.T) {
+	cases := []struct {
+		name    string
+		action  Action
+		ctx     RunContext
+		want    string
+		wantSub []string // substrings that must appear (when an exact match is brittle)
+	}{
+		{
+			name:   "plain command unchanged",
+			action: Action{Name: "GitHub", Command: "open https://github.com"},
+			ctx:    RunContext{},
+			want:   "open https://github.com",
+		},
+		{
+			name:   "value substituted into template",
+			action: Action{Name: "Repo", Type: TypeSelect, Command: "open https://github.com/cloudmanic/{{.Value}}"},
+			ctx:    RunContext{Value: "herdr-plus"},
+			want:   "open https://github.com/cloudmanic/herdr-plus",
+		},
+		{
+			name:   "value appended when template omits it",
+			action: Action{Name: "Say", Type: TypeForm, Command: "say"},
+			ctx:    RunContext{Value: "hi there"},
+			want:   "say 'hi there'",
+		},
+		{
+			name:   "value with single quote is shell-safe when appended",
+			action: Action{Name: "Say", Type: TypeForm, Command: "say"},
+			ctx:    RunContext{Value: "it's me"},
+			want:   `say 'it'\''s me'`,
+		},
+		{
+			name:   "workdir variable",
+			action: Action{Name: "Reveal", Command: "open {{.WorkDir}}"},
+			ctx:    RunContext{WorkDir: "/tmp/project"},
+			want:   "open /tmp/project",
+		},
+		{
+			name:   "session title method",
+			action: Action{Name: "Echo", Command: "echo {{.SessionTitle}}"},
+			ctx:    RunContext{WorkspaceLabel: "herdr-plus"},
+			want:   "echo herdr-plus",
+		},
+		{
+			name:    "urlquery escapes spaces",
+			action:  Action{Name: "Search", Type: TypeForm, Command: "open 'https://g.co/s?q={{.Value | urlquery}}'"},
+			ctx:     RunContext{Value: "hello world"},
+			wantSub: []string{"hello", "world"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.action.render(tc.ctx)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if tc.want != "" && got != tc.want {
+				t.Fatalf("render = %q, want %q", got, tc.want)
+			}
+			for _, sub := range tc.wantSub {
+				if !strings.Contains(got, sub) {
+					t.Fatalf("render = %q, want substring %q", got, sub)
+				}
+			}
+			if tc.name == "urlquery escapes spaces" && strings.Contains(got, "hello world") {
+				t.Fatalf("render = %q, space was not escaped", got)
+			}
+		})
+	}
+}
+
+// TestActionValidate confirms validation rejects incomplete or inconsistent
+// action definitions and accepts well-formed ones.
+func TestActionValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		action  Action
+		wantErr bool
+	}{
+		{"valid command", Action{Name: "A", Command: "open x"}, false},
+		{"valid select", Action{Name: "A", Type: TypeSelect, Command: "open {{.Value}}", Options: []Option{{Label: "x"}}}, false},
+		{"valid form", Action{Name: "A", Type: TypeForm, Command: "open {{.Value}}"}, false},
+		{"missing name", Action{Command: "open x"}, true},
+		{"missing command", Action{Name: "A"}, true},
+		{"select without options", Action{Name: "A", Type: TypeSelect, Command: "x"}, true},
+		{"unknown type", Action{Name: "A", Type: "wat", Command: "x"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.action.validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestOptionResolvedValue checks that an option falls back to its label when no
+// explicit value is given.
+func TestOptionResolvedValue(t *testing.T) {
+	if got := (Option{Label: "Herdr Plus", Value: "herdr-plus"}).resolvedValue(); got != "herdr-plus" {
+		t.Fatalf("resolvedValue = %q, want %q", got, "herdr-plus")
+	}
+	if got := (Option{Label: "herdr-plus"}).resolvedValue(); got != "herdr-plus" {
+		t.Fatalf("resolvedValue = %q, want label fallback %q", got, "herdr-plus")
+	}
+}
+
+// TestShellQuote verifies single-quote escaping produces a single shell token.
+func TestShellQuote(t *testing.T) {
+	if got := shellQuote("plain"); got != "'plain'" {
+		t.Fatalf("shellQuote(plain) = %q", got)
+	}
+	if got := shellQuote("it's"); got != `'it'\''s'` {
+		t.Fatalf("shellQuote(it's) = %q", got)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -8,13 +8,19 @@ package main
 
 import (
 	"embed"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
 )
 
-// embeddedExamples holds the starter files baked into the binary. Today it backs
-// the projects empty-state card (the example shown when no project files exist),
-// keeping the repo's examples/ tree the single source of truth.
+// embeddedExamples holds the starter files baked into the binary: the projects
+// empty-state example and the quick-actions starter actions (seeded into the
+// quick-actions config dir on first run). Keeping them embedded makes the repo's
+// examples/ tree the single source of truth.
 //
 //go:embed examples
 var embeddedExamples embed.FS
@@ -32,4 +38,159 @@ func configBaseDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".config", "herdr-plus"), nil
+}
+
+// quickActionsConfigDir returns the directory that holds quick-action files,
+// ~/.config/herdr-plus/quick-actions.
+func quickActionsConfigDir() (string, error) {
+	base, err := configBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "quick-actions"), nil
+}
+
+// projectConfigDirName is the directory a repo adds at its root to ship its own
+// herdr-plus config. Quick actions for a repo live in
+// <repo>/.herdr-plus/quick-actions/.
+const projectConfigDirName = ".herdr-plus"
+
+// projectQuickActionsDir returns the project-local quick-actions directory within
+// workDir, e.g. <workDir>/.herdr-plus/quick-actions. It returns "" when workDir
+// is unknown. Unlike the global dir, it is never created or seeded: project
+// config is opt-in and read only when the repo actually provides it.
+func projectQuickActionsDir(workDir string) string {
+	if workDir == "" {
+		return ""
+	}
+	return filepath.Join(workDir, projectConfigDirName, "quick-actions")
+}
+
+// ensureQuickActionsConfig makes sure the quick-actions config directory exists
+// and returns its path. The very first time (when the directory does not yet
+// exist) it seeds the directory with the embedded example actions. Once the
+// directory exists it is left untouched, so deleting an example never causes it
+// to reappear.
+func ensureQuickActionsConfig() (string, error) {
+	dir, err := quickActionsConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(dir); err == nil {
+		return dir, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	if err := seedQuickActionsExamples(dir); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// seedQuickActionsExamples copies the embedded example actions into destDir.
+func seedQuickActionsExamples(destDir string) error {
+	srcDir := "examples/quick-actions"
+	entries, err := embeddedExamples.ReadDir(srcDir)
+	if err != nil {
+		// No bundled examples; nothing to seed.
+		return nil
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := embeddedExamples.ReadFile(srcDir + "/" + e.Name())
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(destDir, e.Name()), data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// loadActions reads, parses, and validates every *.toml action in the global
+// quick-actions config directory, returning them sorted by name and tagged as
+// global. A malformed or invalid file fails the whole load with a message naming
+// the offending files, so config mistakes surface loudly instead of an action
+// silently going missing.
+func loadActions() ([]Action, error) {
+	dir, err := ensureQuickActionsConfig()
+	if err != nil {
+		return nil, err
+	}
+	return loadActionsFromDir(dir, originGlobal)
+}
+
+// loadActionsFromDir reads, parses, and validates every *.toml action in dir,
+// tagging each with origin and returning them sorted by name. A directory that
+// does not exist yields no actions and no error, so an absent project config dir
+// simply contributes nothing. A malformed or invalid file fails the whole load
+// with a message naming the offending files and their directory.
+func loadActionsFromDir(dir string, origin actionOrigin) ([]Action, error) {
+	if dir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var actions []Action
+	var problems []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+
+		var a Action
+		if _, err := toml.DecodeFile(path, &a); err != nil {
+			problems = append(problems, fmt.Sprintf("  %s: %v", e.Name(), err))
+			continue
+		}
+		a.source = e.Name()
+		a.origin = origin
+		if err := a.validate(); err != nil {
+			problems = append(problems, "  "+err.Error())
+			continue
+		}
+		actions = append(actions, a)
+	}
+
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("invalid action files in %s:\n%s", dir, strings.Join(problems, "\n"))
+	}
+
+	sort.Slice(actions, func(i, j int) bool { return actions[i].Name < actions[j].Name })
+	return actions, nil
+}
+
+// loadPickerActions loads the actions to show in the picker: the global actions
+// plus any project-local actions found in workDir's .herdr-plus/quick-actions/
+// directory. Project actions come first and are tagged originProject, globals
+// originGlobal, so the picker can group them. A repo without a .herdr-plus dir
+// just yields the global set.
+func loadPickerActions(workDir string) ([]Action, error) {
+	global, err := loadActions()
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := loadActionsFromDir(projectQuickActionsDir(workDir), originProject)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(project, global...), nil
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,133 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+)
+
+// RunContext is the bag of variables herdr-plus exposes to an action's command.
+// It is gathered when the quick-actions action fires — from the focused pane herdr
+// reports — then serialized and handed to the picker. The picker substitutes
+// these values into the chosen command (as Go template fields) and also exports
+// them to the command's environment.
+type RunContext struct {
+	// Value is the dynamic input for the action: the chosen option's value for a
+	// "select" action, or the entered string for a "form" action. It is empty for
+	// a plain "command" action.
+	Value string `json:"value"`
+
+	// WorkDir is the working directory the user invoked herdr-plus from. Actions
+	// run with this as their working directory and can read it as {{.WorkDir}}.
+	WorkDir string `json:"work_dir"`
+
+	// herdr session/pane metadata.
+	PaneId         string `json:"pane_id"`
+	TabId          string `json:"tab_id"`
+	TabLabel       string `json:"tab_label"`
+	WorkspaceId    string `json:"workspace_id"`
+	WorkspaceLabel string `json:"workspace_label"`
+	TerminalId     string `json:"terminal_id"`
+	Agent          string `json:"agent"`
+	AgentSessionId string `json:"agent_session_id"`
+}
+
+// SessionTitle is a friendly alias for the workspace label — herdr's closest
+// notion of "what am I working on". Templates can use {{.SessionTitle}}.
+func (c RunContext) SessionTitle() string { return c.WorkspaceLabel }
+
+// SessionId is a friendly alias for the workspace id, available as {{.SessionId}}.
+func (c RunContext) SessionId() string { return c.WorkspaceId }
+
+// Home returns the current user's home directory, available as {{.Home}}.
+func (c RunContext) Home() string {
+	h, _ := os.UserHomeDir()
+	return h
+}
+
+// envPairs renders the context as KEY=VALUE strings so any spawned command can
+// read the same variables from its environment (handy for scripts that would
+// rather not bother with templating). Every field is prefixed HERDR_PLUS_ to
+// avoid colliding with herdr's own HERDR_ variables.
+func (c RunContext) envPairs() []string {
+	return []string{
+		"HERDR_PLUS_VALUE=" + c.Value,
+		"HERDR_PLUS_WORKDIR=" + c.WorkDir,
+		"HERDR_PLUS_PANE_ID=" + c.PaneId,
+		"HERDR_PLUS_TAB_ID=" + c.TabId,
+		"HERDR_PLUS_TAB_LABEL=" + c.TabLabel,
+		"HERDR_PLUS_WORKSPACE_ID=" + c.WorkspaceId,
+		"HERDR_PLUS_WORKSPACE_LABEL=" + c.WorkspaceLabel,
+		"HERDR_PLUS_SESSION_TITLE=" + c.WorkspaceLabel,
+		"HERDR_PLUS_SESSION_ID=" + c.WorkspaceId,
+		"HERDR_PLUS_TERMINAL_ID=" + c.TerminalId,
+		"HERDR_PLUS_AGENT=" + c.Agent,
+		"HERDR_PLUS_AGENT_SESSION_ID=" + c.AgentSessionId,
+	}
+}
+
+// encode serializes the context to a base64 JSON blob so the launching action can
+// pass it to the picker pane as a single, shell-safe environment variable.
+func (c RunContext) encode() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// decodeRunContext is the inverse of encode. An empty string yields a zero
+// context rather than an error so the picker can still run with no metadata.
+func decodeRunContext(s string) (RunContext, error) {
+	var c RunContext
+	if s == "" {
+		return c, nil
+	}
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal(b, &c)
+	return c, err
+}
+
+// pluginContext mirrors the subset of HERDR_PLUGIN_CONTEXT_JSON herdr-plus reads.
+// herdr injects this when it runs a plugin action, describing the pane that was
+// focused when the action fired — exactly the context a quick action wants.
+type pluginContext struct {
+	WorkspaceID      string `json:"workspace_id"`
+	WorkspaceLabel   string `json:"workspace_label"`
+	WorkspaceCwd     string `json:"workspace_cwd"`
+	TabID            string `json:"tab_id"`
+	TabLabel         string `json:"tab_label"`
+	FocusedPaneID    string `json:"focused_pane_id"`
+	FocusedPaneCwd   string `json:"focused_pane_cwd"`
+	FocusedPaneAgent string `json:"focused_pane_agent"`
+}
+
+// contextFromPluginEnv builds a RunContext from HERDR_PLUGIN_CONTEXT_JSON, which
+// herdr sets when it runs the quick-actions action. The working directory is the
+// focused pane's cwd (the user's real directory), falling back to the workspace
+// cwd. Any field herdr does not supply is left empty — a partial context is far
+// better than refusing to launch.
+func contextFromPluginEnv() RunContext {
+	var pc pluginContext
+	if raw := os.Getenv("HERDR_PLUGIN_CONTEXT_JSON"); raw != "" {
+		_ = json.Unmarshal([]byte(raw), &pc)
+	}
+	return RunContext{
+		WorkDir:        firstNonEmpty(pc.FocusedPaneCwd, pc.WorkspaceCwd),
+		PaneId:         pc.FocusedPaneID,
+		TabId:          pc.TabID,
+		TabLabel:       pc.TabLabel,
+		WorkspaceId:    pc.WorkspaceID,
+		WorkspaceLabel: pc.WorkspaceLabel,
+		Agent:          pc.FocusedPaneAgent,
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,121 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRunContextRoundTrip checks that a context survives encode/decode intact,
+// since the launching action and the picker are separate processes that
+// communicate through this serialized blob.
+func TestRunContextRoundTrip(t *testing.T) {
+	want := RunContext{
+		Value:          "some value",
+		WorkDir:        "/Users/spicer/Development/cloudmanic/herdr-plus",
+		PaneId:         "p_172",
+		TabId:          "w1:1",
+		TabLabel:       "claude",
+		WorkspaceId:    "w1",
+		WorkspaceLabel: "herdr-plus",
+		TerminalId:     "term_1",
+		Agent:          "claude",
+		AgentSessionId: "abc-123",
+	}
+
+	encoded, err := want.encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	got, err := decodeRunContext(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestDecodeEmptyContext confirms an empty string decodes to a zero context
+// rather than an error, so the picker can still run with no metadata.
+func TestDecodeEmptyContext(t *testing.T) {
+	got, err := decodeRunContext("")
+	if err != nil {
+		t.Fatalf("decode empty: %v", err)
+	}
+	if (got != RunContext{}) {
+		t.Fatalf("decode empty = %+v, want zero context", got)
+	}
+}
+
+// TestContextAliases verifies the friendly accessors map to the workspace
+// fields.
+func TestContextAliases(t *testing.T) {
+	c := RunContext{WorkspaceLabel: "herdr-plus", WorkspaceId: "w1"}
+	if c.SessionTitle() != "herdr-plus" {
+		t.Fatalf("SessionTitle = %q", c.SessionTitle())
+	}
+	if c.SessionId() != "w1" {
+		t.Fatalf("SessionId = %q", c.SessionId())
+	}
+}
+
+// TestEnvPairs confirms the context is exported with the HERDR_PLUS_ prefix and
+// includes the session-title alias.
+func TestEnvPairs(t *testing.T) {
+	c := RunContext{Value: "v", WorkDir: "/wd", WorkspaceLabel: "herdr-plus"}
+	pairs := c.envPairs()
+
+	want := map[string]string{
+		"HERDR_PLUS_VALUE":         "v",
+		"HERDR_PLUS_WORKDIR":       "/wd",
+		"HERDR_PLUS_SESSION_TITLE": "herdr-plus",
+	}
+	for key, val := range want {
+		found := false
+		for _, p := range pairs {
+			if p == key+"="+val {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("env pairs missing %s=%s in %v", key, val, pairs)
+		}
+	}
+	for _, p := range pairs {
+		if !strings.HasPrefix(p, "HERDR_PLUS_") {
+			t.Fatalf("env pair %q is not HERDR_PLUS_ prefixed", p)
+		}
+	}
+}
+
+// TestContextFromPluginEnv confirms the run context is built from the
+// HERDR_PLUGIN_CONTEXT_JSON herdr injects, mapping the focused pane's cwd to the
+// working directory.
+func TestContextFromPluginEnv(t *testing.T) {
+	t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", `{"workspace_id":"w3","workspace_label":"herdr-plus","workspace_cwd":"/ws","tab_id":"w3:t1","tab_label":"shell","focused_pane_id":"w3:p2","focused_pane_cwd":"/Users/spicer/code","focused_pane_agent":"claude"}`)
+
+	c := contextFromPluginEnv()
+	if c.WorkDir != "/Users/spicer/code" {
+		t.Fatalf("WorkDir = %q, want the focused pane cwd", c.WorkDir)
+	}
+	if c.WorkspaceId != "w3" || c.WorkspaceLabel != "herdr-plus" || c.PaneId != "w3:p2" || c.Agent != "claude" {
+		t.Fatalf("context = %+v", c)
+	}
+}
+
+// TestContextFromPluginEnvWorkspaceFallback confirms the workspace cwd is used
+// when the focused pane has none.
+func TestContextFromPluginEnvWorkspaceFallback(t *testing.T) {
+	t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", `{"workspace_id":"w3","workspace_cwd":"/ws","focused_pane_id":"w3:p2"}`)
+	if got := contextFromPluginEnv().WorkDir; got != "/ws" {
+		t.Fatalf("WorkDir = %q, want the workspace cwd fallback", got)
+	}
+}

--- a/examples/quick-actions/github.toml
+++ b/examples/quick-actions/github.toml
@@ -1,0 +1,7 @@
+# A plain command action: selecting it runs `command` immediately.
+# This is the simplest possible action — just a name, a description, and a
+# command. `type` defaults to "command" when omitted.
+
+name = "GitHub"
+description = "Open https://github.com"
+command = "open https://github.com"

--- a/examples/quick-actions/google-search.toml
+++ b/examples/quick-actions/google-search.toml
@@ -1,0 +1,14 @@
+# A "form" action: choosing it shows a text field, and whatever you type becomes
+# {{.Value}} in the command. The built-in `urlquery` template function escapes
+# the text so it is safe inside a URL.
+#
+# The optional [form] table customizes the field's prompt and placeholder.
+
+name = "Search Google"
+description = "Type a query and open the results"
+type = "form"
+command = "open 'https://www.google.com/search?q={{.Value | urlquery}}'"
+
+[form]
+prompt = "Search Google for"
+placeholder = "e.g. herdr terminal multiplexer"

--- a/examples/quick-actions/google.toml
+++ b/examples/quick-actions/google.toml
@@ -1,0 +1,6 @@
+# Another plain command action.
+
+name = "Google"
+description = "Open https://google.com"
+type = "command"
+command = "open https://google.com"

--- a/examples/quick-actions/open-repo.toml
+++ b/examples/quick-actions/open-repo.toml
@@ -1,0 +1,26 @@
+# A "select" action: choosing it shows a second fuzzy list of options, and the
+# option you pick becomes {{.Value}} in the command.
+#
+# Each option has a `label` (shown in the list) and a `value` (substituted into
+# the command). If `value` is omitted, the label is used as the value too. An
+# optional `description` shows dim text next to the label.
+
+name = "Open Repo on GitHub"
+description = "Pick one of our repos and open it"
+type = "select"
+command = "open https://github.com/cloudmanic/{{.Value}}"
+
+[[options]]
+label = "Herdr Plus"
+value = "herdr-plus"
+description = "cloudmanic/herdr-plus"
+
+[[options]]
+label = "Options Cafe"
+value = "options-cafe"
+description = "cloudmanic/options-cafe"
+
+[[options]]
+label = "Skyclerk"
+value = "skyclerk"
+description = "cloudmanic/skyclerk"

--- a/examples/quick-actions/open-working-dir.toml
+++ b/examples/quick-actions/open-working-dir.toml
@@ -1,0 +1,22 @@
+# A command action that uses a context variable. The command is a Go
+# text/template rendered against the run context, so {{.WorkDir}} expands to the
+# directory you launched herdr-plus from. Other variables you can use:
+#
+#   {{.WorkDir}}        the working directory you launched from
+#   {{.SessionTitle}}   the herdr workspace label (e.g. the repo name)
+#   {{.SessionId}}      the herdr workspace id
+#   {{.TabLabel}}       the herdr tab label
+#   {{.PaneId}}         the pane herdr-plus was launched from
+#   {{.WorkspaceLabel}} {{.WorkspaceId}} {{.TabId}} {{.TerminalId}}
+#   {{.Agent}}          the agent running in the pane, if any
+#   {{.AgentSessionId}} that agent's session id
+#   {{.Home}}           your home directory
+#   {{.Value}}          the selected option / entered text (select & form only)
+#
+# The same values are also exported to the command's environment as
+# HERDR_PLUS_WORKDIR, HERDR_PLUS_SESSION_TITLE, and so on.
+
+name = "Reveal Working Dir"
+description = "Open the launch directory in Finder"
+type = "command"
+command = "open {{.WorkDir}}"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -42,6 +42,24 @@ title = "Herdr Plus: Projects"
 placement = "zoomed"
 command = ["./bin/herdr-plus", "projects-ui"]
 
+# quick-actions — a fuzzy launcher for one-off actions/scripts (command, select,
+# or form), loaded from ~/.config/herdr-plus/quick-actions/ (plus a repo's own
+# .herdr-plus/quick-actions/). Commands template against and run in the directory
+# you launched from. Bind a key or run it from herdr's action menu.
+[[actions]]
+id = "quick-actions"
+title = "Herdr Plus: Quick Actions"
+command = ["./bin/herdr-plus", "quick-actions"]
+
+# quick-actions-picker — the action picker as a herdr-managed overlay pane. The
+# quick-actions action opens it (passing the launch context), and herdr restores
+# your previous focus when it closes.
+[[panes]]
+id = "quick-actions-picker"
+title = "Quick Actions"
+placement = "overlay"
+command = ["./bin/herdr-plus", "quick-actions-ui"]
+
 # ping — a smoke-test action that proves the plugin loop end to end: it talks to
 # herdr over the socket and prints the focused pane/workspace. Its output is
 # captured in `herdr plugin log list --plugin cloudmanic.herdr-plus`.

--- a/main.go
+++ b/main.go
@@ -17,10 +17,11 @@ import (
 // registers it from herdr-plugin.toml and runs this binary with a subcommand per
 // manifest entry point.
 //
-//   - "projects" is the Projects action herdr runs from a keybinding: it asks
-//     herdr to open the browser as a zoomed plugin pane.
-//   - "projects-ui" is the browser itself; herdr runs it inside that zoomed pane
-//     (the `picker` entrypoint), so end users never run it directly.
+//   - "projects" / "quick-actions" are the actions herdr runs from a keybinding:
+//     each asks herdr to open its UI as a plugin pane.
+//   - "projects-ui" / "quick-actions-ui" are those UIs; herdr runs them inside the
+//     pane it opens (the `picker` / `quick-actions-picker` entrypoints), so end
+//     users never run them directly.
 //   - "ping" is a smoke test that proves the plugin loop end to end.
 //
 // The bare binary has no launcher of its own, so it just prints usage.
@@ -32,6 +33,12 @@ func main() {
 			return
 		case "projects-ui":
 			runProjectsUI()
+			return
+		case "quick-actions":
+			launchQuickActions()
+			return
+		case "quick-actions-ui":
+			runQuickActionsUI()
 			return
 		case "ping":
 			runPing()

--- a/quickactions.go
+++ b/quickactions.go
@@ -1,0 +1,55 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+// launchQuickActions is the Quick Actions action's entry point. herdr runs it
+// server-side (from the plugin action / keybinding), so it has no terminal of its
+// own. It captures the focused pane's context (working directory, workspace) from
+// the env herdr injects, then asks herdr to open the action picker as an overlay
+// pane — passing the encoded context along so the chosen command runs in the
+// directory you launched from, not the picker's. herdr creates the overlay and,
+// when the picker exits, tears it down and restores your previous focus.
+func launchQuickActions() {
+	ctx := contextFromPluginEnv()
+	enc, err := ctx.encode()
+	if err != nil {
+		errExit("could not encode run context:", err)
+	}
+
+	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
+	// call back into the CLI from a plugin command.
+	herdr := os.Getenv("HERDR_BIN_PATH")
+	if herdr == "" {
+		herdr = "herdr"
+	}
+
+	args := []string{
+		"plugin", "pane", "open",
+		"--plugin", "cloudmanic.herdr-plus",
+		"--entrypoint", "quick-actions-picker",
+		"--placement", "overlay",
+		// Hand the launch context to the picker as a single shell-safe env var.
+		"--env", "HERDR_PLUS_CTX=" + enc,
+	}
+	// Run the overlay pane's shell in the launching directory too, so the picker
+	// and anything it spawns default to the right place.
+	if ctx.WorkDir != "" {
+		args = append(args, "--cwd", ctx.WorkDir)
+	}
+
+	cmd := exec.Command(herdr, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		errExit("could not open the quick-actions picker:", err)
+	}
+}

--- a/quickactionspicker.go
+++ b/quickactionspicker.go
@@ -1,0 +1,418 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// quickActionsTitle is the heading shown across the top of the action picker.
+const quickActionsTitle = "⚡ Quick Actions"
+
+// pickerHeaderLines is how many screen lines precede the embedded fuzzyList in
+// every picker stage: the title bar and the blank line under it. A mouse click's
+// screen row minus this offset is the list-local line passed to clickRow.
+const pickerHeaderLines = 2
+
+// stage is which screen the picker is currently showing.
+type stage int
+
+const (
+	// stageActions is the top-level list of actions.
+	stageActions stage = iota
+	// stageSelect is the option list shown for a "select" action.
+	stageSelect
+	// stageForm is the text field shown for a "form" action.
+	stageForm
+)
+
+// pickerModel holds the state of the fuzzy-finder TUI. It is a small state
+// machine: pick an action, then for select/form actions gather the extra input
+// before the program quits and the chosen action runs.
+type pickerModel struct {
+	ctx RunContext
+
+	stage stage
+
+	actions    []Action
+	actionList fuzzyList
+
+	// current is the action awaiting extra input (set in the select/form stages).
+	current    *Action
+	optionList fuzzyList
+	formInput  textinput.Model
+
+	width  int
+	height int
+
+	// Results, read back after the program exits.
+	chosen   *Action // the action to run, nil if the user cancelled
+	value    string  // resolved option value or form input for the chosen action
+	quitting bool
+}
+
+// newPickerModel builds the initial TUI state showing every action. Actions are
+// partitioned by origin so project-local actions sort and render ahead of the
+// global ones; m.actions is stored in that same project-then-global order so each
+// list row's ref indexes straight back into it.
+func newPickerModel(ctx RunContext, actions []Action) pickerModel {
+	var project, global []Action
+	for _, a := range actions {
+		if a.origin == originProject {
+			project = append(project, a)
+		} else {
+			global = append(global, a)
+		}
+	}
+
+	ordered := make([]Action, 0, len(actions))
+	ordered = append(ordered, project...)
+	ordered = append(ordered, global...)
+
+	return pickerModel{
+		ctx:        ctx,
+		stage:      stageActions,
+		actions:    ordered,
+		actionList: newFuzzyList("Type to filter…", actionListItems(project, global)),
+	}
+}
+
+// actionListItems turns the project and global actions into picker rows. When
+// both groups are present it brackets each with a non-selectable "Project" /
+// "Global" heading so the origin of every action is clear; when only one group
+// exists it emits a plain, ungrouped list so a repo without project actions looks
+// exactly as it did before. Each selectable row's ref is its index into the
+// concatenated project++global slice, matching the order newPickerModel stores in
+// m.actions.
+func actionListItems(project, global []Action) []listItem {
+	grouped := len(project) > 0 && len(global) > 0
+	items := make([]listItem, 0, len(project)+len(global)+2)
+
+	if grouped {
+		items = append(items, listItem{name: "Project"})
+	}
+	for i, a := range project {
+		items = append(items, listItem{name: a.Name, desc: a.Description, selectable: true, ref: i})
+	}
+
+	if grouped {
+		items = append(items, listItem{name: "Global"})
+	}
+	for j, a := range global {
+		items = append(items, listItem{name: a.Name, desc: a.Description, selectable: true, ref: len(project) + j})
+	}
+
+	return items
+}
+
+// Init implements tea.Model and starts the cursor blinking.
+func (m pickerModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Update routes key presses to the handler for the current stage and forwards
+// everything else (window sizes, the blink tick) to the active input.
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.MouseMsg:
+		return m.updateMouse(msg)
+
+	case tea.KeyMsg:
+		switch m.stage {
+		case stageActions:
+			return m.updateActions(msg)
+		case stageSelect:
+			return m.updateSelect(msg)
+		case stageForm:
+			return m.updateForm(msg)
+		}
+	}
+
+	return m.forwardToInput(msg)
+}
+
+// updateMouse turns mouse input into list navigation: the wheel moves the
+// highlight, and the left button selects the row under the pointer — running it
+// on release, the natural completion of a click. The text-only form stage has no
+// list, so it ignores the mouse. This works only because herdr forwards mouse
+// events to the focused pane's program once that program enables mouse reporting
+// (which runQuickActionsUI does via tea.WithMouseCellMotion); otherwise herdr
+// would keep the clicks for its own pane focus/selection.
+func (m pickerModel) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	switch m.stage {
+	case stageActions:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.actionList.moveUp()
+		case tea.MouseButtonWheelDown:
+			m.actionList.moveDown()
+		case tea.MouseButtonLeft:
+			if m.actionList.clickRow(msg.Y-pickerHeaderLines) && msg.Action == tea.MouseActionRelease {
+				return m.activateAction()
+			}
+		}
+	case stageSelect:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.optionList.moveUp()
+		case tea.MouseButtonWheelDown:
+			m.optionList.moveDown()
+		case tea.MouseButtonLeft:
+			if m.optionList.clickRow(msg.Y-pickerHeaderLines) && msg.Action == tea.MouseActionRelease {
+				return m.activateOption()
+			}
+		}
+	}
+	return m, nil
+}
+
+// updateActions handles keys while choosing an action. Selecting a plain command
+// quits so it can run; selecting a select/form action advances to the matching
+// input stage.
+func (m pickerModel) updateActions(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc":
+		m.quitting = true
+		return m, tea.Quit
+	case "up", "ctrl+p":
+		m.actionList.moveUp()
+		return m, nil
+	case "down", "ctrl+n":
+		m.actionList.moveDown()
+		return m, nil
+	case "enter":
+		return m.activateAction()
+	}
+
+	cmd := m.actionList.editQuery(msg)
+	return m, cmd
+}
+
+// activateAction runs the highlighted action: a plain command quits so it can
+// run, while a select/form action advances to its input stage. It is shared by
+// the enter key and a left-click; activating with nothing selectable is a no-op.
+func (m pickerModel) activateAction() (tea.Model, tea.Cmd) {
+	idx := m.actionList.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	a := m.actions[idx]
+	switch a.effectiveType() {
+	case TypeSelect:
+		m.current = &a
+		m.optionList = newFuzzyList("Pick an option…", optionItems(a.Options))
+		m.stage = stageSelect
+		return m, textinput.Blink
+	case TypeForm:
+		m.current = &a
+		m.formInput = newFormInput(a.Form)
+		m.stage = stageForm
+		return m, textinput.Blink
+	default: // TypeCommand
+		m.chosen = &a
+		return m, tea.Quit
+	}
+}
+
+// updateSelect handles keys while choosing an option for a select action. esc
+// returns to the action list; enter records the chosen value and quits.
+func (m pickerModel) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.current = nil
+		m.stage = stageActions
+		return m, textinput.Blink
+	case "up", "ctrl+p":
+		m.optionList.moveUp()
+		return m, nil
+	case "down", "ctrl+n":
+		m.optionList.moveDown()
+		return m, nil
+	case "enter":
+		return m.activateOption()
+	}
+
+	cmd := m.optionList.editQuery(msg)
+	return m, cmd
+}
+
+// activateOption records the highlighted option's value as the chosen action's
+// value and quits so the action runs. Shared by the enter key and a left-click;
+// activating with nothing selectable is a no-op.
+func (m pickerModel) activateOption() (tea.Model, tea.Cmd) {
+	idx := m.optionList.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	m.value = m.current.Options[idx].resolvedValue()
+	m.chosen = m.current
+	return m, tea.Quit
+}
+
+// updateForm handles keys while entering text for a form action. esc returns to
+// the action list; enter records the entered string and quits.
+func (m pickerModel) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.current = nil
+		m.stage = stageActions
+		return m, textinput.Blink
+	case "enter":
+		m.value = strings.TrimSpace(m.formInput.Value())
+		m.chosen = m.current
+		return m, tea.Quit
+	}
+
+	var cmd tea.Cmd
+	m.formInput, cmd = m.formInput.Update(msg)
+	return m, cmd
+}
+
+// forwardToInput passes a non-key message to whichever input is active so the
+// cursor keeps blinking and text keeps flowing in every stage.
+func (m pickerModel) forwardToInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch m.stage {
+	case stageActions:
+		cmd = m.actionList.editQuery(msg)
+	case stageSelect:
+		cmd = m.optionList.editQuery(msg)
+	case stageForm:
+		m.formInput, cmd = m.formInput.Update(msg)
+	}
+	return m, cmd
+}
+
+// View renders the screen for the current stage.
+func (m pickerModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	var b strings.Builder
+
+	switch m.stage {
+	case stageSelect:
+		b.WriteString(titleStyle.Render(m.current.Name))
+		b.WriteString("\n\n")
+		b.WriteString(m.optionList.view("no matching options"))
+		b.WriteString("\n")
+		b.WriteString(footerStyle.Render("↑/↓ move • click/enter select • esc back"))
+
+	case stageForm:
+		b.WriteString(titleStyle.Render(m.current.Name))
+		b.WriteString("\n\n")
+		prompt := m.current.Form.Prompt
+		if prompt == "" {
+			prompt = "Enter a value"
+		}
+		b.WriteString(descStyle.Render(prompt))
+		b.WriteString("\n")
+		b.WriteString(promptStyle.Render("❯ "))
+		b.WriteString(m.formInput.View())
+		b.WriteString("\n\n")
+		b.WriteString(footerStyle.Render("enter submit • esc back"))
+
+	default: // stageActions
+		b.WriteString(titleStyle.Render(quickActionsTitle))
+		b.WriteString("\n\n")
+		b.WriteString(m.actionList.view("no matching actions"))
+		b.WriteString("\n")
+		b.WriteString(footerStyle.Render("↑/↓ move • click/enter run • esc cancel"))
+	}
+
+	return b.String()
+}
+
+// optionItems turns a select action's options into list rows. A selectable row
+// shows its label plus the option's optional description (the value is never
+// shown, so encoding data into the value — e.g. "host url" — does not clutter
+// the list). A separator option becomes a non-selectable heading/spacer row.
+// ref carries each row's index into the original options slice so the picker can
+// map the selected row back to its option.
+func optionItems(options []Option) []listItem {
+	items := make([]listItem, 0, len(options))
+	for i, o := range options {
+		if o.isSeparator() {
+			items = append(items, listItem{name: o.Heading})
+			continue
+		}
+		items = append(items, listItem{name: o.Label, desc: o.Description, selectable: true, ref: i})
+	}
+	return items
+}
+
+// newFormInput builds the text field for a form action, applying its optional
+// placeholder.
+func newFormInput(form FormConfig) textinput.Model {
+	ti := textinput.New()
+	ti.Prompt = ""
+	ti.Placeholder = form.Placeholder
+	if ti.Placeholder == "" {
+		ti.Placeholder = "Type a value…"
+	}
+	ti.Focus()
+	return ti
+}
+
+// runQuickActionsUI renders the fuzzy-finder TUI inside the zoomed pane herdr
+// opens for the `quick-actions-picker` entrypoint. It recovers the launch context
+// from the HERDR_PLUS_CTX environment variable the launching action set, loads the
+// actions for that working directory, and runs the chosen action with that
+// context. On exit herdr tears the pane down, returning focus to where you were.
+func runQuickActionsUI() {
+	ctx, err := decodeRunContext(os.Getenv("HERDR_PLUS_CTX"))
+	if err != nil {
+		errExit("could not decode run context:", err)
+	}
+
+	actions, err := loadPickerActions(ctx.WorkDir)
+	if err != nil {
+		// Leave the pane open so the user can read the config error.
+		errExit(err)
+	}
+
+	if len(actions) == 0 {
+		dir, _ := quickActionsConfigDir()
+		errExit(fmt.Sprintf("no actions found in %s", dir))
+	}
+
+	// WithMouseCellMotion enables click/release/wheel events so a row can be run
+	// with the mouse.
+	p := tea.NewProgram(newPickerModel(ctx, actions), tea.WithAltScreen(), tea.WithMouseCellMotion())
+	result, err := p.Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "herdr-plus:", err)
+	}
+
+	// Run the chosen action before exiting (which tears the pane down). The context
+	// carries the working directory and session metadata; we fill in the resolved
+	// Value.
+	if m, ok := result.(pickerModel); ok && m.chosen != nil {
+		runCtx := ctx
+		runCtx.Value = m.value
+		if err := m.chosen.run(runCtx); err != nil {
+			fmt.Fprintln(os.Stderr, "herdr-plus: action failed:", err)
+		}
+	}
+}

--- a/quickactionspicker_test.go
+++ b/quickactionspicker_test.go
@@ -1,0 +1,135 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestOptionItems confirms select options render their label plus optional
+// description (never the raw value), that separators become non-selectable
+// heading/spacer rows, and that selectable rows keep their original options
+// index in ref even when separators are interspersed.
+func TestOptionItems(t *testing.T) {
+	opts := []Option{
+		{Label: "With desc", Value: "v1", Description: "a description"}, // 0
+		{Label: "No desc", Value: "some long encoded value"},            // 1
+		{Heading: "Group B"},                  // 2: heading separator
+		{Label: "After heading", Value: "v3"}, // 3
+		{},                                    // 4: blank spacer
+	}
+	items := optionItems(opts)
+
+	if len(items) != 5 {
+		t.Fatalf("got %d items, want 5", len(items))
+	}
+	if !items[0].selectable || items[0].name != "With desc" || items[0].desc != "a description" || items[0].ref != 0 {
+		t.Fatalf("item0 = %+v", items[0])
+	}
+	if !items[1].selectable || items[1].name != "No desc" || items[1].desc != "" || items[1].ref != 1 {
+		t.Fatalf("item1 = %+v, value must not appear as desc", items[1])
+	}
+	if items[2].selectable || items[2].name != "Group B" {
+		t.Fatalf("item2 = %+v, want non-selectable heading", items[2])
+	}
+	if !items[3].selectable || items[3].name != "After heading" || items[3].ref != 3 {
+		t.Fatalf("item3 = %+v, ref must be original options index 3", items[3])
+	}
+	if items[4].selectable || items[4].name != "" {
+		t.Fatalf("item4 = %+v, want blank spacer", items[4])
+	}
+}
+
+// TestActionListItems confirms project and global actions are grouped under
+// "Project"/"Global" headings when both are present — with each selectable row's
+// ref pointing into the concatenated project++global order — and that a
+// global-only set renders as a plain, ungrouped list (no headings).
+func TestActionListItems(t *testing.T) {
+	project := []Action{
+		{Name: "make build", Description: "Build", origin: originProject},
+		{Name: "make test", Description: "Test", origin: originProject},
+	}
+	global := []Action{
+		{Name: "GitHub", Description: "Open GitHub", origin: originGlobal},
+	}
+
+	items := actionListItems(project, global)
+	// Project heading, 2 project rows, Global heading, 1 global row.
+	if len(items) != 5 {
+		t.Fatalf("got %d items, want 5: %+v", len(items), items)
+	}
+	if items[0].selectable || items[0].name != "Project" {
+		t.Fatalf("item0 = %+v, want non-selectable Project heading", items[0])
+	}
+	if !items[1].selectable || items[1].name != "make build" || items[1].ref != 0 {
+		t.Fatalf("item1 = %+v, want make build with ref 0", items[1])
+	}
+	if !items[2].selectable || items[2].name != "make test" || items[2].ref != 1 {
+		t.Fatalf("item2 = %+v, want make test with ref 1", items[2])
+	}
+	if items[3].selectable || items[3].name != "Global" {
+		t.Fatalf("item3 = %+v, want non-selectable Global heading", items[3])
+	}
+	if !items[4].selectable || items[4].name != "GitHub" || items[4].ref != 2 {
+		t.Fatalf("item4 = %+v, want GitHub with ref 2 (index into project++global)", items[4])
+	}
+
+	// Global-only: no headings, refs start at 0.
+	only := actionListItems(nil, global)
+	if len(only) != 1 {
+		t.Fatalf("got %d items for global-only, want 1 (no headings): %+v", len(only), only)
+	}
+	if !only[0].selectable || only[0].name != "GitHub" || only[0].ref != 0 {
+		t.Fatalf("global-only item = %+v, want GitHub ref 0 with no heading", only[0])
+	}
+}
+
+// TestPickerMouseClickRunsAction confirms a left-button release over a command
+// row selects that action and quits so it runs — the click counterpart to enter.
+// With a global-only list (no headings) the rows sit just below the title bar and
+// query line: "build" at screen row 4, "test" at row 5.
+func TestPickerMouseClickRunsAction(t *testing.T) {
+	actions := []Action{
+		{Name: "build", Command: "make build", origin: originGlobal},
+		{Name: "test", Command: "make test", origin: originGlobal},
+	}
+	m := newPickerModel(RunContext{}, actions)
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Action: tea.MouseActionRelease,
+		Button: tea.MouseButtonLeft,
+		Y:      5,
+	})
+	pm, ok := updated.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated)
+	}
+	if pm.chosen == nil || pm.chosen.Name != "test" {
+		t.Fatalf("clicking the 'test' row chose %v, want test", pm.chosen)
+	}
+}
+
+// TestPickerMouseWheelMoves confirms the scroll wheel walks the highlight without
+// running anything.
+func TestPickerMouseWheelMoves(t *testing.T) {
+	actions := []Action{
+		{Name: "build", Command: "make build", origin: originGlobal},
+		{Name: "test", Command: "make test", origin: originGlobal},
+	}
+	m := newPickerModel(RunContext{}, actions)
+
+	updated, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	pm := updated.(pickerModel)
+	if pm.chosen != nil {
+		t.Fatal("the wheel should not run an action")
+	}
+	if got := pm.actionList.selectedIndex(); got != 1 {
+		t.Fatalf("after wheel down selected ref = %d, want 1 (test)", got)
+	}
+}


### PR DESCRIPTION
## What

Adds **Quick Actions** — the second mode from the old build — to the plugin-first rebuild. A `quick-actions` action opens a fuzzy launcher of one-off actions; pick one and it runs **in the directory you launched from**.

Three action types: `command` (run immediately), `select` (pick from a second fuzzy list → `{{.Value}}`), and `form` (type a value → `{{.Value}}`). Commands are Go templates rendered against the launch context (`{{.WorkDir}}`, `{{.SessionTitle}}`, `{{.Value}}`, …), also exported as `HERDR_PLUS_*` env vars.

## How it's wired

- **`action.go`** — the Action model + template rendering + `sh -c` run.
- **`context.go`** — `RunContext` plus `contextFromPluginEnv`, which reads herdr's injected `HERDR_PLUGIN_CONTEXT_JSON` (the focused pane's cwd/workspace) — replacing the old socket-based context gathering.
- **`quickactionspicker.go`** — the multi-stage bubbletea picker (actions → select/form), ported from `old/picker.go`, running in a herdr pane.
- **`quickactions.go`** — `launchQuickActions` captures the focused pane's context, encodes it, and opens the picker as an **overlay** pane via `herdr plugin pane open --env HERDR_PLUS_CTX=…`, so the chosen command runs in your directory, not the picker's. herdr restores your focus when the overlay closes.
- **`config.go`** — quick-actions loaders (global + per-repo `.herdr-plus/quick-actions/`) + example seeding; `examples/quick-actions/`.
- Manifest: `quick-actions` action + `quick-actions-picker` overlay pane.

## Test plan
- `go vet` / `go build` / `go test -race` — green. Ported tests: action render/validate, context round-trip + `contextFromPluginEnv`, picker option/action rows + mouse.
- Live against herdr 0.7.0: `herdr plugin link` registers the action + pane; the picker renders cleanly in a herdr pane (exit 0, no errors). Reads existing `~/.config/herdr-plus/quick-actions/` files (config-compatible).

## Follow-ups
Worktree auto-layout (events), link handlers, distribution polish (goreleaser/brew/install.sh) + docs site.