### PR TITLE
Distribution: prebuilt binaries + no-Go plugin install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+#
+# Date: 2026-06-15
+# Author: Spicer Matthews (spicer@cloudmanic.com)
+# Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+#
+# Release pipeline for herdr-plus. Triggers on every push to main:
+#
+#   1. Determines the next version. If the pushed commit hand-edited
+#      internal/version/version.go (you bumped major/minor manually), the
+#      workflow uses that version as-is. Otherwise it auto-bumps the patch
+#      number, commits the change back to main with [skip ci], and pushes.
+#   2. Tags v<x.y.z> and pushes the tag.
+#   3. Runs goreleaser to cross-compile binaries (linux/darwin/windows ×
+#      amd64/arm64), package them, attach them to a GitHub Release, and push
+#      an updated Homebrew formula into Formula/ in this same repo (using the
+#      default GITHUB_TOKEN — no separate tap repo or PAT required).
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+    # Website-only changes ship via .github/workflows/site.yml and must NOT
+    # cut a new binary release. paths-ignore skips this workflow only when
+    # *every* changed file matches, so a mixed code+site commit still releases.
+    paths-ignore:
+      - "www/**"
+      - ".github/workflows/site.yml"
+  # Manual escape hatch. If a merge commit accidentally carries a skip-CI
+  # marker (or anything else suppresses the auto-trigger), we can rerun the
+  # release flow against the current main without an empty no-op commit.
+  workflow_dispatch:
+
+# Pushing the version bump and the brew formula back to main needs write access
+# to the repo's contents.
+permissions:
+  contents: write
+
+# Serialise releases — no two version bumps racing each other.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the workflow can inspect HEAD~1 for the "did this
+          # commit hand-edit version.go?" check, and so goreleaser sees prior
+          # tags for changelog generation.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      # Set the git identity once for the whole job. Both the version-bump
+      # commit and the annotated release tag need it, and the bump step is
+      # skipped on a hand-edited (non-auto-bumped) release — so configuring it
+      # here keeps tagging working on every path.
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # Decide whether to auto-bump or accept a hand-edited version.
+      - name: Determine version
+        id: version
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(sed -nE 's/.*const Version = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' internal/version/version.go)
+          if [[ -z "$CURRENT" ]]; then
+            echo "Could not parse version from internal/version/version.go" >&2
+            exit 1
+          fi
+
+          # If the pushed commit changed version.go, treat that as a manual
+          # major/minor bump and use the value as-is. Otherwise auto-bump patch.
+          if git diff --name-only HEAD~1..HEAD 2>/dev/null | grep -qx 'internal/version/version.go'; then
+            echo "Version was manually edited to $CURRENT — using as-is."
+            echo "version=$CURRENT"  >> "$GITHUB_OUTPUT"
+            echo "bumped=false"      >> "$GITHUB_OUTPUT"
+          else
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            NEW="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            echo "Auto-bumping $CURRENT → $NEW"
+            echo "version=$NEW" >> "$GITHUB_OUTPUT"
+            echo "bumped=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      # Commit the bumped version.go back to main. The [skip ci] marker tells
+      # GitHub Actions not to re-run this workflow (which would loop forever).
+      - name: Commit version bump
+        if: steps.version.outputs.bumped == 'true'
+        run: |
+          set -euo pipefail
+          NEW="${{ steps.version.outputs.version }}"
+
+          sed -i -E "s/(const Version = )\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\"$NEW\"/" internal/version/version.go
+
+          git add internal/version/version.go
+          git commit -m "Release v$NEW [skip ci]"
+          git push origin HEAD:main
+
+      # Always create + push the tag (even when version was hand-edited — that's
+      # the whole point of accepting it as-is).
+      - name: Tag release
+        run: |
+          set -euo pipefail
+          NEW="${{ steps.version.outputs.version }}"
+          if git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null; then
+            echo "Tag v$NEW already exists, skipping."
+            exit 0
+          fi
+          git tag -a "v$NEW" -m "Release v$NEW"
+          git push origin "v$NEW"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          # Same-repo brew formula push uses the default workflow token — no
+          # separate tap repo or PAT needed.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,94 @@
+#
+# Date: 2026-06-15
+# Author: Spicer Matthews (spicer@cloudmanic.com)
+# Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+#
+# GoReleaser config for herdr-plus. Driven by .github/workflows/release.yml on
+# every push to main: that workflow bumps internal/version/version.go and tags
+# v<x.y.z>, then invokes `goreleaser release --clean`. GoReleaser then
+# cross-compiles the binary, archives it, attaches it to a GitHub Release, and
+# pushes an updated Homebrew formula into Formula/ in this same repo.
+#
+# These prebuilt archives are also what `herdr plugin install` downloads when the
+# machine has no Go toolchain (see scripts/build.sh).
+
+version: 2
+
+project_name: herdr-plus
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: herdr-plus
+    binary: herdr-plus
+    main: .
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    # Skip windows/arm64 — less common, and we'd rather not ship binaries we
+    # can't easily test. Add it back if there's demand.
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+
+archives:
+  - id: default
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - "Merge pull request"
+      - "Merge branch"
+
+# Homebrew formula committed straight back into this repo under Formula/.
+# Installs the standalone binary on your PATH; to use it as a herdr plugin,
+# register it with `herdr plugin install` (or link the install). Users install
+# the binary via:
+#
+#   brew tap cloudmanic/herdr-plus https://github.com/cloudmanic/herdr-plus
+#   brew install cloudmanic/herdr-plus/herdr-plus
+#
+# Because the formula lives in the same repo as the source, the default
+# GITHUB_TOKEN the workflow already holds is enough to push it — no PAT, no
+# separate tap repo. The [skip ci] marker on the formula-update commit stops the
+# new push from triggering a second release run.
+brews:
+  - name: herdr-plus
+    repository:
+      owner: cloudmanic
+      name: herdr-plus
+      branch: main
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    directory: Formula
+    commit_msg_template: "Update {{ .ProjectName }} brew formula to {{ .Tag }} [skip ci]"
+    homepage: "https://github.com/cloudmanic/herdr-plus"
+    description: "herdr-plus — an add-on platform for the herdr terminal multiplexer."
+    license: "MIT"
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    install: |
+      bin.install "herdr-plus"
+    test: |
+      assert_path_exists bin/"herdr-plus"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cloudmanic Labs, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ the plugin's actions with herdr — no editing of your `config.toml`.
 herdr plugin install cloudmanic/herdr-plus
 ```
 
-herdr clones the repo, runs the manifest's `[[build]]` step (`go build`, needs a
-Go toolchain), and registers the actions. Manage it with `herdr plugin list`,
+herdr clones the repo, runs the manifest's `[[build]]` step, and registers the
+actions. That step **prefers a local Go toolchain** (an exact build of the source)
+and **falls back to downloading the latest prebuilt release binary**, so it works
+**with or without Go**. Manage it with `herdr plugin list`,
 `herdr plugin action list --plugin cloudmanic.herdr-plus`, and
 `herdr plugin uninstall cloudmanic.herdr-plus`.
 
@@ -32,6 +34,24 @@ Go toolchain), and registers the actions. Manage it with `herdr plugin list`,
 make build
 herdr plugin link /path/to/herdr-plus     # or: make plugin-link
 ```
+
+### Just the binary
+
+If you'd rather have `herdr-plus` on your `PATH` (e.g. to run `herdr-plus version`),
+prebuilt binaries are published on every release:
+
+```bash
+# Homebrew (the repo is its own tap)
+brew tap cloudmanic/herdr-plus https://github.com/cloudmanic/herdr-plus
+brew install cloudmanic/herdr-plus/herdr-plus
+
+# or the install script (Linux/macOS, no Homebrew)
+curl -fsSL https://raw.githubusercontent.com/cloudmanic/herdr-plus/main/install.sh | sh
+```
+
+The binary on its own doesn't register the plugin with herdr — use
+`herdr plugin install` (above) for that. Every merge to `main` cuts a new release
+with cross-compiled binaries.
 
 ## Projects
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -18,11 +18,13 @@ min_herdr_version = "0.7.0"
 description = "An add-on platform for herdr. Projects: declarative workspace templates you fuzzy-pick to spin up a whole herdr workspace."
 platforms = ["linux", "macos", "windows"]
 
-# Compile the binary from source at install time. herdr runs this once, after you
-# confirm a GitHub install and before registering the plugin. It needs a Go
-# toolchain; the resulting ./bin/herdr-plus is what the entry points below invoke.
+# Produce the binary at install time. herdr runs this once, after you confirm a
+# GitHub install and before registering the plugin. The script prefers a local Go
+# toolchain (an exact build of the cloned source) and falls back to downloading
+# the latest prebuilt release binary, so installing works with or without Go.
+# Either way the result is ./bin/herdr-plus, which the entry points below invoke.
 [[build]]
-command = ["go", "build", "-o", "bin/herdr-plus", "."]
+command = ["sh", "scripts/build.sh"]
 
 # projects — the flagship action. Opens a full-screen browser to fuzzy-pick a
 # project (a declarative set of tabs/panes from ~/.config/herdr-plus/projects/)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+#
+# Date: 2026-06-15
+# Author: Spicer Matthews (spicer@cloudmanic.com)
+# Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+#
+# One-liner installer / upgrader for herdr-plus. Detects the host OS and
+# architecture, downloads the matching archive from the latest GitHub Release,
+# extracts the static `herdr-plus` binary, and drops it into ~/.local/bin
+# (preferred) or /usr/local/bin. Re-running performs an upgrade.
+#
+# Usage:
+#
+#   curl -fsSL https://raw.githubusercontent.com/cloudmanic/herdr-plus/main/install.sh | sh
+#
+# Override the install location:
+#
+#   curl -fsSL .../install.sh | INSTALL_DIR=/opt/bin sh
+#
+# Override the version (default is the latest GitHub Release):
+#
+#   curl -fsSL .../install.sh | VERSION=v0.0.1 sh
+#
+# Designed to run under POSIX `sh` so it works on Alpine / BusyBox / minimal
+# SSH targets in addition to bash on a normal Linux box. herdr plugin install
+# also reuses it (via scripts/build.sh) to fetch a prebuilt binary when the
+# machine has no Go toolchain.
+
+set -eu
+
+REPO="cloudmanic/herdr-plus"
+BINARY="herdr-plus"
+
+# Pretty output when stderr is a terminal, plain otherwise.
+if [ -t 2 ]; then
+	BOLD="$(printf '\033[1m')"
+	DIM="$(printf '\033[2m')"
+	GREEN="$(printf '\033[32m')"
+	RED="$(printf '\033[31m')"
+	YELLOW="$(printf '\033[33m')"
+	RESET="$(printf '\033[0m')"
+else
+	BOLD=""
+	DIM=""
+	GREEN=""
+	RED=""
+	YELLOW=""
+	RESET=""
+fi
+
+# info prints a step-prefixed line to stderr so it doesn't pollute stdout.
+info() {
+	printf '%s==>%s %s\n' "$GREEN" "$RESET" "$1" >&2
+}
+
+warn() {
+	printf '%s==>%s %s\n' "$YELLOW" "$RESET" "$1" >&2
+}
+
+# fatal prints an error and exits non-zero.
+fatal() {
+	printf '%serror:%s %s\n' "$RED" "$RESET" "$1" >&2
+	exit 1
+}
+
+# detect_os normalises uname -s into the lowercase token GoReleaser uses in
+# archive names (linux, darwin).
+detect_os() {
+	uname_s="$(uname -s 2>/dev/null || echo unknown)"
+	case "$uname_s" in
+		Linux) echo "linux" ;;
+		Darwin) echo "darwin" ;;
+		*) fatal "unsupported OS: $uname_s (only Linux and macOS are released)" ;;
+	esac
+}
+
+# detect_arch maps uname -m onto GoReleaser's arch token (amd64 or arm64).
+detect_arch() {
+	uname_m="$(uname -m 2>/dev/null || echo unknown)"
+	case "$uname_m" in
+		x86_64|amd64) echo "amd64" ;;
+		aarch64|arm64) echo "arm64" ;;
+		*) fatal "unsupported architecture: $uname_m (only amd64 and arm64 are released)" ;;
+	esac
+}
+
+# require_cmd ensures cmd is on PATH.
+require_cmd() {
+	command -v "$1" >/dev/null 2>&1 || fatal "$1 is required but not found on PATH"
+}
+
+# fetch downloads url to outfile using curl or wget (whichever is present).
+fetch() {
+	url="$1"
+	outfile="$2"
+	if command -v curl >/dev/null 2>&1; then
+		curl --fail --show-error --silent --location --output "$outfile" "$url"
+	elif command -v wget >/dev/null 2>&1; then
+		wget --quiet --output-document "$outfile" "$url"
+	else
+		fatal "need curl or wget to download release archives"
+	fi
+}
+
+# resolve_version picks the version to install. If the user passed VERSION,
+# trust it as-is. Otherwise follow GitHub's /releases/latest redirect.
+resolve_version() {
+	if [ -n "${VERSION:-}" ]; then
+		echo "$VERSION"
+		return
+	fi
+	url="https://github.com/${REPO}/releases/latest"
+	if command -v curl >/dev/null 2>&1; then
+		header="$(curl --silent --location --head "$url" 2>/dev/null \
+			| grep -i '^location:' | tail -n 1)"
+	else
+		header="$(wget --max-redirect=0 --server-response --output-document=/dev/null "$url" 2>&1 \
+			| grep -i 'Location:' | tail -n 1)"
+	fi
+	tag="${header##*/}"
+	tag="$(printf '%s' "$tag" | tr -d '\r\n')"
+	if [ -z "$tag" ]; then
+		fatal "could not resolve latest version from $url"
+	fi
+	echo "$tag"
+}
+
+# pick_install_dir chooses where to drop the binary, honoring INSTALL_DIR.
+# Default: ~/.local/bin (no sudo), falling back to /usr/local/bin.
+pick_install_dir() {
+	if [ -n "${INSTALL_DIR:-}" ]; then
+		echo "$INSTALL_DIR"
+		return
+	fi
+	if [ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin" 2>/dev/null; then
+		echo "$HOME/.local/bin"
+		return
+	fi
+	echo "/usr/local/bin"
+}
+
+# install_binary moves the extracted binary into the chosen directory, using
+# sudo if the directory isn't writable.
+install_binary() {
+	src="$1"
+	dest_dir="$2"
+	dest="$dest_dir/$BINARY"
+
+	if [ -w "$dest_dir" ] || ([ ! -e "$dest_dir" ] && mkdir -p "$dest_dir" 2>/dev/null); then
+		mv "$src" "$dest"
+		chmod +x "$dest"
+		return
+	fi
+	if command -v sudo >/dev/null 2>&1; then
+		warn "writing to $dest_dir requires sudo"
+		sudo mkdir -p "$dest_dir"
+		sudo mv "$src" "$dest"
+		sudo chmod +x "$dest"
+		return
+	fi
+	fatal "cannot write to $dest_dir and sudo is not available"
+}
+
+# warn_if_not_in_path nudges the user to fix their PATH if we installed
+# somewhere they can't run from.
+warn_if_not_in_path() {
+	dir="$1"
+	case ":$PATH:" in
+		*":$dir:"*) return ;;
+	esac
+	warn "$dir is not on your \$PATH — add this to your shell rc:"
+	printf '\n    %sexport PATH="%s:\$PATH"%s\n\n' "$BOLD" "$dir" "$RESET" >&2
+}
+
+main() {
+	require_cmd tar
+
+	os="$(detect_os)"
+	arch="$(detect_arch)"
+	version="$(resolve_version)"
+	# Strip a leading 'v' so the version slot in the archive name matches
+	# GoReleaser's {{ .Version }} (which is bare). Tags ARE prefixed v.
+	bare_version="${version#v}"
+
+	archive="${BINARY}_${bare_version}_${os}_${arch}.tar.gz"
+	url="https://github.com/${REPO}/releases/download/${version}/${archive}"
+
+	info "Installing ${BINARY} ${version} (${os}/${arch})"
+	info "  source: ${url}"
+
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "$tmp"' EXIT INT TERM
+
+	fetch "$url" "$tmp/$archive" \
+		|| fatal "download failed (was the release published with this archive name?)"
+
+	tar -xzf "$tmp/$archive" -C "$tmp" \
+		|| fatal "extraction failed (archive may be corrupt)"
+
+	if [ ! -f "$tmp/$BINARY" ]; then
+		fatal "archive did not contain a $BINARY binary"
+	fi
+
+	dest_dir="$(pick_install_dir)"
+	info "Installing to ${dest_dir}/${BINARY}"
+	install_binary "$tmp/$BINARY" "$dest_dir"
+
+	info "Done. ${BOLD}${dest_dir}/${BINARY}${RESET}${DIM} (${version})${RESET}"
+	warn_if_not_in_path "$dest_dir"
+}
+
+main "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Date: 2026-06-15
+# Author: Spicer Matthews (spicer@cloudmanic.com)
+# Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+#
+# Build herdr-plus for `herdr plugin install`. herdr runs this as the manifest's
+# [[build]] step after cloning the repo, in the plugin root, with no plugin
+# context and no guaranteed Go toolchain.
+#
+# Prefer a local Go toolchain — it builds the exact cloned source. When Go is
+# absent, fall back to downloading the latest prebuilt release binary via
+# install.sh, so installing the plugin works without Go. Either way the result is
+# ./bin/herdr-plus, which the manifest's actions and panes invoke.
+
+set -eu
+
+mkdir -p bin
+
+if command -v go >/dev/null 2>&1; then
+	echo "herdr-plus: building from source (go build)…" >&2
+	exec go build -o bin/herdr-plus .
+fi
+
+echo "herdr-plus: no Go toolchain found — downloading the latest prebuilt binary…" >&2
+INSTALL_DIR="$(pwd)/bin" sh install.sh


### PR DESCRIPTION
## What

Makes **`herdr plugin install cloudmanic/herdr-plus` work with or without a Go toolchain**, and sets up a real release pipeline that publishes prebuilt binaries.

Before, the manifest's `[[build]]` step was `go build`, so installing required Go. Now it prefers Go (exact build of the source) but **falls back to downloading the latest prebuilt release binary**.

## What's here

- **`.goreleaser.yml`** — cross-compiles (linux/darwin/windows × amd64/arm64), archives, attaches to a GitHub Release, and pushes a Homebrew formula into `Formula/`. (Ported from `old/`.)
- **`.github/workflows/release.yml`** — on push to `main`: auto-bump the patch version in `internal/version/version.go`, tag `v<x.y.z>`, run goreleaser. (Ported from `old/`.)
- **`install.sh`** — standalone POSIX one-liner installer that downloads the latest release binary (`curl … | sh`).
- **`scripts/build.sh`** — the manifest's `[[build]]` step: `go build` when Go is present, else `INSTALL_DIR=./bin install.sh` to download the prebuilt binary. Result is always `./bin/herdr-plus`.
- **`LICENSE`** at the repo root (goreleaser archives it; the brew formula references it).
- **README** — documents both install paths.

## How install now works

| You have Go | `herdr plugin install` does |
|---|---|
| Yes | `go build` — exact build of the cloned source |
| No | downloads the latest prebuilt release binary |

Standalone binary (`herdr-plus` on PATH) is also available via `brew` / `install.sh`, though the binary alone doesn't register the plugin — `herdr plugin install` does that.

## Test plan / notes

- `scripts/build.sh` validated locally (Go path → `bin/herdr-plus`); `sh -n` syntax checks pass on both scripts; `go vet`/`build`/`test` green; manifest re-links cleanly.
- The **release pipeline and the download fallback can't be fully exercised until the first release exists** — which this PR bootstraps: merging it triggers `release.yml`, cutting `v0.1.1` with cross-compiled binaries. After that, the no-Go install path is live. The goreleaser config is a verbatim port of the one that shipped the old `0.0.x` releases.
- `herdr plugin link` (dev) is unaffected — it doesn't run `[[build]]`.

## Follow-ups
Docs site (`www/`), worktree auto-layout (events), link handlers.