### PR TITLE
Read config from herdr's managed plugin dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,30 @@ The binary on its own doesn't register the plugin with herdr — use
 `herdr plugin install` (above) for that. Every merge to `main` cuts a new release
 with cross-compiled binaries.
 
+## Configuration
+
+herdr-plus keeps its config in herdr's managed plugin directory — find it with:
+
+```bash
+herdr plugin config-dir cloudmanic.herdr-plus
+# → ~/.config/herdr/plugins/config/cloudmanic.herdr-plus
+```
+
+Inside it, `projects/` holds your [project templates](#projects) and
+`quick-actions/` your [actions](#quick-actions). herdr provisions this directory
+and keeps it across uninstall/upgrade. (Running the binary *outside* herdr falls
+back to `~/.config/herdr-plus/`, honoring `$XDG_CONFIG_HOME`.)
+
 ## Projects
 
 Pick a project from a full-screen fuzzy browser and herdr-plus builds its whole
 workspace. Trigger it from herdr's plugin action menu, or
 [bind a key](#binding-a-key) — the action is `cloudmanic.herdr-plus.projects`.
 
-A project is one TOML file in `~/.config/herdr-plus/projects/` (honoring
-`$XDG_CONFIG_HOME`). The file name doesn't matter; add a file to add a project,
-delete it to remove it. With no files there, the browser shows an onboarding card.
+A project is one TOML file in the `projects/` subdir of
+[herdr-plus's config dir](#configuration). The file name doesn't matter; add a
+file to add a project, delete it to remove it. With no files there, the browser
+shows an onboarding card.
 
 ```toml
 name = "Options Cafe"
@@ -116,9 +131,9 @@ A tab uses *either* `command` *or* `[[tabs.panes]]`, not both.
 
 A fuzzy launcher for one-off commands. Trigger it (action
 `cloudmanic.herdr-plus.quick-actions`), fuzzy-pick an action, and it runs in the
-directory you launched from. Actions are TOML files in
-`~/.config/herdr-plus/quick-actions/` (seeded with editable examples on first
-run). A repo can also ship its own in `<repo>/.herdr-plus/quick-actions/`, shown
+directory you launched from. Actions are TOML files in the `quick-actions/` subdir
+of [herdr-plus's config dir](#configuration) (seeded with editable examples on
+first run). A repo can also ship its own in `<repo>/.herdr-plus/quick-actions/`, shown
 under a **Project** heading above your **Global** ones — this repo ships
 `make build` / `make test` as a live example.
 

--- a/config.go
+++ b/config.go
@@ -25,11 +25,21 @@ import (
 //go:embed examples
 var embeddedExamples embed.FS
 
-// configBaseDir returns the root configuration directory, ~/.config/herdr-plus.
-// It honors $XDG_CONFIG_HOME when set (the cross-platform convention) and
-// otherwise falls back to ~/.config so the location is the same on macOS and
-// Linux.
+// configBaseDir returns the root configuration directory for herdr-plus's
+// projects and quick-actions.
+//
+// When herdr runs us as a plugin it sets HERDR_PLUGIN_CONFIG_DIR to the standard,
+// herdr-managed per-plugin config directory
+// (~/.config/herdr/plugins/config/cloudmanic.herdr-plus). That is the canonical
+// home for our config — herdr provisions it, isolates it per plugin, and keeps it
+// across uninstall/upgrade — so we prefer it whenever it is set.
+//
+// Outside herdr (running the binary directly, dev, tests) the variable is unset,
+// so we fall back to the legacy ~/.config/herdr-plus, honoring $XDG_CONFIG_HOME.
 func configBaseDir() (string, error) {
+	if d := os.Getenv("HERDR_PLUGIN_CONFIG_DIR"); d != "" {
+		return d, nil
+	}
 	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
 		return filepath.Join(x, "herdr-plus"), nil
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,46 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestConfigBaseDirPrefersManagedDir confirms herdr's managed plugin config
+// directory (HERDR_PLUGIN_CONFIG_DIR) wins over the legacy location when set —
+// the case that runs whenever herdr executes a plugin command.
+func TestConfigBaseDirPrefersManagedDir(t *testing.T) {
+	managed := filepath.Join(t.TempDir(), "herdr", "plugins", "config", "cloudmanic.herdr-plus")
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", managed)
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/should-be-ignored")
+
+	got, err := configBaseDir()
+	if err != nil {
+		t.Fatalf("configBaseDir: %v", err)
+	}
+	if got != managed {
+		t.Fatalf("configBaseDir = %q, want the managed dir %q", got, managed)
+	}
+}
+
+// TestConfigBaseDirFallsBackToLegacy confirms that without the managed dir, config
+// falls back to ~/.config/herdr-plus under $XDG_CONFIG_HOME (the path used when
+// the binary runs outside herdr).
+func TestConfigBaseDirFallsBackToLegacy(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	got, err := configBaseDir()
+	if err != nil {
+		t.Fatalf("configBaseDir: %v", err)
+	}
+	if want := filepath.Join(xdg, "herdr-plus"); got != want {
+		t.Fatalf("configBaseDir = %q, want %q", got, want)
+	}
+}

--- a/project_test.go
+++ b/project_test.go
@@ -16,6 +16,9 @@ import (
 // makes sure it exists, mirroring how the real config layout is rooted.
 func projectsDirIn(t *testing.T, tmp string) string {
 	t.Helper()
+	// Pin config to the temp XDG dir even if these tests run inside a herdr
+	// plugin context (where HERDR_PLUGIN_CONFIG_DIR would otherwise win).
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", "")
 	dir := filepath.Join(tmp, "herdr-plus", "projects")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir projects dir: %v", err)


### PR DESCRIPTION
## What

Switch herdr-plus to read its `projects/` and `quick-actions/` config from herdr's **standard managed plugin directory** instead of `~/.config/herdr-plus/`.

When herdr runs the plugin it sets `HERDR_PLUGIN_CONFIG_DIR` to `~/.config/herdr/plugins/config/cloudmanic.herdr-plus/`. `configBaseDir()` now prefers that, falling back to the legacy `~/.config/herdr-plus/` (honoring `$XDG_CONFIG_HOME`) when the var is unset — i.e. running the binary outside herdr, dev, or tests.

## Why it's safe

herdr provisions this dir per plugin and **keeps it across uninstall/upgrade** — I verified this directly (installed a throwaway plugin, dropped a marker in its config dir, uninstalled → the config dir + marker survived; only the cloned binary was removed). So it's the canonical, durable home for plugin config.

## Changes
- `config.go` — `configBaseDir` prefers `HERDR_PLUGIN_CONFIG_DIR`.
- `config_test.go` — precedence tests (managed > XDG fallback); `project_test.go` pins `HERDR_PLUGIN_CONFIG_DIR=""` so config tests stay deterministic even inside a plugin context.
- `README.md` — a **Configuration** section pointing at `herdr plugin config-dir cloudmanic.herdr-plus`.

## Migration note

Existing config in `~/.config/herdr-plus/` needs to move to the managed dir to be picked up (the dotfiles side of this is handled separately). `go vet`/`build`/`test -race` green.