### PR TITLE
Keep herdr-plugin.toml version in sync with the release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@
 #   1. Determines the next version. If the pushed commit hand-edited
 #      internal/version/version.go (you bumped major/minor manually), the
 #      workflow uses that version as-is. Otherwise it auto-bumps the patch
-#      number, commits the change back to main with [skip ci], and pushes.
+#      number. Either way it syncs that version into BOTH version.go and
+#      herdr-plugin.toml's `version` field, commits with [skip ci], and pushes.
 #   2. Tags v<x.y.z> and pushes the tag.
 #   3. Runs goreleaser to cross-compile binaries (linux/darwin/windows ×
 #      amd64/arm64), package them, attach them to a GitHub Release, and push
@@ -96,19 +97,30 @@ jobs:
             echo "bumped=true"  >> "$GITHUB_OUTPUT"
           fi
 
-      # Commit the bumped version.go back to main. The [skip ci] marker tells
-      # GitHub Actions not to re-run this workflow (which would loop forever).
-      - name: Commit version bump
-        if: steps.version.outputs.bumped == 'true'
+      # Sync the release version into BOTH files that carry it and commit if
+      # anything changed:
+      #   - internal/version/version.go (printed by `herdr-plus version`)
+      #   - herdr-plugin.toml's `version` field (what herdr shows in the plugin
+      #     install preview and `herdr plugin list`)
+      # This runs on both paths — the auto-bump (version.go was the old value) and
+      # a hand-edited version (version.go already new, but the manifest may still
+      # be stale). The diff guard makes it a no-op when both already match. The
+      # [skip ci] marker stops the push from re-triggering this workflow.
+      - name: Sync version into version.go + manifest
         run: |
           set -euo pipefail
           NEW="${{ steps.version.outputs.version }}"
 
           sed -i -E "s/(const Version = )\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\"$NEW\"/" internal/version/version.go
+          sed -i -E "s/^(version = )\"[0-9]+\.[0-9]+\.[0-9]+\"/\1\"$NEW\"/" herdr-plugin.toml
 
-          git add internal/version/version.go
-          git commit -m "Release v$NEW [skip ci]"
-          git push origin HEAD:main
+          if git diff --quiet internal/version/version.go herdr-plugin.toml; then
+            echo "version.go and herdr-plugin.toml already at v$NEW — nothing to commit."
+          else
+            git add internal/version/version.go herdr-plugin.toml
+            git commit -m "Release v$NEW [skip ci]"
+            git push origin HEAD:main
+          fi
 
       # Always create + push the tag (even when version was hand-edited — that's
       # the whole point of accepting it as-is).

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -13,7 +13,8 @@
 
 id = "cloudmanic.herdr-plus"
 name = "Herdr Plus"
-version = "0.1.0"
+# Kept in sync with internal/version/version.go by .github/workflows/release.yml.
+version = "0.1.3"
 min_herdr_version = "0.7.0"
 description = "An add-on platform for herdr. Projects: declarative workspace templates you fuzzy-pick to spin up a whole herdr workspace."
 platforms = ["linux", "macos", "windows"]


### PR DESCRIPTION
## What

Fixes the version herdr shows in the plugin install preview / `herdr plugin list` being stuck at **`0.1.0`** while the actual release was `0.1.3`.

## Why

There are two version numbers:
- `internal/version/version.go` → printed by `herdr-plus version`; the release pipeline **auto-bumps** it (tags follow it). At `0.1.3`.
- `herdr-plugin.toml`'s `version` field → what **herdr** reads and displays. Hardcoded at `0.1.0`; the pipeline never touched it.

They drifted because `release.yml` only bumped `version.go`.

## Changes

- **`herdr-plugin.toml`** — bump `version` to `0.1.3` to match the current release.
- **`.github/workflows/release.yml`** — the version step now syncs **both** `version.go` *and* the manifest's `version` (an anchored `^version = ` sed, so `min_herdr_version` is left alone), committing if either changed. Runs on both the auto-bump and hand-edited paths, guarded by a `git diff` no-op check.

After this merges, the release pipeline will bump both to `0.1.4` in lockstep, and the install preview will show the right number from now on.

## Test plan
- Verified the seds locally: manifest `version` bumps, `min_herdr_version` untouched; `version.go` bumps. `go build`/`test` green.