### PR TITLE
Prep for herdr Marketplace: drop Windows platform, expand description

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,13 +26,11 @@ builds:
     main: .
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    # Linux + macOS only. The manifest declares platforms = ["linux", "macos"]
+    # (we don't test on Windows, and the socket client + sh-based build step
+    # aren't validated there), so we don't ship Windows binaries to match.
+    goos: [linux, darwin]
     goarch: [amd64, arm64]
-    # Skip windows/arm64 — less common, and we'd rather not ship binaries we
-    # can't easily test. Add it back if there's demand.
-    ignore:
-      - goos: windows
-        goarch: arm64
     ldflags:
       - -s -w
 
@@ -40,9 +38,6 @@ archives:
   - id: default
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats: [tar.gz]
-    format_overrides:
-      - goos: windows
-        formats: [zip]
     files:
       - LICENSE*
       - README*

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -8,16 +8,17 @@
 # repo, runs the [[build]] step below, and registers the entry points), or for
 # local development `herdr plugin link .` from a checkout.
 #
-# This is the plugin-first rebuild. Phase 0 ships only a `ping` smoke test that
-# proves the plugin loop; the Projects feature and friends arrive in later phases.
+# This is the plugin-first rebuild. It ships Projects (declarative workspace
+# templates you fuzzy-pick) and Quick Actions (a fuzzy launcher for one-off
+# scripts), plus a `ping` smoke test that proves the plugin loop end to end.
 
 id = "cloudmanic.herdr-plus"
 name = "Herdr Plus"
 # Kept in sync with internal/version/version.go by .github/workflows/release.yml.
 version = "0.1.4"
 min_herdr_version = "0.7.0"
-description = "An add-on platform for herdr. Projects: declarative workspace templates you fuzzy-pick to spin up a whole herdr workspace."
-platforms = ["linux", "macos", "windows"]
+description = "An add-on platform for herdr. Projects: fuzzy-pick a declarative template to spin up a whole workspace — every tab, pane, and startup command. Quick Actions: a fuzzy launcher for one-off scripts, run in the directory you launched from."
+platforms = ["linux", "macos"]
 
 # Produce the binary at install time. herdr runs this once, after you confirm a
 # GitHub install and before registering the plugin. The script prefers a local Go


### PR DESCRIPTION
## What

Marketplace-readiness cleanup, prompted by a review against [herdr's Marketplace docs](https://herdr.dev/docs/marketplace/).

- **Drop `windows` from `platforms`** in `herdr-plugin.toml` → `["linux", "macos"]`. We've never tested on Windows; the socket client and the `sh scripts/build.sh` build step aren't validated there. The docs say to *"declare `platforms` honestly, because the index will use it to show where a plugin runs."*
- **Drop Windows from the goreleaser build matrix** to match — we no longer attach a Windows binary (or the now-dead `windows → zip` archive override) to releases.
- **Expand the manifest `description`** to mention Quick Actions, not just Projects. This is the field the Marketplace index displays.
- **Refresh the stale Phase 0 header comment** now that both Projects and Quick Actions ship.

## Already handled outside this PR (repo metadata)

- Added the **`herdr-plugin` GitHub topic** (the Marketplace discovery signal).
- Refreshed the GitHub repo description (previously still mentioned removed "modes").
- Set the homepage to https://herdrplus.com.

## Verification

- `go build ./...` + `go test ./...` green.
- `install.sh` has no Windows references, so nothing breaks there.
- goreleaser config validated by CI.