### PR TITLE
Fix quick-actions failing to spawn outside the plugin's install dir

### DIFF
--- a/quickactions.go
+++ b/quickactions.go
@@ -40,11 +40,15 @@ func launchQuickActions() {
 		// Hand the launch context to the picker as a single shell-safe env var.
 		"--env", "HERDR_PLUS_CTX=" + enc,
 	}
-	// Run the overlay pane's shell in the launching directory too, so the picker
-	// and anything it spawns default to the right place.
-	if ctx.WorkDir != "" {
-		args = append(args, "--cwd", ctx.WorkDir)
-	}
+	// IMPORTANT: do not add --cwd here. The manifest registers this pane with a
+	// relative command (./bin/herdr-plus), which herdr resolves against the pane's
+	// working directory — so the pane must run in the plugin's own install dir for
+	// that path to resolve. Passing --cwd <launch dir> made herdr look for
+	// ./bin/herdr-plus inside the launch directory and fail to spawn the picker.
+	// The launch directory still reaches the picker — and the action it runs —
+	// through HERDR_PLUS_CTX (ctx.WorkDir), which sets each command's cmd.Dir and
+	// the per-repo action lookup. So --cwd was purely cosmetic; dropping it loses
+	// nothing and matches how the projects pane (which never set it) already works.
 
 	cmd := exec.Command(herdr, args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## The bug

Quick Actions (`prefix+down`) failed to open from any directory **except** the plugin's own install dir, while Projects (`prefix+up`) always worked. The herdr server log showed it every time:

```
ERROR herdr::pane: failed to spawn ... Unable to spawn
  /Users/spicer/.dotfiles/./bin/herdr-plus because it does not exist
  method="plugin.pane.open"
```

## Root cause

The manifest registers the picker panes with a **relative** command, `["./bin/herdr-plus", …]`, which herdr resolves against the **pane's working directory**.

- **projects** opens its pane with no `--cwd` → the pane runs in the plugin's dir → `./bin/herdr-plus` resolves. ✅
- **quick-actions** opened its overlay with `--cwd <launch dir>` (`quickactions.go`) → herdr resolved `./bin/herdr-plus` against e.g. `~/.dotfiles` → spawn fails. ❌

## Fix

Remove the `--cwd` block from `launchQuickActions()`. It was purely cosmetic — the launch directory still reaches the picker **and every action it runs** through `HERDR_PLUS_CTX` → `ctx.WorkDir`, which sets:
- each command's `cmd.Dir` (`action.go:178-179`), and
- the per-repo `.herdr-plus/quick-actions/` lookup (`quickactionspicker.go:389`).

So actions still run in your launch directory; only the (unused) pane cwd changes, letting the relative binary path resolve exactly like projects. Added a comment so it doesn't get reintroduced.

## Verified

- `go build` / `go vet` / `go test ./...` all green.
- No test asserted `--cwd`.

Diagnosed from a herdr server log on a machine where the plugin was installed outside its source tree (credit to the diagnosis Spicer relayed).