### PR TITLE
feat: support wildcard worktree layout (repo = "*")

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ name = "terminal"              # no command — just an empty shell
 ```
 
 - **`repo`** (required) matches the new worktree's repository name — the repo's
-  basename, e.g. `options-cafe` — case-insensitively.
+  basename, e.g. `options-cafe` — case-insensitively. Set `repo = "*"` to create a
+  **wildcard layout** that matches any repo (see below).
 - **`branch`** (optional) narrows a layout to worktrees created on exactly that
   branch. When more than one layout matches, a branch-specific one wins over a
   repo-only one.
@@ -216,6 +217,39 @@ herdr-plus does nothing when nothing matches.
 
 The handler's output shows up in `herdr plugin log list --plugin
 cloudmanic.herdr-plus`, so you can confirm whether a layout fired.
+
+### Wildcard (generic) layouts
+
+Set `repo = "*"` to define a layout that applies to **every** repo that doesn't
+have its own specific layout — a generic project template:
+
+```toml
+repo = "*"
+
+[[tabs]]
+name = "claude"
+command = "claude --dangerously-skip-permissions --chrome"
+
+[[tabs]]
+name = "code-review"
+command = "lazygit"
+
+[[tabs]]
+name = "terminal"
+```
+
+This is useful when you have many repos that all want the same workspace shape.
+Instead of one file per repo, write one wildcard layout and you're done.
+
+**Specificity:** when multiple layouts match a worktree, the most specific wins:
+
+1. Repo + branch (e.g. `repo = "my-app"`, `branch = "main"`)
+2. Repo only (e.g. `repo = "my-app"`)
+3. Wildcard + branch (e.g. `repo = "*"`, `branch = "main"`)
+4. Wildcard only (e.g. `repo = "*"`)
+
+A repo-specific layout always beats a wildcard, so you can set a generic default
+and still override individual repos when needed.
 
 ## Binding a key
 

--- a/worktree.go
+++ b/worktree.go
@@ -30,12 +30,14 @@ import (
 type WorktreeLayout struct {
 	// Repo selects which worktrees this layout applies to, matched
 	// case-insensitively against the new worktree's repo name (the repository's
-	// basename, e.g. "options-cafe"). Required.
+	// basename, e.g. "options-cafe"). Set to "*" to match any repo as a universal
+	// fallback (a wildcard layout). Required.
 	Repo string `toml:"repo"`
 
 	// Branch, when set, narrows the layout to worktrees created on exactly this
-	// branch (case-insensitive). Empty applies to every branch of the repo, and a
-	// branch-specific layout is preferred over a repo-only one when both match.
+	// branch (case-insensitive). Empty applies to every branch of the repo. When
+	// multiple layouts match, specificity determines the winner: repo+branch >
+	// repo-only > wildcard+branch > wildcard-only.
 	Branch string `toml:"branch"`
 
 	// Tabs is the ordered list of tabs to open in the worktree's workspace,

--- a/worktree.go
+++ b/worktree.go
@@ -60,14 +60,17 @@ func (l WorktreeLayout) validate() error {
 	return validateTabs(l.Repo, l.source, l.Tabs)
 }
 
-// matches reports whether this layout applies to the given worktree event. The
-// repo must match (against either the repo name or the basename of the repo
-// root, case-insensitively); a layout with a Branch additionally requires the
+// matches reports whether this layout applies to the given worktree event. A
+// repo value of "*" is a wildcard that matches any repo; otherwise the repo must
+// match (against either the repo name or the basename of the repo root,
+// case-insensitively). A layout with a Branch additionally requires the
 // worktree's branch to match.
 func (l WorktreeLayout) matches(ev worktreeEvent) bool {
 	repo := strings.TrimSpace(l.Repo)
-	if !strings.EqualFold(repo, ev.RepoName) && !strings.EqualFold(repo, filepath.Base(ev.RepoRoot)) {
-		return false
+	if repo != "*" {
+		if !strings.EqualFold(repo, ev.RepoName) && !strings.EqualFold(repo, filepath.Base(ev.RepoRoot)) {
+			return false
+		}
 	}
 	if l.Branch != "" && !strings.EqualFold(strings.TrimSpace(l.Branch), ev.Branch) {
 		return false
@@ -136,26 +139,38 @@ func loadWorktreeLayouts() ([]WorktreeLayout, error) {
 }
 
 // matchWorktreeLayout returns the best matching layout for an event, if any.
-// Among all matching layouts a branch-specific one wins over a repo-only one (it
-// is more specific); ties break by file name, which loadWorktreeLayouts already
-// sorts by.
+// Specificity determines the winner: repo+branch (4) > repo-only (3) >
+// wildcard+branch (2) > wildcard-only (1). Ties at the same score break by
+// filename, which loadWorktreeLayouts already sorts by (first wins).
 func matchWorktreeLayout(layouts []WorktreeLayout, ev worktreeEvent) (WorktreeLayout, bool) {
 	var best WorktreeLayout
-	found := false
+	bestScore := 0
 	for _, l := range layouts {
 		if !l.matches(ev) {
 			continue
 		}
-		if !found {
-			best, found = l, true
-			continue
-		}
-		// A branch-specific match beats the repo-only match we already have.
-		if best.Branch == "" && l.Branch != "" {
-			best = l
+		s := layoutSpecificity(l)
+		if s > bestScore {
+			best, bestScore = l, s
 		}
 	}
-	return best, found
+	return best, bestScore > 0
+}
+
+// layoutSpecificity scores a layout's match precision. Higher is more specific.
+func layoutSpecificity(l WorktreeLayout) int {
+	isWildcard := strings.TrimSpace(l.Repo) == "*"
+	hasBranch := strings.TrimSpace(l.Branch) != ""
+	switch {
+	case !isWildcard && hasBranch:
+		return 4
+	case !isWildcard && !hasBranch:
+		return 3
+	case isWildcard && hasBranch:
+		return 2
+	default:
+		return 1
+	}
 }
 
 // worktreeEvent is the subset of the `worktree.created` payload herdr-plus acts

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -133,6 +133,7 @@ func TestWorktreeLayoutValidate(t *testing.T) {
 		wantErr bool
 	}{
 		{"valid", WorktreeLayout{Repo: "r", Tabs: []ProjectTab{{Name: "t", Command: "ls"}}}, false},
+		{"wildcard repo", WorktreeLayout{Repo: "*", Tabs: []ProjectTab{{Name: "t"}}}, false},
 		{"no repo", WorktreeLayout{Tabs: []ProjectTab{{Name: "t"}}}, true},
 		{"no tabs", WorktreeLayout{Repo: "r"}, true},
 		{"bad split", WorktreeLayout{Repo: "r", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Split: "sideways"}}}}}, true},
@@ -143,6 +144,61 @@ func TestWorktreeLayoutValidate(t *testing.T) {
 				t.Fatalf("validate() err = %v, wantErr = %v", err, c.wantErr)
 			}
 		})
+	}
+}
+
+// TestMatchWorktreeLayoutWildcard covers the wildcard repo = "*" matching:
+// a wildcard matches any repo, but a repo-specific layout always wins;
+// a wildcard with a branch filter only matches that branch; and among
+// wildcards, branch-specific beats branch-less.
+func TestMatchWorktreeLayoutWildcard(t *testing.T) {
+	ev, err := parseWorktreeEvent(realEventJSON, mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseWorktreeEvent: %v", err)
+	}
+
+	wildcard := WorktreeLayout{Repo: "*", Tabs: []ProjectTab{{Name: "w"}}, source: "wildcard.toml"}
+	wildcardBranch := WorktreeLayout{Repo: "*", Branch: "probe-wt", Tabs: []ProjectTab{{Name: "wb"}}, source: "wildcard-branch.toml"}
+	wildcardWrongBranch := WorktreeLayout{Repo: "*", Branch: "main", Tabs: []ProjectTab{{Name: "ww"}}, source: "wildcard-wrong.toml"}
+	repoOnly := WorktreeLayout{Repo: "wt-probe-repo", Tabs: []ProjectTab{{Name: "r"}}, source: "repo.toml"}
+	repoBranch := WorktreeLayout{Repo: "wt-probe-repo", Branch: "probe-wt", Tabs: []ProjectTab{{Name: "rb"}}, source: "repo-branch.toml"}
+
+	// Wildcard matches when no repo-specific layout exists.
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{wildcard}, ev); !ok || got.source != "wildcard.toml" {
+		t.Fatalf("wildcard alone: got %q, %v; want wildcard.toml", got.source, ok)
+	}
+
+	// Repo-specific layout beats wildcard.
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{wildcard, repoOnly}, ev); !ok || got.source != "repo.toml" {
+		t.Fatalf("repo vs wildcard: got %q, %v; want repo.toml", got.source, ok)
+	}
+
+	// Repo+branch beats repo-only beats wildcard+branch beats wildcard-only.
+	all := []WorktreeLayout{wildcard, wildcardBranch, repoOnly, repoBranch}
+	if got, ok := matchWorktreeLayout(all, ev); !ok || got.source != "repo-branch.toml" {
+		t.Fatalf("full priority: got %q, %v; want repo-branch.toml", got.source, ok)
+	}
+
+	// Without repo+branch, repo-only wins.
+	noRepoBranch := []WorktreeLayout{wildcard, wildcardBranch, repoOnly}
+	if got, ok := matchWorktreeLayout(noRepoBranch, ev); !ok || got.source != "repo.toml" {
+		t.Fatalf("no repo+branch: got %q, %v; want repo.toml", got.source, ok)
+	}
+
+	// Without any repo-specific, wildcard+branch wins over wildcard-only.
+	wildcardsOnly := []WorktreeLayout{wildcard, wildcardBranch}
+	if got, ok := matchWorktreeLayout(wildcardsOnly, ev); !ok || got.source != "wildcard-branch.toml" {
+		t.Fatalf("wildcards only: got %q, %v; want wildcard-branch.toml", got.source, ok)
+	}
+
+	// Wildcard with wrong branch does not match.
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{wildcardWrongBranch}, ev); ok {
+		t.Fatalf("wildcard wrong branch: got %q, %v; want no match", got.source, ok)
+	}
+
+	// Wildcard-only still matches even when branch doesn't match any branch filter.
+	if got, ok := matchWorktreeLayout([]WorktreeLayout{wildcardWrongBranch, wildcard}, ev); !ok || got.source != "wildcard.toml" {
+		t.Fatalf("wildcard fallback: got %q, %v; want wildcard.toml", got.source, ok)
 	}
 }
 
@@ -201,6 +257,29 @@ name = "terminal"
 	}
 	if got[1].Repo != "options-cafe" || got[1].Branch != "main" || len(got[1].Tabs) != 2 {
 		t.Fatalf("loaded layout[1] = %+v, want options-cafe/main with 2 tabs", got[1])
+	}
+
+	// A wildcard layout file loads alongside repo-specific ones.
+	wildcardLayout := `repo = "*"
+
+[[tabs]]
+name = "default"
+command = "claude"
+`
+	if err := os.WriteFile(filepath.Join(dir, "default.toml"), []byte(wildcardLayout), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = loadWorktreeLayouts()
+	if err != nil {
+		t.Fatalf("loadWorktreeLayouts (with wildcard): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d layouts, want 3", len(got))
+	}
+	// Sorted by file name: bevio.toml, default.toml, options-cafe.toml.
+	if got[1].Repo != "*" || len(got[1].Tabs) != 1 || got[1].Tabs[0].Command != "claude" {
+		t.Fatalf("loaded wildcard layout = %+v, want repo=* with 1 tab", got[1])
 	}
 
 	// A malformed file fails the whole load with a naming error.


### PR DESCRIPTION
## Summary

- Adds `repo = "*"` support in worktree layout files to match any repo as a universal fallback — a "generic project template"
- Implements 4-tier specificity scoring so repo-specific layouts always win over wildcards (repo+branch > repo-only > wildcard+branch > wildcard-only)
- Documents the feature in the README with usage examples and specificity rules

Closes #29

## Test plan

- [x] New `TestMatchWorktreeLayoutWildcard` covers all priority combinations (7 sub-cases)
- [x] Wildcard validation case added to `TestWorktreeLayoutValidate`
- [x] Wildcard file round-trip in `TestLoadWorktreeLayouts`
- [x] All existing tests pass unchanged (no regressions)
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)