### PR TITLE
fix(fuzzylist): reset list cursor on query change

### DIFF
--- a/fuzzylist.go
+++ b/fuzzylist.go
@@ -40,10 +40,11 @@ type scoredItem struct {
 // separators, and rendering live here once (and stay reusable for future
 // pickers).
 type fuzzyList struct {
-	input    textinput.Model
-	items    []listItem
-	filtered []scoredItem
-	cursor   int
+	input     textinput.Model
+	items     []listItem
+	filtered  []scoredItem
+	cursor    int
+	lastQuery string
 }
 
 // newFuzzyList builds a list over items with a focused, empty query box.
@@ -65,6 +66,10 @@ func newFuzzyList(placeholder string, items []listItem) fuzzyList {
 // matches that land inside the name.
 func (l *fuzzyList) filter() {
 	q := strings.TrimSpace(l.input.Value())
+	if q != l.lastQuery {
+		l.cursor = 0
+		l.lastQuery = q
+	}
 	l.filtered = l.filtered[:0]
 
 	if q == "" {

--- a/fuzzylist_test.go
+++ b/fuzzylist_test.go
@@ -159,3 +159,49 @@ func TestFuzzyListClickRow(t *testing.T) {
 		t.Fatalf("a missed click moved the cursor: ref = %d, want 1", got)
 	}
 }
+
+// TestFuzzyListQueryChangeResetsCursor verifies that when the query changes,
+// the cursor resets to 0 (the top matched item), preventing the issue where
+// starting with a separator (which defaults the initial cursor to index 1)
+// causes the second matching item (index 1 of filtered) to be highlighted
+// instead of the first matched item (index 0 of filtered).
+func TestFuzzyListQueryChangeResetsCursor(t *testing.T) {
+	items := []listItem{
+		{name: "Group Heading", selectable: false},
+		{name: "alpha", selectable: true, ref: 1},
+		{name: "bravo", selectable: true, ref: 2},
+	}
+	l := newFuzzyList("", items)
+
+	// Since index 0 is a heading, the initial cursor must skip it and land on index 1 ("alpha").
+	if got := l.cursor; got != 1 {
+		t.Fatalf("initial cursor = %d, want 1", got)
+	}
+	if got := l.selectedIndex(); got != 1 {
+		t.Fatalf("initial selectedIndex = %d, want 1 (alpha)", got)
+	}
+
+	// Change query to "a" so "alpha" and "bravo" both match.
+	l.input.SetValue("a")
+	l.filter()
+
+	// Since the query changed, the cursor should have been reset to 0, which points to "alpha".
+	if got := l.cursor; got != 0 {
+		t.Fatalf("cursor after typing 'a' = %d, want 0", got)
+	}
+	if got := l.selectedIndex(); got != 1 {
+		t.Fatalf("selectedIndex after typing 'a' = %d, want 1 (alpha)", got)
+	}
+
+	// Clear query back to ""
+	l.input.SetValue("")
+	l.filter()
+
+	// Cursor should go back to 1 (skipping heading).
+	if got := l.cursor; got != 1 {
+		t.Fatalf("cursor after clearing query = %d, want 1", got)
+	}
+	if got := l.selectedIndex(); got != 1 {
+		t.Fatalf("selectedIndex after clearing query = %d, want 1 (alpha)", got)
+	}
+}


### PR DESCRIPTION
### Summary

This PR resolves an issue in the fuzzy list selection where typing a query would cause the second matching item in the list to be highlighted instead of the first one.

### The Problem

When opening the fuzzy finder project selection:
1. If the list has a group heading at the top (which is non-selectable, e.g. at index `0`), the list cursor initially clamps to the first selectable row (at index `1`).
2. When the user starts typing a query, all non-selectable group headings are excluded from the results list, leaving only selectable matching projects (meaning the top matched item is now at index `0` of the filtered list).
3. However, since the cursor index (`l.cursor`) remained at index `1`, the second matching item was selected instead of the top-ranked match.

### The Solution

* Added tracking for the last active search query (`lastQuery`) in `fuzzyList`.
* In `filter()`, if the query has changed, the cursor (`l.cursor`) is reset back to `0` so that the first matched item is highlighted.
* Added a comprehensive unit test `TestFuzzyListQueryChangeResetsCursor` in `fuzzylist_test.go` to verify this behavior and protect against future regressions.

---

Closes cloudmanic/herdr-plus#30