### PR TITLE
Projects: open highlighted project as a git worktree (ctrl+g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,22 @@ Inside it, `projects/` holds your [project templates](#projects) and
 and keeps it across uninstall/upgrade. (Running the binary *outside* herdr falls
 back to `~/.config/herdr-plus/`, honoring `$XDG_CONFIG_HOME`.)
 
+Optional global settings live in `config.toml` in that same directory:
+
+```toml
+[worktree]
+branch_prefix = "your-name/" # used verbatim; include your own trailing /
+```
+
 ## Projects
 
 Pick a project from a full-screen fuzzy browser and herdr-plus builds its whole
 workspace. Trigger it from herdr's plugin action menu, or
 [bind a key](#binding-a-key) — the action is `cloudmanic.herdr-plus.projects`.
+Inside the browser, **Enter** opens the highlighted project as a normal workspace;
+**ctrl+g** opens it as a git worktree. The worktree prompt accepts an optional
+branch name: empty lets herdr generate `worktree/...`, bare names get the optional
+`[worktree] branch_prefix`, and names containing `/` are used as-is.
 
 A project is one TOML file in the `projects/` subdir of
 [herdr-plus's config dir](#configuration). The file name doesn't matter; add a

--- a/config.go
+++ b/config.go
@@ -25,6 +25,12 @@ import (
 //go:embed examples
 var embeddedExamples embed.FS
 
+type PluginConfig struct {
+	Worktree struct {
+		BranchPrefix string `toml:"branch_prefix"`
+	} `toml:"worktree"`
+}
+
 // configBaseDir returns the root configuration directory for herdr-plus's
 // projects and quick-actions.
 //
@@ -48,6 +54,29 @@ func configBaseDir() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, ".config", "herdr-plus"), nil
+}
+
+func configFilePath() (string, error) {
+	base, err := configBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "config.toml"), nil
+}
+
+func loadPluginConfig() (PluginConfig, error) {
+	var cfg PluginConfig
+	path, err := configFilePath()
+	if err != nil {
+		return cfg, err
+	}
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	return cfg, nil
 }
 
 // quickActionsConfigDir returns the directory that holds quick-action files,

--- a/config_test.go
+++ b/config_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -42,5 +43,54 @@ func TestConfigBaseDirFallsBackToLegacy(t *testing.T) {
 	}
 	if want := filepath.Join(xdg, "herdr-plus"); got != want {
 		t.Fatalf("configBaseDir = %q, want %q", got, want)
+	}
+}
+
+// TestLoadPluginConfigMissingFile confirms the optional global config is truly
+// optional: no config.toml means zero values and no error.
+func TestLoadPluginConfigMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		t.Fatalf("loadPluginConfig missing file: %v", err)
+	}
+	if cfg.Worktree.BranchPrefix != "" {
+		t.Fatalf("BranchPrefix = %q, want empty", cfg.Worktree.BranchPrefix)
+	}
+}
+
+// TestLoadPluginConfigParsesBranchPrefix confirms config.toml can set the
+// optional worktree branch prefix.
+func TestLoadPluginConfigParsesBranchPrefix(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("[worktree]\nbranch_prefix = \"dvic/\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		t.Fatalf("loadPluginConfig: %v", err)
+	}
+	if cfg.Worktree.BranchPrefix != "dvic/" {
+		t.Fatalf("BranchPrefix = %q, want dvic/", cfg.Worktree.BranchPrefix)
+	}
+}
+
+// TestLoadPluginConfigRejectsMalformedFile confirms parse errors surface instead
+// of being treated as a missing optional config.
+func TestLoadPluginConfigRejectsMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("[worktree\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := loadPluginConfig(); err == nil {
+		t.Fatal("expected malformed config.toml to error")
 	}
 }

--- a/herdr.go
+++ b/herdr.go
@@ -87,6 +87,23 @@ func (c *herdrClient) call(method string, params map[string]any, out any) error 
 	return nil
 }
 
+// worktreeCreateParams builds the worktree.create payload. A blank branch is
+// omitted so herdr can generate its native worktree/<name> branch.
+func worktreeCreateParams(cwd, branch string, focus bool) map[string]any {
+	params := map[string]any{
+		"cwd":   cwd,
+		"focus": focus,
+	}
+	if b := strings.TrimSpace(branch); b != "" {
+		params["branch"] = b
+	}
+	return params
+}
+
+func (c *herdrClient) worktreeCreate(cwd, branch string, focus bool) error {
+	return c.call("worktree.create", worktreeCreateParams(cwd, branch, focus), nil)
+}
+
 // paneSplit splits the target pane in the given direction ("down" for a new pane
 // beneath it, "right" for one beside it), creating a new pane, and returns the
 // new pane's id. When focus is true the new pane becomes the focused pane (the

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -1,0 +1,42 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import "testing"
+
+// TestWorktreeCreateParams confirms the worktree.create contract: cwd/focus are
+// always sent, while a blank branch is omitted so herdr can generate its default.
+func TestWorktreeCreateParams(t *testing.T) {
+	cases := []struct {
+		name       string
+		branch     string
+		wantBranch string
+		wantKey    bool
+	}{
+		{"empty", "", "", false},
+		{"whitespace", "   \t", "", false},
+		{"trimmed", "  feature/x  ", "feature/x", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := worktreeCreateParams("/srv/repo", c.branch, true)
+			if got["cwd"] != "/srv/repo" {
+				t.Fatalf("cwd = %v, want /srv/repo", got["cwd"])
+			}
+			if got["focus"] != true {
+				t.Fatalf("focus = %v, want true", got["focus"])
+			}
+			branch, ok := got["branch"]
+			if ok != c.wantKey {
+				t.Fatalf("branch key present = %v, want %v (params=%v)", ok, c.wantKey, got)
+			}
+			if ok && branch != c.wantBranch {
+				t.Fatalf("branch = %v, want %q", branch, c.wantBranch)
+			}
+		})
+	}
+}

--- a/projects.go
+++ b/projects.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -51,12 +52,17 @@ func runProjectsUI() {
 		errExit(err)
 	}
 
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		errExit(err)
+	}
+
 	dir, _ := projectsConfigDir()
 
 	// WithMouseCellMotion enables click/release/wheel events so a project can be
 	// opened with the mouse. herdr forwards these to us once we ask for them;
 	// until then it keeps the mouse for its own pane focus/selection.
-	p := tea.NewProgram(newProjectsModel(projects, dir), tea.WithAltScreen(), tea.WithMouseCellMotion())
+	p := tea.NewProgram(newProjectsModel(projects, dir, cfg.Worktree.BranchPrefix), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	result, err := p.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "herdr-plus:", err)
@@ -72,6 +78,12 @@ func runProjectsUI() {
 	client, err := newHerdrClient()
 	if err != nil {
 		errExit(err)
+	}
+	if m.worktree {
+		if err := openProjectAsWorktree(client, *m.chosen, m.branch); err != nil {
+			errExit("could not open project as worktree:", err)
+		}
+		return
 	}
 	if err := openProject(client, *m.chosen); err != nil {
 		errExit("could not open project:", err)
@@ -96,6 +108,20 @@ func openProject(client *herdrClient, p Project) error {
 
 	// Lay the project's tabs into the new workspace.
 	return layoutTabs(client, ws, rootTab, rootPane, p.Tabs)
+}
+
+func openProjectAsWorktree(client *herdrClient, p Project, branch string) error {
+	dir, err := filepath.Abs(p.expandedWorkingDir())
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("working directory is not absolute: %s", dir)
+	}
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return fmt.Errorf("working directory does not exist: %s", dir)
+	}
+	return client.worktreeCreate(dir, branch, true)
 }
 
 // layoutTabs lays an ordered list of tabs — each with its panes and optional

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -28,6 +28,13 @@ const docsURL = "https://github.com/cloudmanic/herdr-plus"
 // mouse click's screen row minus this offset is the list-local line for clickRow.
 const projectsHeaderLines = 2
 
+type projectsMode int
+
+const (
+	modeList projectsMode = iota
+	modeBranch
+)
+
 // Projects-browser styles. These build on the shared palette in styles.go
 // (titleStyle, nameStyle, descStyle, footerStyle, …); here we add the few extra
 // pieces the full-screen browser needs.
@@ -73,8 +80,14 @@ type projectsModel struct {
 
 	// chosen is the project to open, read back after the program exits; nil when
 	// the user cancelled.
-	chosen   *Project
-	quitting bool
+	chosen *Project
+
+	mode         projectsMode
+	branchInput  textinput.Model
+	branchPrefix string
+	worktree     bool
+	branch       string
+	quitting     bool
 }
 
 // ungroupedHeading labels the catch-all bucket for projects that declare no
@@ -87,12 +100,17 @@ const ungroupedHeading = "Ungrouped"
 // Projects are arranged into group headings (see orderProjectsByGroup) and the
 // resulting display order is stored on the model so each list row's ref indexes
 // straight back into it.
-func newProjectsModel(projects []Project, projectsDir string) projectsModel {
+func newProjectsModel(projects []Project, projectsDir, branchPrefix string) projectsModel {
 	ordered, items := orderProjectsByGroup(projects)
+	branchInput := textinput.New()
+	branchInput.Prompt = ""
+	branchInput.Placeholder = "empty → generated name"
 	return projectsModel{
-		projects:    ordered,
-		list:        newFuzzyList("Type to filter projects…", items),
-		projectsDir: projectsDir,
+		projects:     ordered,
+		list:         newFuzzyList("Type to filter projects…", items),
+		projectsDir:  projectsDir,
+		branchInput:  branchInput,
+		branchPrefix: branchPrefix,
 	}
 }
 
@@ -186,6 +204,10 @@ func (m projectsModel) Init() tea.Cmd {
 // Update routes key presses; everything else (window sizes, the blink tick) is
 // forwarded to the query box so the cursor keeps blinking and text keeps flowing.
 func (m projectsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.mode == modeBranch {
+		return m.updateBranch(msg)
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -216,6 +238,8 @@ func (m projectsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "enter":
 			return m.activateProject()
+		case "ctrl+g":
+			return m.promptWorktreeBranch()
 		}
 
 		cmd := m.list.editQuery(msg)
@@ -246,6 +270,44 @@ func (m projectsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m projectsModel) updateBranch(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.chosen == nil {
+				m.mode = modeList
+				return m, nil
+			}
+			m.worktree = true
+			m.branch = resolveWorktreeBranch(m.branchInput.Value(), m.branchPrefix)
+			return m, tea.Quit
+		case "esc":
+			m.mode = modeList
+			m.chosen = nil
+			m.worktree = false
+			m.branch = ""
+			return m, nil
+		}
+
+		var cmd tea.Cmd
+		m.branchInput, cmd = m.branchInput.Update(msg)
+		return m, cmd
+
+	case tea.MouseMsg:
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	m.branchInput, cmd = m.branchInput.Update(msg)
+	return m, cmd
+}
+
 // activateProject records the highlighted project as the chosen one and signals
 // a quit so its workspace gets built. Shared by the enter key and a left-click;
 // activating with nothing selectable is a no-op.
@@ -257,6 +319,23 @@ func (m projectsModel) activateProject() (tea.Model, tea.Cmd) {
 	p := m.projects[idx]
 	m.chosen = &p
 	return m, tea.Quit
+}
+
+func (m projectsModel) promptWorktreeBranch() (tea.Model, tea.Cmd) {
+	idx := m.list.selectedIndex()
+	if idx < 0 {
+		return m, nil
+	}
+	p := m.projects[idx]
+	m.chosen = &p
+	m.worktree = false
+	m.branch = ""
+	m.branchInput.SetValue("")
+	m.branchInput.Prompt = ""
+	m.branchInput.Placeholder = "empty → generated name"
+	cmd := m.branchInput.Focus()
+	m.mode = modeBranch
+	return m, cmd
 }
 
 // View renders the screen for the current state: the onboarding card when there
@@ -278,6 +357,9 @@ func (m projectsModel) View() string {
 	if len(m.projects) == 0 {
 		return m.emptyView(w, h)
 	}
+	if m.mode == modeBranch {
+		return m.branchView(w, h)
+	}
 	return m.browserView(w, h)
 }
 
@@ -290,7 +372,7 @@ func (m projectsModel) browserView(w, h int) string {
 	body := m.list.view("no matching projects")
 
 	detail := m.detailBar(w)
-	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · esc quit")
+	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · ctrl+g worktree · esc quit")
 
 	top := header + "\n\n" + body
 	bottom := detail + "\n" + footer
@@ -301,6 +383,28 @@ func (m projectsModel) browserView(w, h int) string {
 		gap = 1
 	}
 	return top + strings.Repeat("\n", gap) + bottom
+}
+
+func (m projectsModel) branchView(w, h int) string {
+	header := headerBarStyle.Width(w).Render(projectsTitle)
+
+	name, dir := "", ""
+	if m.chosen != nil {
+		name = m.chosen.Name
+		dir = m.chosen.expandedWorkingDir()
+	}
+
+	body := nameStyle.Render(name) + "\n" +
+		dirIconStyle.Render("📁 ") + pathStyle.Render(truncate(dir, w-6)) + "\n\n" +
+		promptStyle.Render("❯ ") + m.branchInput.View()
+	footer := footerStyle.Render("  enter create · esc back")
+
+	top := header + "\n\n" + body
+	gap := h - lipgloss.Height(top) - lipgloss.Height(footer)
+	if gap < 1 {
+		gap = 1
+	}
+	return top + strings.Repeat("\n", gap) + footer
 }
 
 // detailBar renders the bordered preview of the currently highlighted project:

--- a/projectsmodel_test.go
+++ b/projectsmodel_test.go
@@ -35,7 +35,7 @@ func step(t *testing.T, m projectsModel, msg tea.Msg) projectsModel {
 // TestNewProjectsModelItems confirms each project becomes a selectable list row
 // carrying its name, description, and original index.
 func TestNewProjectsModelItems(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	if len(m.list.items) != 2 {
 		t.Fatalf("got %d list items, want 2", len(m.list.items))
 	}
@@ -119,7 +119,7 @@ func TestOrderProjectsByGroupHeadings(t *testing.T) {
 // the cursor starts on the first project under the first heading (skipping the
 // heading row), and entering opens the project its ref points at.
 func TestProjectsModelGroupedSelect(t *testing.T) {
-	m := newProjectsModel(groupedProjects(), "/cfg/projects")
+	m := newProjectsModel(groupedProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 
 	// Cursor parks on the first selectable row, not the "Acme" heading.
@@ -141,7 +141,7 @@ func TestProjectsModelGroupedSelect(t *testing.T) {
 // query collapses the grouped view to a single ranked list with no headings, and
 // enter opens the lone match.
 func TestProjectsModelGroupedFilterDropsHeadings(t *testing.T) {
-	m := newProjectsModel(groupedProjects(), "/cfg/projects")
+	m := newProjectsModel(groupedProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("loose")})
 
@@ -159,7 +159,7 @@ func TestProjectsModelGroupedFilterDropsHeadings(t *testing.T) {
 // TestProjectsModelEnterSelects confirms pressing enter records the highlighted
 // project and signals a quit.
 func TestProjectsModelEnterSelects(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyDown}) // move to Bravo
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -174,7 +174,7 @@ func TestProjectsModelEnterSelects(t *testing.T) {
 
 // TestProjectsModelEscCancels confirms esc records no selection.
 func TestProjectsModelEscCancels(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 
 	if m.chosen != nil {
@@ -188,7 +188,7 @@ func TestProjectsModelEscCancels(t *testing.T) {
 // TestProjectsModelFilterThenSelect confirms typing narrows the list and enter
 // then opens the single remaining match.
 func TestProjectsModelFilterThenSelect(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("brav")})
 	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -202,7 +202,7 @@ func TestProjectsModelFilterThenSelect(t *testing.T) {
 // row opens it — the click counterpart to enter. With the title bar and query
 // line above, the two projects sit at screen rows 4 (Alpha) and 5 (Bravo).
 func TestProjectsModelMouseClickOpens(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = step(t, m, tea.MouseMsg{
 		Action: tea.MouseActionRelease,
@@ -218,7 +218,7 @@ func TestProjectsModelMouseClickOpens(t *testing.T) {
 // TestProjectsModelMouseWheelMoves confirms the scroll wheel walks the highlight
 // without opening anything.
 func TestProjectsModelMouseWheelMoves(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	m = step(t, m, tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
 
@@ -230,11 +230,119 @@ func TestProjectsModelMouseWheelMoves(t *testing.T) {
 	}
 }
 
+// TestProjectsModelCtrlGEntersBranchMode confirms ctrl+g on a selectable row
+// switches to the worktree branch prompt with an empty, focused input.
+func TestProjectsModelCtrlGEntersBranchMode(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "dvic/")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+
+	if m.mode != modeBranch {
+		t.Fatalf("mode = %v, want modeBranch", m.mode)
+	}
+	if m.chosen == nil || m.chosen.Name != "Alpha" {
+		t.Fatalf("chosen = %v, want Alpha", m.chosen)
+	}
+	if m.branchInput.Value() != "" {
+		t.Fatalf("branch input = %q, want empty", m.branchInput.Value())
+	}
+	if !m.branchInput.Focused() {
+		t.Fatal("branch input should be focused")
+	}
+}
+
+// TestProjectsModelBranchEnterTyped confirms entering a bare branch name opens a
+// worktree and resolves it through the configured prefix.
+func TestProjectsModelBranchEnterTyped(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "dvic/")
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature")})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.worktree {
+		t.Fatal("enter in branch mode should mark worktree")
+	}
+	if m.chosen == nil || m.chosen.Name != "Alpha" {
+		t.Fatalf("chosen = %v, want Alpha", m.chosen)
+	}
+	if m.branch != "dvic/feature" {
+		t.Fatalf("branch = %q, want dvic/feature", m.branch)
+	}
+}
+
+// TestProjectsModelBranchEnterEmpty confirms an empty branch stays empty so
+// herdr can generate its native worktree branch name.
+func TestProjectsModelBranchEnterEmpty(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "dvic/")
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.worktree {
+		t.Fatal("enter in branch mode should mark worktree")
+	}
+	if m.branch != "" {
+		t.Fatalf("branch = %q, want empty", m.branch)
+	}
+}
+
+// TestProjectsModelBranchEscReturnsToList confirms escape backs out of the
+// branch prompt without choosing a worktree.
+func TestProjectsModelBranchEscReturnsToList(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "dvic/")
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want modeList", m.mode)
+	}
+	if m.worktree {
+		t.Fatal("esc should not mark worktree")
+	}
+}
+
+// TestProjectsModelCtrlGOnHeadingNoops confirms ctrl+g only opens branch mode
+// when the highlighted row maps to a project.
+func TestProjectsModelCtrlGOnHeadingNoops(t *testing.T) {
+	m := newProjectsModel(groupedProjects(), "/cfg/projects", "dvic/")
+	m.list.cursor = 0 // "Acme" heading, not selectable.
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+
+	if m.mode != modeList {
+		t.Fatalf("mode = %v, want modeList", m.mode)
+	}
+	if m.chosen != nil {
+		t.Fatalf("chosen = %v, want nil", m.chosen)
+	}
+}
+
+// TestProjectsModelBranchModeIgnoresMouse confirms a click while the branch
+// prompt is open cannot activate the list row underneath.
+func TestProjectsModelBranchModeIgnoresMouse(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlG})
+	m = step(t, m, tea.MouseMsg{
+		Action: tea.MouseActionRelease,
+		Button: tea.MouseButtonLeft,
+		Y:      5,
+	})
+
+	if m.mode != modeBranch {
+		t.Fatalf("mode = %v, want modeBranch", m.mode)
+	}
+	if m.worktree {
+		t.Fatal("mouse in branch mode should not activate a row")
+	}
+	if m.chosen == nil || m.chosen.Name != "Alpha" {
+		t.Fatalf("chosen = %v, want the original Alpha target", m.chosen)
+	}
+}
+
 // TestProjectsModelBrowserView confirms the populated view shows the header, the
 // project names, and the highlighted project's working directory in the detail
 // bar.
 func TestProjectsModelBrowserView(t *testing.T) {
-	m := newProjectsModel(sampleProjects(), "/cfg/projects")
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	view := m.View()
 
@@ -248,7 +356,7 @@ func TestProjectsModelBrowserView(t *testing.T) {
 // TestProjectsModelEmptyState confirms that with no projects the onboarding card
 // renders (with the config path and docs link) and any exit key closes it.
 func TestProjectsModelEmptyState(t *testing.T) {
-	m := newProjectsModel(nil, "/cfg/projects")
+	m := newProjectsModel(nil, "/cfg/projects", "")
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	view := m.View()
 

--- a/worktreebranch.go
+++ b/worktreebranch.go
@@ -1,0 +1,20 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import "strings"
+
+func resolveWorktreeBranch(input, prefix string) string {
+	branch := strings.TrimSpace(input)
+	if branch == "" {
+		return ""
+	}
+	if prefix == "" || strings.Contains(branch, "/") {
+		return branch
+	}
+	return prefix + branch
+}

--- a/worktreebranch_test.go
+++ b/worktreebranch_test.go
@@ -1,0 +1,31 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import "testing"
+
+// TestResolveWorktreeBranch confirms bare names get the optional prefix, names
+// containing "/" are left alone, and the prefix is used verbatim.
+func TestResolveWorktreeBranch(t *testing.T) {
+	cases := []struct {
+		input  string
+		prefix string
+		want   string
+	}{
+		{"", "dvic/", ""},
+		{"foo", "dvic/", "dvic/foo"},
+		{"x/foo", "dvic/", "x/foo"},
+		{"foo", "", "foo"},
+		{"foo", "dvic", "dvicfoo"},
+	}
+	for _, c := range cases {
+		got := resolveWorktreeBranch(c.input, c.prefix)
+		if got != c.want {
+			t.Fatalf("resolveWorktreeBranch(%q, %q) = %q, want %q", c.input, c.prefix, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
In the Projects browser, ctrl+g on the highlighted project creates a git worktree from its working_dir.

It prompts for an optional branch: empty lets herdr generate its native worktree/... name, typed bare names get the optional [worktree] branch_prefix, and names containing / are used as-is. base=HEAD. Tabs are supplied by the existing worktree.created layout handler, with no layoutTabs call from the picker path.

This adds optional config.toml [worktree] branch_prefix with an empty default, keeps Enter opening a normal workspace, and does not change the manifest or registered keybindings.

Includes tests and README updates.