### PR TITLE
projects: warn via stderr instead of log.Printf on pane-label failure

### DIFF
--- a/projects.go
+++ b/projects.go
@@ -9,7 +9,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -194,7 +193,8 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []Projec
 			}
 			if lbl := strings.TrimSpace(pane.Label); lbl != "" {
 				if err := client.paneRename(paneID, lbl); err != nil {
-					log.Printf("warning: failed to label pane %d in tab %q: %v", j+1, t.Name, err)
+					// Labeling is cosmetic — warn but keep building the workspace.
+					fmt.Fprintf(os.Stderr, "herdr-plus: failed to label pane %d in tab %q: %v\n", j+1, t.Name, err)
 				}
 			}
 			if strings.TrimSpace(pane.Command) != "" {


### PR DESCRIPTION
Small follow-up to #33 (thanks again @javimb!).

The pane-label failure warning added in #33 used `log.Printf`:

```go
log.Printf("warning: failed to label pane %d in tab %q: %v", j+1, t.Name, err)
```

That stamps a `log`-package timestamp prefix and pulls in the `log` package solely for this one line — inconsistent with the rest of the plugin, which emits messages via `fmt` to stdout/stderr with a `herdr-plus:` prefix (what herdr captures in the plugin log). This switches it to match:

```go
// Labeling is cosmetic — warn but keep building the workspace.
fmt.Fprintf(os.Stderr, "herdr-plus: failed to label pane %d in tab %q: %v\n", j+1, t.Name, err)
```

and drops the now-unused `log` import.

**Behavior is unchanged** — labeling stays best-effort and a failure never aborts building the workspace. `go build`, `go test`, and `go vet` all pass.