### PR TITLE
fix(styles): use ANSI palette colors so text is readable on light terminals

### DIFF
--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -45,25 +45,25 @@ var (
 	// detailBoxStyle frames the bottom bar that previews the highlighted project.
 	detailBoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#A78BFA")).
+			BorderForeground(lipgloss.Color("5")).
 			Padding(0, 1)
 
 	// dirIconStyle / pathStyle render the "📁 <working dir>" line of the detail bar.
-	dirIconStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA"))
-	pathStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
-	tabNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#C4B5FD"))
-	dotStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
+	dirIconStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	pathStyle    = lipgloss.NewStyle()
+	tabNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("13"))
+	dotStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 
 	// Empty-state styles: a centered onboarding card.
 	cardStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#A78BFA")).
+			BorderForeground(lipgloss.Color("5")).
 			Padding(1, 3)
-	cardTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Bold(true)
-	bodyStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
-	pathHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#F2A900")).Bold(true)
-	codeStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#9CA3AF"))
-	linkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#67E8F9")).Underline(true)
+	cardTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
+	bodyStyle      = lipgloss.NewStyle()
+	pathHintStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true)
+	codeStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	linkStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Underline(true)
 )
 
 // projectsModel is the full-screen projects browser. It is a thin shell around

--- a/styles.go
+++ b/styles.go
@@ -8,8 +8,12 @@ package main
 
 import "github.com/charmbracelet/lipgloss"
 
-// Palette. A small, cohesive set of colors for a clean dark-terminal look,
-// shared by the fuzzyList component and the projects browser in this package.
+// Palette. A small, cohesive set of colors shared by the fuzzyList component
+// and the projects browser in this package. Foregrounds that render directly
+// against the terminal background use ANSI palette colors (or the terminal's
+// default foreground) instead of fixed hex values, so text stays readable on
+// both light and dark terminal themes. titleStyle keeps its hex pair because
+// it sets both foreground and background, making it self-contained.
 var (
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
@@ -17,14 +21,14 @@ var (
 			Background(lipgloss.Color("#A78BFA")).
 			Padding(0, 1)
 
-	promptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Bold(true)
-	countStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
+	promptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
+	countStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 
-	nameStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#E5E7EB"))
-	nameSelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF")).Bold(true)
-	descStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280"))
-	matchStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F2A900")).Bold(true)
-	barStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Bold(true)
-	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
-	headingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#8B5CF6")).Bold(true)
+	nameStyle    = lipgloss.NewStyle()
+	nameSelStyle = lipgloss.NewStyle().Bold(true)
+	descStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	matchStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true)
+	barStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
+	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	headingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
 )


### PR DESCRIPTION
Fixes #40

### Summary

Quick Actions and Projects text is nearly invisible on light terminal themes. This switches foregrounds that render against the terminal background from dark-theme hex values to ANSI palette colors (or the terminal's default foreground), so both UIs stay readable on light and dark themes.

### The Problem

The shared palette in `styles.go` (and the Projects styles in `projectsmodel.go`) hardcodes foregrounds chosen for dark terminals — `#E5E7EB` for list items, `#FFFFFF` for the selected row, grays for muted text. On a light background these have almost no contrast (see #40).

### The Solution

- List items and body text use the terminal's default foreground; the selected row is distinguished by bold + the selection bar.
- Violet accents → ANSI `5`/`13` (magenta), muted text → `8`, fuzzy-match highlights → `3`, links → `6` — these track whatever palette the user's terminal defines.
- `titleStyle` (the purple title chip) keeps its hex pair since it sets both foreground and background and is self-contained.

One tradeoff: exact accent shades now follow the user's 16-color palette rather than the fixed violet, so the dark-theme look can shift slightly depending on the palette.

### Before / After

(light terminal theme, Quick Actions inside herdr)

| Before | After |
| --- | --- |
| <img width="408" height="186" alt="before" src="https://github.com/user-attachments/assets/cf8bb4ae-a3d9-49d6-9878-9269fb6a876e" /> | <img width="390" height="225" alt="after" src="https://github.com/user-attachments/assets/e14b1a87-5814-42b7-b942-cbe0a737f850" /> |


### Testing

`go build`, `go vet`, `go test -race ./...` pass on macOS. Verified visually in a light-themed terminal inside herdr.