### PR TITLE
fix(projects): scroll the picker list to fit the terminal height

### DIFF
--- a/fuzzylist.go
+++ b/fuzzylist.go
@@ -164,41 +164,50 @@ func (l *fuzzyList) selectedIndex() int {
 	return it.ref
 }
 
-// listPromptLines is how many lines view() renders before the first result row:
-// the query/prompt line and the blank spacer beneath it. rowIndexAt and view()
-// share it, so the two must always agree about the list's layout.
+// listPromptLines is how many lines the list renders before the first result
+// row: the query/prompt line and the blank spacer beneath it. The renderer and
+// the hit-testing both read buildLines, so their line accounting can never drift.
 const listPromptLines = 2
 
 // rowIndexAt maps a view-local screen line (line 0 is the query/prompt line) to
 // the index into filtered of the selectable row drawn there, or -1 when the line
-// is the prompt, a blank spacer, a separator/heading, or past the end of the
-// list. It mirrors view()'s exact line accounting — the prompt line, the blank
-// spacer, then one line per selectable row and a blank (plus an optional heading
-// line) per separator — so this and view() must change together.
+// is the prompt, a blank spacer, a separator/heading, a scroll hint, or past the
+// end. This is the unbounded (whole-list) form, for callers that don't clamp
+// height.
 func (l *fuzzyList) rowIndexAt(y int) int {
-	line := listPromptLines
-	for i, s := range l.filtered {
-		if !s.item.selectable {
-			line++ // the separator's leading blank line
-			if s.item.name != "" {
-				line++ // its heading line
-			}
-			continue
-		}
-		if line == y {
-			return i
-		}
-		line++
+	return l.rowIndexAtLimited(y, 0)
+}
+
+// rowIndexAtLimited is rowIndexAt for a height-limited list: maxLines caps the
+// total lines the list may render (0 means unbounded). It shares buildLines with
+// the renderer, so a click always maps to exactly the row shown at that line —
+// scroll window and hint lines included. The caller must pass the same maxLines
+// it rendered with.
+func (l *fuzzyList) rowIndexAtLimited(y, maxLines int) int {
+	if y < 0 {
+		return -1
 	}
-	return -1
+	lines := l.buildLines("", maxLines)
+	if y >= len(lines) {
+		return -1
+	}
+	return lines[y].idx
 }
 
 // clickRow moves the highlight to the selectable row at view-local line y,
 // reporting whether y landed on one. It is the mouse counterpart to moveUp /
 // moveDown: the caller subtracts its own header height from the click's screen
-// row before calling, so y is measured from the top of view()'s own output.
+// row before calling, so y is measured from the top of the list's own output.
+// This unbounded form assumes the whole list is rendered.
 func (l *fuzzyList) clickRow(y int) bool {
-	idx := l.rowIndexAt(y)
+	return l.clickRowLimited(y, 0)
+}
+
+// clickRowLimited is clickRow for a height-limited list, where maxLines caps the
+// rendered lines (0 means unbounded). The caller must pass the same maxLines it
+// rendered with so the click lands on the row actually shown at line y.
+func (l *fuzzyList) clickRowLimited(y, maxLines int) bool {
+	idx := l.rowIndexAtLimited(y, maxLines)
 	if idx < 0 {
 		return false
 	}
@@ -215,13 +224,38 @@ func (l *fuzzyList) editQuery(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// view renders the query line, the match count (selectable rows only), and the
-// result rows. Separators render as a blank line plus an optional dim heading;
-// emptyMsg is shown when no selectable row matches the query.
+// view renders the whole list — query line, match count, and every result row —
+// with no height limit. Kept for callers and tests that don't clamp height.
 func (l fuzzyList) view(emptyMsg string) string {
-	var b strings.Builder
+	return l.viewLimited(emptyMsg, 0)
+}
 
-	matched, total := 0, 0
+// viewLimited renders the list clamped to maxLines total screen lines (0 means
+// unbounded). When the results don't fit it shows a scrolling window around the
+// cursor, bracketed by "↑ N more" / "↓ N more" hints, so the list never spills
+// past its budget and clips the layout around it. The cursor row is always shown.
+func (l fuzzyList) viewLimited(emptyMsg string, maxLines int) string {
+	lines := l.buildLines(emptyMsg, maxLines)
+	parts := make([]string, len(lines))
+	for i, ln := range lines {
+		parts[i] = ln.text
+	}
+	return strings.Join(parts, "\n") + "\n"
+}
+
+// listLine is one rendered screen line of the list. idx is the index into
+// filtered of the selectable row shown on that line, or -1 for the prompt, a
+// blank, a heading, a scroll hint, or the empty-state message. The renderer and
+// the click hit-testing both read buildLines, so they share one source of truth
+// for what sits on every line.
+type listLine struct {
+	text string
+	idx  int
+}
+
+// counts returns how many selectable rows match the current query and how many
+// exist in total (separators excluded from both).
+func (l fuzzyList) counts() (matched, total int) {
 	for _, it := range l.items {
 		if it.selectable {
 			total++
@@ -232,29 +266,134 @@ func (l fuzzyList) view(emptyMsg string) string {
 			matched++
 		}
 	}
+	return matched, total
+}
 
-	b.WriteString(promptStyle.Render("❯ "))
-	b.WriteString(l.input.View())
-	b.WriteString("   ")
-	b.WriteString(countStyle.Render(fmt.Sprintf("%d/%d", matched, total)))
-	b.WriteString("\n\n")
+// entryLines is how many screen lines filtered[i] occupies: one for a selectable
+// row, two for a heading separator (its leading blank plus the heading line), one
+// for a blank spacer separator.
+func (l fuzzyList) entryLines(i int) int {
+	it := l.filtered[i].item
+	if it.selectable {
+		return 1
+	}
+	if it.name != "" {
+		return 2
+	}
+	return 1
+}
+
+// window picks the contiguous slice [start,end) of filtered to render so the
+// cursor stays visible and the slice — plus up to two scroll-hint lines — fits in
+// maxLines. It also returns the hidden selectable-row counts above and below, for
+// the hints. maxLines <= 0 (or a list that already fits) renders everything with
+// no hints. Below the space for even one hint the hints are dropped rather than
+// allowed to overflow the budget.
+func (l fuzzyList) window(maxLines int) (start, end, topMore, botMore int) {
+	n := len(l.filtered)
+	if n == 0 {
+		return 0, 0, 0, 0
+	}
+	if maxLines <= 0 {
+		return 0, n, 0, 0
+	}
+
+	avail := maxLines - listPromptLines
+	if avail < 1 {
+		avail = 1
+	}
+
+	total := 0
+	for i := 0; i < n; i++ {
+		total += l.entryLines(i)
+	}
+	if total <= avail {
+		return 0, n, 0, 0
+	}
+
+	reserve := 0
+	if avail > 2 {
+		reserve = 2
+	}
+	budget := avail - reserve
+	if budget < 1 {
+		budget = 1
+	}
+
+	// Grow a window outward from the cursor, filling below then above, so the
+	// highlighted row is always drawn and roughly centered.
+	start, end = l.cursor, l.cursor+1
+	used := l.entryLines(l.cursor)
+	i, j := l.cursor+1, l.cursor-1
+	for {
+		grew := false
+		if i < n && used+l.entryLines(i) <= budget {
+			used += l.entryLines(i)
+			end = i + 1
+			i++
+			grew = true
+		}
+		if j >= 0 && used+l.entryLines(j) <= budget {
+			used += l.entryLines(j)
+			start = j
+			j--
+			grew = true
+		}
+		if !grew {
+			break
+		}
+	}
+
+	if reserve > 0 {
+		for k := 0; k < start; k++ {
+			if l.filtered[k].item.selectable {
+				topMore++
+			}
+		}
+		for k := end; k < n; k++ {
+			if l.filtered[k].item.selectable {
+				botMore++
+			}
+		}
+	}
+	return start, end, topMore, botMore
+}
+
+// buildLines renders the list into ordered screen lines: the query/count prompt,
+// a blank, then the visible window of result rows (a scrolling slice with
+// "↑/↓ N more" hints when the results outgrow maxLines). emptyMsg is shown when
+// nothing matches. It is the single layout both the renderer and the click
+// hit-testing read, so the two can never disagree about what sits on a line.
+func (l fuzzyList) buildLines(emptyMsg string, maxLines int) []listLine {
+	matched, total := l.counts()
+
+	prompt := promptStyle.Render("❯ ") + l.input.View() + "   " +
+		countStyle.Render(fmt.Sprintf("%d/%d", matched, total))
+	out := []listLine{{text: prompt, idx: -1}, {text: "", idx: -1}}
 
 	if matched == 0 {
-		b.WriteString(descStyle.Render("  " + emptyMsg))
-		b.WriteString("\n")
+		out = append(out, listLine{text: descStyle.Render("  " + emptyMsg), idx: -1})
+		return out
 	}
-	for i, s := range l.filtered {
+
+	start, end, topMore, botMore := l.window(maxLines)
+
+	if topMore > 0 {
+		out = append(out, listLine{text: scrollHintStyle.Render(fmt.Sprintf("  ↑ %d more", topMore)), idx: -1})
+	}
+	for i := start; i < end; i++ {
+		s := l.filtered[i]
 		it := s.item
 		if !it.selectable {
 			// A blank line separates groups; a heading (if any) labels the group.
-			b.WriteString("\n")
+			out = append(out, listLine{text: "", idx: -1})
 			if it.name != "" {
-				b.WriteString(headingStyle.Render(it.name))
-				b.WriteString("\n")
+				out = append(out, listLine{text: headingStyle.Render(it.name), idx: -1})
 			}
 			continue
 		}
 		selected := i == l.cursor
+		var b strings.Builder
 		if selected {
 			b.WriteString(barStyle.Render("▌ "))
 		} else {
@@ -265,9 +404,12 @@ func (l fuzzyList) view(emptyMsg string) string {
 			b.WriteString("  ")
 			b.WriteString(descStyle.Render(it.desc))
 		}
-		b.WriteString("\n")
+		out = append(out, listLine{text: b.String(), idx: i})
 	}
-	return b.String()
+	if botMore > 0 {
+		out = append(out, listLine{text: scrollHintStyle.Render(fmt.Sprintf("  ↓ %d more", botMore)), idx: -1})
+	}
+	return out
 }
 
 // highlightName renders a row's name with the fuzzy-matched characters

--- a/fuzzylist_test.go
+++ b/fuzzylist_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -133,6 +134,89 @@ func TestFuzzyListRowIndexAtMatchesView(t *testing.T) {
 	if got := l.rowIndexAt(len(lines) + 5); got != -1 {
 		t.Fatalf("rowIndexAt past the end = %d, want -1", got)
 	}
+}
+
+// manyItems returns n selectable rows, useful for exercising the scroll window.
+func manyItems(n int) []listItem {
+	items := make([]listItem, n)
+	for i := 0; i < n; i++ {
+		items[i] = listItem{name: fmt.Sprintf("row-%02d", i), selectable: true, ref: i}
+	}
+	return items
+}
+
+// TestFuzzyListWindowFitsBudget confirms a list taller than its budget is clamped
+// to at most maxLines rendered lines, keeps the cursor row visible, and brackets
+// the clipped list with scroll hints.
+func TestFuzzyListWindowFitsBudget(t *testing.T) {
+	l := newFuzzyList("", manyItems(40))
+
+	const maxLines = 12
+	// Move the cursor into the middle so both hints should appear.
+	for i := 0; i < 20; i++ {
+		l.moveDown()
+	}
+
+	lines := l.buildLines("none", maxLines)
+	if len(lines) > maxLines {
+		t.Fatalf("rendered %d lines, want <= %d", len(lines), maxLines)
+	}
+
+	// The highlighted row must be somewhere in the rendered window.
+	found := false
+	for _, ln := range lines {
+		if ln.idx == l.cursor {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cursor row (filtered idx %d) not in the rendered window", l.cursor)
+	}
+
+	joined := l.viewLimited("none", maxLines)
+	if !strings.Contains(joined, "↑") || !strings.Contains(joined, "↓") {
+		t.Fatalf("expected both scroll hints on a mid-list window:\n%s", joined)
+	}
+}
+
+// TestFuzzyListWindowUnboundedRendersAll confirms maxLines == 0 keeps the old
+// whole-list behaviour: every row present, no scroll hints.
+func TestFuzzyListWindowUnboundedRendersAll(t *testing.T) {
+	l := newFuzzyList("", manyItems(40))
+	got := l.view("none")
+	if strings.Contains(got, "↑") || strings.Contains(got, "↓") {
+		t.Fatalf("unbounded view should have no scroll hints:\n%s", got)
+	}
+	if !strings.Contains(got, "row-39") {
+		t.Fatal("unbounded view should render the last row")
+	}
+}
+
+// TestFuzzyListClickRowLimitedMapsWindow confirms a click on a scrolled list maps
+// to the row actually shown at that screen line, not the unscrolled position.
+func TestFuzzyListClickRowLimitedMapsWindow(t *testing.T) {
+	l := newFuzzyList("", manyItems(40))
+	const maxLines = 12
+	for i := 0; i < 20; i++ {
+		l.moveDown()
+	}
+
+	lines := l.buildLines("none", maxLines)
+	// Find a rendered screen line that carries a selectable row and click it.
+	for y, ln := range lines {
+		if ln.idx < 0 {
+			continue
+		}
+		want := ln.idx
+		if !l.clickRowLimited(y, maxLines) {
+			t.Fatalf("clickRowLimited(%d) reported no hit on a row line", y)
+		}
+		if l.cursor != want {
+			t.Fatalf("clickRowLimited(%d) set cursor %d, want %d", y, l.cursor, want)
+		}
+		return
+	}
+	t.Fatal("no selectable row line found in the windowed render")
 }
 
 // TestFuzzyListClickRow confirms clicking a row's line moves the highlight there

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -28,6 +28,9 @@ const docsURL = "https://github.com/cloudmanic/herdr-plus"
 // mouse click's screen row minus this offset is the list-local line for clickRow.
 const projectsHeaderLines = 2
 
+// browserFooter is the hint line pinned to the bottom of the projects browser.
+const browserFooter = "  ↑/↓ move · type to filter · click/enter open · esc quit"
+
 // Projects-browser styles. These build on the shared palette in styles.go
 // (titleStyle, nameStyle, descStyle, footerStyle, …); here we add the few extra
 // pieces the full-screen browser needs.
@@ -233,8 +236,10 @@ func (m projectsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.list.moveDown()
 		case tea.MouseButtonLeft:
 			// Move the highlight to the clicked row, opening it on release — the
-			// natural completion of a click.
-			if m.list.clickRow(msg.Y-projectsHeaderLines) && msg.Action == tea.MouseActionRelease {
+			// natural completion of a click. The list is scrolled to the same budget
+			// browserView renders with, so the click maps to the row actually shown.
+			w, h := m.dims()
+			if m.list.clickRowLimited(msg.Y-projectsHeaderLines, m.listBudget(w, h)) && msg.Action == tea.MouseActionRelease {
 				return m.activateProject()
 			}
 		}
@@ -259,14 +264,9 @@ func (m projectsModel) activateProject() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-// View renders the screen for the current state: the onboarding card when there
-// are no projects, otherwise the header / list / detail-bar / footer layout.
-func (m projectsModel) View() string {
-	if m.quitting {
-		return ""
-	}
-
-	// Fall back to a sane size until the first WindowSizeMsg arrives.
+// dims returns the current terminal size, falling back to a sane default until
+// the first WindowSizeMsg arrives.
+func (m projectsModel) dims() (int, int) {
 	w, h := m.width, m.height
 	if w <= 0 {
 		w = 80
@@ -274,23 +274,49 @@ func (m projectsModel) View() string {
 	if h <= 0 {
 		h = 24
 	}
+	return w, h
+}
 
+// View renders the screen for the current state: the onboarding card when there
+// are no projects, otherwise the header / list / detail-bar / footer layout.
+func (m projectsModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	w, h := m.dims()
 	if len(m.projects) == 0 {
 		return m.emptyView(w, h)
 	}
 	return m.browserView(w, h)
 }
 
+// listBudget is the number of screen lines the fuzzy list may occupy: the full
+// height minus the title bar, the blank line under it, the pinned detail bar +
+// footer, and one line of minimum gap. Keeping it a shared method means the
+// renderer and the mouse hit-testing scroll the list to exactly the same window.
+func (m projectsModel) listBudget(w, h int) int {
+	header := headerBarStyle.Width(w).Render(projectsTitle)
+	bottom := m.detailBar(w) + "\n" + footerStyle.Render(browserFooter)
+
+	budget := h - lipgloss.Height(header) - 1 - lipgloss.Height(bottom) - 1
+	if budget < listPromptLines+1 {
+		budget = listPromptLines + 1
+	}
+	return budget
+}
+
 // browserView lays out the populated projects browser: a full-width title bar up
-// top, the fuzzy list below it, and the highlighted project's detail bar pinned
-// just above the footer at the bottom of the screen.
+// top, the fuzzy list (scrolled to fit the space between) below it, and the
+// highlighted project's detail bar pinned just above the footer at the bottom of
+// the screen.
 func (m projectsModel) browserView(w, h int) string {
 	header := headerBarStyle.Width(w).Render(projectsTitle)
 
-	body := m.list.view("no matching projects")
+	body := m.list.viewLimited("no matching projects", m.listBudget(w, h))
 
 	detail := m.detailBar(w)
-	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · esc quit")
+	footer := footerStyle.Render(browserFooter)
 
 	top := header + "\n\n" + body
 	bottom := detail + "\n" + footer

--- a/styles.go
+++ b/styles.go
@@ -27,4 +27,7 @@ var (
 	barStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#A78BFA")).Bold(true)
 	footerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
 	headingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#8B5CF6")).Bold(true)
+
+	// scrollHintStyle dims the "↑/↓ N more" markers that bracket a scrolled list.
+	scrollHintStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Italic(true)
 )


### PR DESCRIPTION
## Problem

The Projects browser renders **every** row unconditionally. On short terminals (or when a lot of project templates are defined) the list is taller than the screen, so it overflows and clips the title bar / detail bar — the only workaround today is to zoom the terminal out.

## Fix

Add a height-aware viewport to the shared `fuzzyList`:

- `viewLimited(emptyMsg, maxLines)` renders a scrolling window around the cursor, bounded by the space `projectsModel` budgets for the list (`listBudget`), bracketed by dim `↑ N more` / `↓ N more` hints. It never spills past its budget, and the cursor row is always visible.
- A single `buildLines` layout now feeds both the renderer and the mouse hit-testing (`rowIndexAtLimited` / `clickRowLimited`), so a click always maps to the row actually shown at that screen line — window and hint lines included.
- The unbounded `view` / `rowIndexAt` / `clickRow` remain as thin wrappers, so existing callers and tests are unaffected.

## Tests

- Existing suite passes; `go vet` clean.
- Added `TestFuzzyListWindowFitsBudget` (clamps to budget, keeps cursor visible, shows both hints mid-list), `TestFuzzyListWindowUnboundedRendersAll` (0 = old behavior), and `TestFuzzyListClickRowLimitedMapsWindow` (clicks map through the scroll offset).