### PR TITLE
feat: Windows support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,11 +26,14 @@ builds:
     main: .
     env:
       - CGO_ENABLED=0
-    # Linux + macOS only. The manifest declares platforms = ["linux", "macos"]
-    # (we don't test on Windows, and the socket client + sh-based build step
-    # aren't validated there), so we don't ship Windows binaries to match.
-    goos: [linux, darwin]
+    # The manifest declares platforms = ["linux", "macos", "windows"], so we ship
+    # binaries for all three. Skip windows/arm64 — less common, and we'd rather
+    # not ship a binary we can't easily test; add it back if there's demand.
+    goos: [linux, darwin, windows]
     goarch: [amd64, arm64]
+    ignore:
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -s -w
 
@@ -38,6 +41,10 @@ archives:
   - id: default
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats: [tar.gz]
+    # Windows archives ship as .zip, the platform-native format.
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     files:
       - LICENSE*
       - README*

--- a/action.go
+++ b/action.go
@@ -10,10 +10,17 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"text/template"
 )
+
+// templateFuncs are the helper functions available inside a quick action's
+// command template, on top of text/template's builtins (e.g. urlquery). opener
+// expands to the platform's default open command so a single action works on
+// every OS — see opener in shell.go.
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{"opener": opener}
+}
 
 // Action types. An action's Type decides what happens between selecting it in
 // the picker and running its command.
@@ -147,7 +154,7 @@ func (a Action) validate() error {
 // position the value precisely with {{.Value}} or just receive it as its last
 // argument.
 func (a Action) render(ctx RunContext) (string, error) {
-	tmpl, err := template.New(a.Name).Parse(a.Command)
+	tmpl, err := template.New(a.Name).Funcs(templateFuncs()).Parse(a.Command)
 	if err != nil {
 		return "", fmt.Errorf("parse command for %q: %w", a.Name, err)
 	}
@@ -166,15 +173,16 @@ func (a Action) render(ctx RunContext) (string, error) {
 
 // run renders and executes the action's command through the shell, in the
 // invoking pane's working directory and with the context exported as
-// HERDR_PLUS_* environment variables. Running through "sh -c" lets commands use
-// pipes, arguments, and full scripts.
+// HERDR_PLUS_* environment variables. Running through a shell (see
+// shellCommand: `sh -c`, or PowerShell on Windows) lets commands use pipes,
+// arguments, and full scripts.
 func (a Action) run(ctx RunContext) error {
 	cmdline, err := a.render(ctx)
 	if err != nil {
 		return err
 	}
 
-	cmd := exec.Command("sh", "-c", cmdline)
+	cmd := shellCommand(cmdline)
 	if ctx.WorkDir != "" {
 		cmd.Dir = ctx.WorkDir
 	}

--- a/action_run_integration_test.go
+++ b/action_run_integration_test.go
@@ -1,0 +1,49 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestActionRunQuotingRoundTrip is the empirical half of the quoting contract: it
+// renders and runs a real action through the host's actual shell (PowerShell on
+// Windows, sh elsewhere) and asserts a hostile Value — spaces, a single quote, a
+// double quote, and a $ that PowerShell would otherwise expand as a variable —
+// comes back out verbatim. The unit tests prove shellQuote's output; this proves
+// that output actually survives the shell shellCommand launches, which is the DoD
+// guarantee for quick-action value injection on Windows.
+//
+// It exercises render()'s auto-append path: a command with no {{.Value}} gets the
+// value appended as one shell-quoted argument (via shellQuote). That is the path
+// herdr-plus is responsible for making injection-safe. A command that hand-quotes
+// {{.Value}} itself (e.g. echo '{{.Value}}') is the author's responsibility — the
+// raw value is substituted verbatim there — so it is intentionally not asserted.
+func TestActionRunQuotingRoundTrip(t *testing.T) {
+	// A value that breaks naive concatenation on both shells at once: spaces, both
+	// quote styles, and a PowerShell variable sigil.
+	const nasty = `a b 'c" $x`
+
+	// echo with no {{.Value}} → render appends shellQuote(value). `echo` is
+	// Write-Output on PowerShell and the echo builtin on sh; both print their
+	// argument verbatim.
+	a := Action{Name: "roundtrip", Type: TypeForm, Command: "echo"}
+	cmdline, err := a.render(RunContext{Value: nasty})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	out, err := shellCommand(cmdline).Output()
+	if err != nil {
+		t.Fatalf("run %q: %v", cmdline, err)
+	}
+
+	if got := strings.TrimRight(string(out), "\r\n"); got != nasty {
+		t.Fatalf("round-trip through shell = %q, want %q (cmdline: %q)", got, nasty, cmdline)
+	}
+}

--- a/action_test.go
+++ b/action_test.go
@@ -35,16 +35,18 @@ func TestActionRender(t *testing.T) {
 			want:   "open https://github.com/cloudmanic/herdr-plus",
 		},
 		{
+			// The value is appended and quoted for the current platform's shell;
+			// build the expected string with shellQuote so it holds on Windows too.
 			name:   "value appended when template omits it",
 			action: Action{Name: "Say", Type: TypeForm, Command: "say"},
 			ctx:    RunContext{Value: "hi there"},
-			want:   "say 'hi there'",
+			want:   "say " + shellQuote("hi there"),
 		},
 		{
 			name:   "value with single quote is shell-safe when appended",
 			action: Action{Name: "Say", Type: TypeForm, Command: "say"},
 			ctx:    RunContext{Value: "it's me"},
-			want:   `say 'it'\''s me'`,
+			want:   "say " + shellQuote("it's me"),
 		},
 		{
 			name:   "workdir variable",
@@ -63,6 +65,14 @@ func TestActionRender(t *testing.T) {
 			action:  Action{Name: "Search", Type: TypeForm, Command: "open 'https://g.co/s?q={{.Value | urlquery}}'"},
 			ctx:     RunContext{Value: "hello world"},
 			wantSub: []string{"hello", "world"},
+		},
+		{
+			// {{opener}} renders to the host's open command (open/xdg-open/
+			// Start-Process); assert against opener() so it holds on every OS.
+			name:   "opener helper renders host open command",
+			action: Action{Name: "Open", Command: "{{opener}} https://github.com"},
+			ctx:    RunContext{},
+			want:   opener() + " https://github.com",
 		},
 	}
 
@@ -128,12 +138,5 @@ func TestOptionResolvedValue(t *testing.T) {
 	}
 }
 
-// TestShellQuote verifies single-quote escaping produces a single shell token.
-func TestShellQuote(t *testing.T) {
-	if got := shellQuote("plain"); got != "'plain'" {
-		t.Fatalf("shellQuote(plain) = %q", got)
-	}
-	if got := shellQuote("it's"); got != `'it'\''s'` {
-		t.Fatalf("shellQuote(it's) = %q", got)
-	}
-}
+// Shell quoting is OS-specific and lives in shell_test.go (posixQuote /
+// powershellQuote are tested directly there, on every platform).

--- a/examples/quick-actions/github.toml
+++ b/examples/quick-actions/github.toml
@@ -4,4 +4,6 @@
 
 name = "GitHub"
 description = "Open https://github.com"
-command = "open https://github.com"
+# {{opener}} expands to your OS's default open command (open / xdg-open /
+# Start-Process), so the same action works on macOS, Linux, and Windows.
+command = "{{opener}} https://github.com"

--- a/examples/quick-actions/google-search.toml
+++ b/examples/quick-actions/google-search.toml
@@ -7,7 +7,7 @@
 name = "Search Google"
 description = "Type a query and open the results"
 type = "form"
-command = "open 'https://www.google.com/search?q={{.Value | urlquery}}'"
+command = "{{opener}} 'https://www.google.com/search?q={{.Value | urlquery}}'"
 
 [form]
 prompt = "Search Google for"

--- a/examples/quick-actions/google.toml
+++ b/examples/quick-actions/google.toml
@@ -3,4 +3,4 @@
 name = "Google"
 description = "Open https://google.com"
 type = "command"
-command = "open https://google.com"
+command = "{{opener}} https://google.com"

--- a/examples/quick-actions/open-repo.toml
+++ b/examples/quick-actions/open-repo.toml
@@ -8,7 +8,7 @@
 name = "Open Repo on GitHub"
 description = "Pick one of our repos and open it"
 type = "select"
-command = "open https://github.com/cloudmanic/{{.Value}}"
+command = "{{opener}} https://github.com/cloudmanic/{{.Value}}"
 
 [[options]]
 label = "Herdr Plus"

--- a/examples/quick-actions/open-working-dir.toml
+++ b/examples/quick-actions/open-working-dir.toml
@@ -17,6 +17,8 @@
 # HERDR_PLUS_WORKDIR, HERDR_PLUS_SESSION_TITLE, and so on.
 
 name = "Reveal Working Dir"
-description = "Open the launch directory in Finder"
+description = "Open the launch directory in your file manager"
 type = "command"
-command = "open {{.WorkDir}}"
+# {{opener}} is your OS's open command; single-quoting {{.WorkDir}} keeps a path
+# with spaces intact on every shell.
+command = "{{opener}} '{{.WorkDir}}'"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -18,15 +18,47 @@ name = "Herdr Plus"
 version = "0.1.16"
 min_herdr_version = "0.7.0"
 description = "An extension for herdr — a collection of tools that make it better. Projects: fuzzy-pick a declarative template to spin up a whole workspace — every tab, pane, and startup command. Quick Actions: a fuzzy launcher for one-off scripts, run in the directory you launched from."
-platforms = ["linux", "macos"]
+# Windows is supported under herdr's Windows beta (a manifest platform in
+# preview). Per-command `platforms` below override this list so each OS runs the
+# right build step and the right binary name (herdr-plus vs herdr-plus.exe).
+platforms = ["linux", "macos", "windows"]
 
 # Produce the binary at install time. herdr runs this once, after you confirm a
-# GitHub install and before registering the plugin. The script prefers a local Go
-# toolchain (an exact build of the cloned source) and falls back to downloading
-# the latest prebuilt release binary, so installing works with or without Go.
-# Either way the result is ./bin/herdr-plus, which the entry points below invoke.
+# GitHub install and before registering the plugin.
+#
+# Unix: the sh script prefers a local Go toolchain (an exact build of the cloned
+# source) and falls back to downloading the latest prebuilt release binary, so
+# installing works with or without Go. The result is ./bin/herdr-plus.
 [[build]]
+platforms = ["linux", "macos"]
 command = ["sh", "scripts/build.sh"]
+
+# Windows: no POSIX `sh`, so build straight from source with the Go toolchain.
+# The result is ./bin/herdr-plus.exe. Installing via `herdr plugin install` on
+# Windows therefore needs Go on PATH; for a checkout you can also build once
+# (`go build -o bin/herdr-plus.exe .`) and `herdr plugin link .`.
+[[build]]
+platforms = ["windows"]
+command = ["go", "build", "-o", "bin/herdr-plus.exe", "."]
+
+# Every entry point below is declared twice: a unix entry (platforms = linux,
+# macos → ./bin/herdr-plus) and a windows twin (platforms = windows). Two entries
+# are unavoidable — herdr requires a unique id per action/pane, and the two OSes
+# need different commands — so the windows twins carry a `-windows` id suffix. The
+# Go code that opens a pane picks the right entrypoint at runtime via
+# paneEntrypoint() (see shell.go), so nothing is hardcoded per-OS.
+#
+# The windows command is `powershell ... & .\bin\herdr-plus.exe <sub>`, not the
+# bare `.\bin\herdr-plus.exe`, for two Windows-specific reasons proven
+# empirically against the herdr Windows beta:
+#   1. Relative exe resolution. herdr runs the command with cwd = plugin root, but
+#      Windows' CreateProcessW resolves a *relative* application path against
+#      herdr's own cwd, not the child cwd it sets — so `.\bin\herdr-plus.exe`
+#      spawned directly fails with os error 3. Going through powershell (found on
+#      PATH) fixes this: powershell's cwd is the plugin root, and its `&` operator
+#      resolves `.\bin\herdr-plus.exe` from there.
+#   2. Extension. Windows cannot spawn an extensionless PE by its bare path
+#      (CreateProcessW appends .exe), so the binary must be named herdr-plus.exe.
 
 # projects — the flagship action. Opens a full-screen browser to fuzzy-pick a
 # project (a declarative set of tabs/panes from ~/.config/herdr-plus/projects/)
@@ -35,7 +67,14 @@ command = ["sh", "scripts/build.sh"]
 [[actions]]
 id = "projects"
 title = "Herdr Plus: Projects"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "projects"]
+
+[[actions]]
+id = "projects-windows"
+title = "Herdr Plus: Projects"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe projects"]
 
 # picker — the projects browser as a herdr-managed pane (no throwaway workspace).
 # Opened by the projects action via `herdr plugin pane open`; herdr gives it a
@@ -44,7 +83,17 @@ command = ["./bin/herdr-plus", "projects"]
 id = "picker"
 title = "Herdr Plus: Projects"
 placement = "zoomed"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "projects-ui"]
+
+[[panes]]
+id = "picker-windows"
+title = "Herdr Plus: Projects"
+placement = "zoomed"
+platforms = ["windows"]
+# Panes deliberately omit -NonInteractive (which actions/events keep): this hosts
+# an interactive bubbletea TUI, and -NonInteractive would break its input.
+command = ["powershell", "-NoProfile", "-Command", "& .\\bin\\herdr-plus.exe projects-ui"]
 
 # quick-actions — a fuzzy launcher for one-off actions/scripts (command, select,
 # or form), loaded from ~/.config/herdr-plus/quick-actions/ (plus a repo's own
@@ -53,7 +102,14 @@ command = ["./bin/herdr-plus", "projects-ui"]
 [[actions]]
 id = "quick-actions"
 title = "Herdr Plus: Quick Actions"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "quick-actions"]
+
+[[actions]]
+id = "quick-actions-windows"
+title = "Herdr Plus: Quick Actions"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe quick-actions"]
 
 # quick-actions-picker — the action picker as a herdr-managed overlay pane. The
 # quick-actions action opens it (passing the launch context), and herdr restores
@@ -62,7 +118,16 @@ command = ["./bin/herdr-plus", "quick-actions"]
 id = "quick-actions-picker"
 title = "Quick Actions"
 placement = "overlay"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "quick-actions-ui"]
+
+[[panes]]
+id = "quick-actions-picker-windows"
+title = "Quick Actions"
+placement = "overlay"
+platforms = ["windows"]
+# Omits -NonInteractive on purpose — interactive TUI pane; see picker-windows.
+command = ["powershell", "-NoProfile", "-Command", "& .\\bin\\herdr-plus.exe quick-actions-ui"]
 
 # ping — a smoke-test action that proves the plugin loop end to end: it talks to
 # herdr over the socket and prints the focused pane/workspace. Its output is
@@ -70,7 +135,14 @@ command = ["./bin/herdr-plus", "quick-actions-ui"]
 [[actions]]
 id = "ping"
 title = "Herdr Plus: ping"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "ping"]
+
+[[actions]]
+id = "ping-windows"
+title = "Herdr Plus: ping"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe ping"]
 
 # worktree.created / worktree.opened — herdr fires worktree.created when it
 # creates a new git worktree and worktree.opened when it opens an existing one
@@ -84,8 +156,20 @@ command = ["./bin/herdr-plus", "ping"]
 # it by hand. Output is captured in the plugin log.
 [[events]]
 on = "worktree.created"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "on-worktree"]
+
+[[events]]
+on = "worktree.created"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe on-worktree"]
+
+[[events]]
+on = "worktree.opened"
+platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "on-worktree"]
 
 [[events]]
 on = "worktree.opened"
-command = ["./bin/herdr-plus", "on-worktree"]
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe on-worktree"]

--- a/herdr.go
+++ b/herdr.go
@@ -11,17 +11,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"time"
 )
 
-// herdrClient talks to the running herdr instance over its unix domain socket.
-// The protocol is newline-delimited JSON: one request object per line, one
-// response object per line. Each call opens a short-lived connection, writes a
-// single request, and reads a single response. herdr injects HERDR_SOCKET_PATH
-// into every plugin command, so this works whenever herdr runs us.
+// herdrClient talks to the running herdr instance over its local IPC endpoint:
+// a unix domain socket on macOS/Linux and a named pipe on Windows (dialHerdr
+// hides the difference). The protocol is newline-delimited JSON: one request
+// object per line, one response object per line. Each call opens a short-lived
+// connection, writes a single request, and reads a single response. herdr
+// injects HERDR_SOCKET_PATH into every plugin command, so this works whenever
+// herdr runs us.
 type herdrClient struct {
 	socketPath string
 }
@@ -60,7 +61,7 @@ type response struct {
 // call sends a single request over a fresh connection and decodes the result
 // into out (which may be nil when the caller does not care about the payload).
 func (c *herdrClient) call(method string, params map[string]any, out any) error {
-	conn, err := net.Dial("unix", c.socketPath)
+	conn, err := dialHerdr(c.socketPath)
 	if err != nil {
 		return fmt.Errorf("connect herdr socket: %w", err)
 	}

--- a/herdr.go
+++ b/herdr.go
@@ -63,7 +63,7 @@ type response struct {
 func (c *herdrClient) call(method string, params map[string]any, out any) error {
 	conn, err := dialHerdr(c.socketPath)
 	if err != nil {
-		return fmt.Errorf("connect herdr socket: %w", err)
+		return fmt.Errorf("connect herdr IPC endpoint: %w", err)
 	}
 	defer conn.Close()
 

--- a/herdrdial_other.go
+++ b/herdrdial_other.go
@@ -1,0 +1,22 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+//go:build !windows
+
+package main
+
+import (
+	"io"
+	"net"
+)
+
+// dialHerdr opens a connection to herdr's IPC endpoint. On unix that endpoint is
+// the unix domain socket at socketPath (the value herdr injects as
+// HERDR_SOCKET_PATH). The returned connection is used only as an
+// io.ReadWriteCloser by call(), so the Windows twin can return an *os.File.
+func dialHerdr(socketPath string) (io.ReadWriteCloser, error) {
+	return net.Dial("unix", socketPath)
+}

--- a/herdrdial_windows.go
+++ b/herdrdial_windows.go
@@ -1,0 +1,51 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"syscall"
+	"time"
+)
+
+// On Windows herdr has no unix domain socket. It listens on a named pipe whose
+// name is the HERDR_SOCKET_PATH value, exposed under the pipe namespace as
+// \\.\pipe\<socketPath>. The on-disk file at socketPath is only a PID:nonce
+// liveness marker — not the endpoint — so we must open the pipe, not the file.
+const pipePrefix = `\\.\pipe\`
+
+// errPipeBusy is Win32 ERROR_PIPE_BUSY (231): every instance of the pipe is
+// currently serving another client. It is transient — herdr creates a new
+// instance as soon as one frees up — so dialHerdr retries briefly instead of
+// failing the whole call.
+const errPipeBusy = syscall.Errno(231)
+
+// dialHerdr opens a connection to herdr's IPC endpoint. On Windows that is the
+// named pipe \\.\pipe\<socketPath>, opened for read/write. The *os.File it
+// returns satisfies the io.ReadWriteCloser that call() needs; the newline-
+// delimited JSON protocol is identical to the unix socket. It retries on
+// ERROR_PIPE_BUSY for up to ~1s so a momentarily saturated pipe does not fail
+// an otherwise-healthy request.
+func dialHerdr(socketPath string) (io.ReadWriteCloser, error) {
+	pipePath := pipePrefix + socketPath
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		f, err := os.OpenFile(pipePath, os.O_RDWR, 0)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, errPipeBusy) || time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,0 +1,92 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// manifest mirrors the parts of herdr-plugin.toml this test asserts on: the
+// top-level platform list plus every entry-point group that carries a per-OS
+// `platforms` override and a `command`.
+type manifest struct {
+	Platforms []string       `toml:"platforms"`
+	Build     []manifestStep `toml:"build"`
+	Actions   []manifestStep `toml:"actions"`
+	Panes     []manifestStep `toml:"panes"`
+	Events    []manifestStep `toml:"events"`
+}
+
+type manifestStep struct {
+	Platforms []string `toml:"platforms"`
+	Command   []string `toml:"command"`
+}
+
+// TestManifestWindowsCoverage parses the real herdr-plugin.toml and enforces the
+// Windows port's manifest contract: it is valid TOML, declares the windows
+// platform, and every entry-point group (build, actions, panes, events) has a
+// windows-targeted entry whose command invokes the herdr-plus.exe binary. This
+// is the manifest half of the Definition of Done — an accidental drop of a
+// windows entry (or of the .exe binary) fails here instead of silently at
+// install time.
+func TestManifestWindowsCoverage(t *testing.T) {
+	var m manifest
+	if _, err := toml.DecodeFile("herdr-plugin.toml", &m); err != nil {
+		t.Fatalf("herdr-plugin.toml is not valid TOML: %v", err)
+	}
+
+	if !contains(m.Platforms, "windows") {
+		t.Fatalf("top-level platforms = %v, must include windows", m.Platforms)
+	}
+
+	groups := map[string][]manifestStep{
+		"build":   m.Build,
+		"actions": m.Actions,
+		"panes":   m.Panes,
+		"events":  m.Events,
+	}
+	for name, steps := range groups {
+		if !hasWindowsEntry(name, steps) {
+			t.Errorf("%s: no windows-targeted entry found", name)
+		}
+	}
+}
+
+// hasWindowsEntry reports whether steps contains at least one windows entry, and
+// (for non-build groups) that its command runs the herdr-plus.exe binary. The
+// binary is not command[0] — the windows entries shell out through powershell
+// (`powershell ... & .\bin\herdr-plus.exe <sub>`), so the .exe appears inside a
+// later argument — hence the check scans every element. The build group is
+// exempt: it runs `go build`, not the plugin binary.
+func hasWindowsEntry(group string, steps []manifestStep) bool {
+	for _, s := range steps {
+		if !contains(s.Platforms, "windows") {
+			continue
+		}
+		if group == "build" {
+			return true
+		}
+		for _, arg := range s.Command {
+			if strings.Contains(arg, "herdr-plus.exe") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/project.go
+++ b/project.go
@@ -217,17 +217,40 @@ func validateTabs(label, source string, tabs []ProjectTab) error {
 // path, expanding a leading ~ to the home directory and any $VARS in the path.
 // An empty working_dir defaults to the user's home directory, so a minimal
 // project still opens somewhere sensible.
-func (p Project) expandedWorkingDir() string {
+//
+// Home comes from os.UserHomeDir (USERPROFILE on Windows, HOME elsewhere), and
+// the result is filepath.Clean'd so a config written with forward slashes lands
+// on native separators — both so this works on Windows. Only $VAR / ${VAR}
+// syntax is expanded (os.ExpandEnv), not Windows %VAR%; document that for users.
+func (p Project) expandedWorkingDir() (string, error) {
 	dir := strings.TrimSpace(p.WorkingDir)
-	home, _ := os.UserHomeDir()
+
+	home, err := os.UserHomeDir()
+	needsHome := dir == "" || dir == "~" || strings.HasPrefix(dir, "~/")
+	if err != nil && needsHome {
+		// Only a fatal problem when the path actually references home; an absolute
+		// or relative working_dir resolves fine without it.
+		return "", fmt.Errorf("resolve home directory for working_dir %q: %w", p.WorkingDir, err)
+	}
 
 	if dir == "" || dir == "~" {
-		return home
+		return home, nil
 	}
 	if strings.HasPrefix(dir, "~/") {
 		dir = filepath.Join(home, dir[2:])
 	}
-	return os.ExpandEnv(dir)
+	return filepath.Clean(os.ExpandEnv(dir)), nil
+}
+
+// displayWorkingDir resolves the working directory for UI contexts that have no
+// way to surface an error (the picker's detail bar). On failure it falls back to
+// the raw working_dir so the picker still renders something rather than breaking.
+func (p Project) displayWorkingDir() string {
+	dir, err := p.expandedWorkingDir()
+	if err != nil {
+		return strings.TrimSpace(p.WorkingDir)
+	}
+	return dir
 }
 
 // tabLabels returns the tab names in order for the browser's detail bar,

--- a/project_test.go
+++ b/project_test.go
@@ -252,7 +252,11 @@ func TestTabLabels(t *testing.T) {
 // all resolve sensibly relative to the home directory.
 func TestExpandedWorkingDir(t *testing.T) {
 	home := t.TempDir()
+	// os.UserHomeDir reads USERPROFILE on Windows and HOME elsewhere; set both so
+	// the ~ cases resolve to our temp home on every platform. HOME also feeds the
+	// $HOME expansion case below.
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	cases := []struct {
 		in   string
@@ -262,12 +266,17 @@ func TestExpandedWorkingDir(t *testing.T) {
 		{"~", home},
 		{"~/code/x", filepath.Join(home, "code", "x")},
 		{"$HOME/code/y", filepath.Join(home, "code", "y")},
-		{"/srv/abs", "/srv/abs"},
+		{"/srv/abs", filepath.Clean("/srv/abs")},
 	}
 	for _, c := range cases {
-		got := Project{WorkingDir: c.in}.expandedWorkingDir()
-		if got != c.want {
-			t.Fatalf("expandedWorkingDir(%q) = %q, want %q", c.in, got, c.want)
+		got, err := Project{WorkingDir: c.in}.expandedWorkingDir()
+		if err != nil {
+			t.Fatalf("expandedWorkingDir(%q) returned error: %v", c.in, err)
+		}
+		// expandedWorkingDir normalizes separators (filepath.Clean); compare against
+		// a cleaned want so the $VAR case matches on Windows too.
+		if want := filepath.Clean(c.want); got != want {
+			t.Fatalf("expandedWorkingDir(%q) = %q, want %q", c.in, got, want)
 		}
 	}
 }

--- a/projects.go
+++ b/projects.go
@@ -32,7 +32,7 @@ func launchProjects() {
 
 	cmd := exec.Command(herdr, "plugin", "pane", "open",
 		"--plugin", "cloudmanic.herdr-plus",
-		"--entrypoint", "picker",
+		"--entrypoint", paneEntrypoint("picker"),
 		"--placement", "zoomed",
 	)
 	cmd.Stdout = os.Stdout
@@ -97,7 +97,10 @@ func runProjectsUI() {
 // the user to it; the picker pane this was launched from is then torn down by
 // herdr when runProjectsUI exits.
 func openProject(client *herdrClient, p Project) error {
-	dir := p.expandedWorkingDir()
+	dir, err := p.expandedWorkingDir()
+	if err != nil {
+		return err
+	}
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
 		return fmt.Errorf("working directory does not exist: %s", dir)
 	}
@@ -122,7 +125,11 @@ func openProject(client *herdrClient, p Project) error {
 func openProjectAsWorktree(client *herdrClient, p Project, branch string) error {
 	// filepath.Abs already returns an absolute path (or an error), so no separate
 	// IsAbs check is needed after it.
-	dir, err := filepath.Abs(p.expandedWorkingDir())
+	expanded, err := p.expandedWorkingDir()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	dir, err := filepath.Abs(expanded)
 	if err != nil {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -402,7 +402,7 @@ func (m projectsModel) branchView(w, h int) string {
 	name, dir := "", ""
 	if m.chosen != nil {
 		name = m.chosen.Name
-		dir = m.chosen.expandedWorkingDir()
+		dir = m.chosen.displayWorkingDir()
 	}
 
 	body := nameStyle.Render(name) + "\n" +
@@ -440,7 +440,7 @@ func (m projectsModel) detailBar(w int) string {
 		inner = 10
 	}
 
-	dirLine := dirIconStyle.Render("📁 ") + pathStyle.Render(truncate(p.expandedWorkingDir(), inner-3))
+	dirLine := dirIconStyle.Render("📁 ") + pathStyle.Render(truncate(p.displayWorkingDir(), inner-3))
 
 	labels := p.tabLabels()
 	styled := make([]string, len(labels))

--- a/projectsmodel_test.go
+++ b/projectsmodel_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -346,7 +347,9 @@ func TestProjectsModelBrowserView(t *testing.T) {
 	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
 	view := m.View()
 
-	for _, want := range []string{"Alpha", "Bravo", "/srv/alpha"} {
+	// The detail bar shows the resolved working dir, which expandedWorkingDir
+	// normalizes to native separators (\srv\alpha on Windows).
+	for _, want := range []string{"Alpha", "Bravo", filepath.Clean("/srv/alpha")} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("browser view missing %q:\n%s", want, view)
 		}

--- a/quickactions.go
+++ b/quickactions.go
@@ -35,7 +35,7 @@ func launchQuickActions() {
 	args := []string{
 		"plugin", "pane", "open",
 		"--plugin", "cloudmanic.herdr-plus",
-		"--entrypoint", "quick-actions-picker",
+		"--entrypoint", paneEntrypoint("quick-actions-picker"),
 		"--placement", "overlay",
 		// Hand the launch context to the picker as a single shell-safe env var.
 		"--env", "HERDR_PLUS_CTX=" + enc,

--- a/shell.go
+++ b/shell.go
@@ -1,0 +1,104 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// This file is the one place that knows which shell herdr-plus's quick actions
+// run under, and how to quote a value for it. Everything OS-specific about
+// running a command string lives here — the rest of the plugin calls
+// shellCommand / shellQuote and stays free of runtime.GOOS checks.
+//
+// It matters only for quick actions, which the plugin executes itself (see
+// action.go). Project and worktree tab commands are typed straight into a herdr
+// pane and run by that pane's own shell, so they never pass through here.
+
+// platform bundles everything about the host OS that quick-action execution
+// varies on: the shell commands run under, how to quote a value for that shell,
+// the pane-entrypoint suffix, and the default "open this" command. Selecting it
+// once (currentPlatform) keeps a single OS switch here instead of one per
+// concern — adding an OS is a new case, not four scattered edits.
+type platform struct {
+	shellPrefix      []string            // argv prefix; the command string is appended
+	quote            func(string) string // wrap a value as one literal shell argument
+	entrypointSuffix string              // appended to a base pane id (see paneEntrypoint)
+	opener           string              // command that opens a URL/file in its default handler
+}
+
+// currentPlatform is the descriptor for the OS this binary was built for. GOOS is
+// fixed per build, so it is resolved once at init rather than on every call.
+var currentPlatform = func() platform {
+	switch runtime.GOOS {
+	case "windows":
+		// Windows PowerShell (always present, unlike pwsh). The "-windows" suffix
+		// selects the .exe pane twins; Windows cannot spawn the extensionless PE.
+		return platform{
+			shellPrefix:      []string{"powershell", "-NoProfile", "-NonInteractive", "-Command"},
+			quote:            powershellQuote,
+			entrypointSuffix: "-windows",
+			opener:           "Start-Process",
+		}
+	case "darwin":
+		return platform{shellPrefix: []string{"sh", "-c"}, quote: posixQuote, opener: "open"}
+	default: // linux and other unixes
+		return platform{shellPrefix: []string{"sh", "-c"}, quote: posixQuote, opener: "xdg-open"}
+	}
+}()
+
+// shellCommand builds an *exec.Cmd that runs cmdline through the platform's
+// default shell. Running through a shell — rather than splitting the string
+// ourselves — is deliberate: a quick action's command may use pipes,
+// redirection, and multiple arguments.
+func shellCommand(cmdline string) *exec.Cmd {
+	argv := append(append([]string{}, currentPlatform.shellPrefix...), cmdline)
+	return exec.Command(argv[0], argv[1:]...)
+}
+
+// shellQuote wraps s so the platform shell treats it as a single literal
+// argument — no word splitting, no variable expansion. It uses the quoting rules
+// of the shell shellCommand runs under, so the two always agree.
+func shellQuote(s string) string {
+	return currentPlatform.quote(s)
+}
+
+// posixQuote wraps s in single quotes, escaping any embedded single quote the
+// usual POSIX way ('\'' closes the quote, adds an escaped quote, and reopens
+// it). Single quotes make the shell treat everything inside literally.
+func posixQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// powershellQuote wraps s in single quotes for PowerShell, escaping an embedded
+// single quote by doubling it ('' is a literal quote inside a single-quoted
+// string). A PowerShell single-quoted string is fully literal — no $var or
+// backtick interpretation — which is exactly what we want for an injected value.
+func powershellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// paneEntrypoint maps a base pane id to the entrypoint id registered for the
+// current OS. On Windows every pane is declared twice in herdr-plugin.toml — the
+// unix id and a `-windows` twin that runs the .exe binary (Windows cannot spawn
+// the extensionless PE by its bare path). Callers that open a pane pass the base
+// id through here so the "-windows" suffix lives in one place, not scattered
+// runtime.GOOS checks at each call site.
+func paneEntrypoint(base string) string {
+	return base + currentPlatform.entrypointSuffix
+}
+
+// opener returns the platform command that opens a URL, file, or directory in
+// its default handler: `open` on macOS, `xdg-open` on Linux, and PowerShell's
+// `Start-Process` on Windows. Quick actions reach it through the {{opener}}
+// template function (see templateFuncs), so one example — `{{opener}} <target>`
+// — works on every OS instead of hardcoding the macOS-only `open`.
+func opener() string {
+	return currentPlatform.opener
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -1,0 +1,108 @@
+//
+// Date: 2026-06-15
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestPosixQuote verifies POSIX single-quote escaping produces a single token,
+// escaping an embedded quote the '\'' way. Tested directly (not via shellQuote)
+// so it runs on every platform, not just Unix.
+func TestPosixQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"it's", `'it'\''s'`},
+		{"a b c", "'a b c'"},
+		{"", "''"},
+	}
+	for _, c := range cases {
+		if got := posixQuote(c.in); got != c.want {
+			t.Fatalf("posixQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestPowershellQuote verifies PowerShell single-quote escaping produces a single
+// literal token, escaping an embedded quote by doubling it ('' -> '). Tested
+// directly so it runs on every platform, not just Windows.
+func TestPowershellQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"it's", "'it''s'"},
+		{"a b c", "'a b c'"},
+		{`$env:PATH`, `'$env:PATH'`}, // single quotes keep it literal, no expansion
+		{"", "''"},
+	}
+	for _, c := range cases {
+		if got := powershellQuote(c.in); got != c.want {
+			t.Fatalf("powershellQuote(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestShellQuoteDispatch confirms shellQuote picks the rules for the host shell,
+// so it agrees with the shell shellCommand runs.
+func TestShellQuoteDispatch(t *testing.T) {
+	got := shellQuote("it's")
+	want := posixQuote("it's")
+	if runtime.GOOS == "windows" {
+		want = powershellQuote("it's")
+	}
+	if got != want {
+		t.Fatalf("shellQuote(it's) = %q, want %q for GOOS=%s", got, want, runtime.GOOS)
+	}
+}
+
+// TestShellCommand confirms the invoked shell and its arguments match the host:
+// PowerShell -Command on Windows, sh -c elsewhere, with the command string as
+// the final argument either way.
+func TestShellCommand(t *testing.T) {
+	cmd := shellCommand("echo hi")
+	args := cmd.Args
+	if len(args) == 0 {
+		t.Fatal("shellCommand produced no args")
+	}
+	if got := args[len(args)-1]; got != "echo hi" {
+		t.Fatalf("last arg = %q, want the command string", got)
+	}
+	if runtime.GOOS == "windows" {
+		if args[0] != "powershell" {
+			t.Fatalf("shell = %q, want powershell", args[0])
+		}
+	} else if args[0] != "sh" || args[1] != "-c" {
+		t.Fatalf("shell = %v, want [sh -c ...]", args[:2])
+	}
+}
+
+// TestPaneEntrypoint confirms the base pane id gets the "-windows" suffix on
+// Windows and is returned unchanged elsewhere, matching the paired manifest
+// entries (picker / picker-windows). This is what keeps the runtime.GOOS branch
+// out of the pane-open call sites.
+func TestPaneEntrypoint(t *testing.T) {
+	got := paneEntrypoint("picker")
+	want := "picker"
+	if runtime.GOOS == "windows" {
+		want = "picker-windows"
+	}
+	if got != want {
+		t.Fatalf("paneEntrypoint(picker) = %q, want %q for GOOS=%s", got, want, runtime.GOOS)
+	}
+}
+
+// TestOpener confirms opener returns the current platform's open command, so the
+// {{opener}} template helper renders to something runnable on the host.
+func TestOpener(t *testing.T) {
+	want := map[string]string{"windows": "Start-Process", "darwin": "open"}[runtime.GOOS]
+	if want == "" {
+		want = "xdg-open"
+	}
+	if got := opener(); got != want {
+		t.Fatalf("opener() = %q, want %q for GOOS=%s", got, want, runtime.GOOS)
+	}
+}

--- a/util.go
+++ b/util.go
@@ -9,7 +9,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 // errExit prints a "herdr-plus:"-prefixed message to stderr and exits non-zero.
@@ -27,11 +26,4 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
-}
-
-// shellQuote wraps a string in single quotes so the shell treats it as one
-// literal argument, escaping any embedded single quotes the usual POSIX way
-// ('\'' closes the quote, adds an escaped quote, and reopens it).
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }


### PR DESCRIPTION
Adds Windows support to the herdr-plus plugin. Verified end-to-end against a live herdr 0.7.4-preview on Windows 11 (Go 1.26.2); Linux/macOS behaviour unchanged.

## What was needed on Windows

Three platform differences drove the change:

1. **IPC is a named pipe, not a unix socket.** herdr on Windows exposes its socket API as a named pipe at `\\.\pipe\<socketPath>` (the on-disk `herdr.sock` is just a liveness marker). Protocol is identical newline-delimited JSON, no token handshake. Added build-tagged `dialHerdr`: named pipe on Windows (retrying on `ERROR_PIPE_BUSY`), unix socket elsewhere. Stdlib only, no new deps.
2. **Can't spawn an extensionless PE.** `CreateProcessW` appends `.exe`, so the binary is `herdr-plus.exe` and each action/pane gets a `-windows` twin (herdr requires unique action/pane ids; duplicate event `on=` differentiated by `platforms` is allowed). Relative-path spawn resolves against herdr's cwd, so Windows entries shell through `powershell -Command "& .\bin\herdr-plus.exe <sub>"`. Panes omit `-NonInteractive` (interactive TUIs); actions/events keep it.
3. **Shell + quoting differ.** Centralized every OS difference into one `platform` descriptor in `shell.go` (PowerShell vs `sh`, PowerShell vs POSIX quoting, pane suffix, `{{opener}}` = `Start-Process`/`open`/`xdg-open`) — no scattered `runtime.GOOS`.

## Verified

- Cross-OS `go build` (windows/linux/darwin), `go vet ./...`, `go test ./...` all green.
- Plugin links + enables with `platforms = [linux, macos, windows]`.
- Named-pipe transport, action spawn, Projects workspace open (tabs + split panes + startup commands, hostile-value quoting round-trip), and `worktree.created` → auto-layout all exercised on the live host.
- `~`/`$VARS` expansion unit-tested on Windows.

## Also

- `expandedWorkingDir` now surfaces a home-dir resolution error instead of silently discarding it (a missing `USERPROFILE` would have resolved `~` to a wrong path).
- goreleaser ships Windows `amd64` binaries as `.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
