### PR TITLE
docs: note Windows install needs Go on PATH (follow-up to #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ and **falls back to downloading the latest prebuilt release binary**, so it work
 `herdr plugin action list --plugin cloudmanic.herdr-plus`, and
 `herdr plugin uninstall cloudmanic.herdr-plus`.
 
+> **Windows** (herdr's Windows support is in preview): the plugin installs and
+> runs on Windows, but its build step compiles straight from source with the Go
+> toolchain — there's **no prebuilt-binary fallback** like the Linux/macOS `sh`
+> script has — so **Go must be on your `PATH`** to `herdr plugin install`. The
+> plugin talks to herdr over a named pipe there instead of a unix socket; it's
+> validated against the herdr Windows beta.
+
 **Local development:** build the binary and link your checkout in place:
 
 ```bash

--- a/www/content/docs/installation.md
+++ b/www/content/docs/installation.md
@@ -22,6 +22,12 @@ plugin's actions. The build step **prefers a local Go toolchain** (an exact buil
 of the cloned source) and **falls back to downloading the latest prebuilt release
 binary**, so it works **with or without Go**.
 
+> **Windows** (herdr's Windows support is in preview): the plugin's Windows build
+> step compiles straight from source with the Go toolchain — there is **no
+> prebuilt-binary fallback** like the Linux/macOS `sh` script has — so **Go must
+> be on your `PATH`** to install. On Windows the plugin talks to herdr over a
+> named pipe rather than a unix socket.
+
 After it finishes, manage the plugin with:
 
 ```bash
@@ -92,7 +98,9 @@ curl -fsSL https://raw.githubusercontent.com/cloudmanic/herdr-plus/main/install.
 ## Supported platforms
 
 Releases are cross-compiled for **Linux** and **macOS** on `amd64` (x86_64) and
-`arm64` (aarch64). herdr-plus is not tested on Windows.
+`arm64` (aarch64), plus **Windows** on `amd64` (shipped as a `.zip`). Windows
+support tracks herdr's Windows beta and is validated against it; installing on
+Windows builds from source, so it needs Go on your `PATH` (see the note above).
 
 ## Checking the version
 


### PR DESCRIPTION
Follow-up to #45 (Windows support).

Windows now works, but its build step compiles straight from source with the Go toolchain — there's **no prebuilt-binary fallback** like the Linux/macOS `sh` script has — so **Go must be on the user's `PATH`** to `herdr plugin install` on Windows. That wasn't documented anywhere, so a Windows user would hit a confusing failure.

## Changes
- **README** — a Windows note in the Install section: needs Go on PATH, no prebuilt fallback, talks to herdr over a named pipe.
- **installation.md** — the same note by the build-step paragraph, and updated the **Supported platforms** section, which still said *"herdr-plus is not tested on Windows"* — now reflects Windows `amd64` (`.zip`), validated against herdr's Windows beta.

Docs only — no code changes.