### PR TITLE
Add headless `open <name>` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,27 @@ name = "terminal"   # no command — just an empty shell
 Tabs open in file order. The first tab reuses the workspace's root tab; the rest
 are created behind it. A tab with no `command` is just an empty shell.
 
+### Opening by name (headless)
+
+The picker is interactive, but a project can also be opened directly — no browser,
+no fuzzy-picking — with the `open` subcommand:
+
+```sh
+herdr-plus open harbor-sysadmin
+```
+
+It loads the same templates, resolves the one whose `name` matches (exactly, or
+case-insensitively as a fallback), and builds its workspace through the **identical
+code path** the picker uses — so there is a single source of truth for the layout.
+A mistyped name fails with the list of available projects.
+
+Run it from **inside herdr** (a pane shell, a keybinding, another tool): like every
+herdr-plus command it reaches the running herdr over its socket, and it asks herdr
+where your project templates live, so it finds the same ones the picker shows. This
+is the scriptable entry point for spinning up a known workspace in one shot — handy
+for shell aliases, scripts, and AI agents. (To get `herdr-plus` on your `PATH`, see
+[Just the binary](#just-the-binary).)
+
 ### Grouping
 
 A project may set an optional `group` to cluster related projects under a heading

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ import (
 //   - "projects-ui" / "quick-actions-ui" are those UIs; herdr runs them inside the
 //     pane it opens (the `picker` / `quick-actions-picker` entrypoints), so end
 //     users never run them directly.
+//   - "open <name>" opens a project's workspace headlessly, by name, skipping the
+//     interactive picker — the scriptable entry point for spinning up a known
+//     workspace in one shot.
 //   - "ping" is a smoke test that proves the plugin loop end to end.
 //   - "on-worktree" is herdr's worktree event handler, run for both worktree.created
 //     and worktree.opened (via the [[events]] entries in herdr-plugin.toml), not the
@@ -42,6 +45,9 @@ func main() {
 			return
 		case "quick-actions-ui":
 			runQuickActionsUI()
+			return
+		case "open":
+			runOpen(os.Args[2:])
 			return
 		case "ping":
 			runPing()

--- a/open.go
+++ b/open.go
@@ -1,0 +1,132 @@
+//
+// Date: 2026-07-23
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// runOpen implements the headless `open <name>` subcommand: it opens a project's
+// workspace by name, skipping the interactive fuzzy picker entirely. It loads the
+// same project templates the picker uses, resolves the one whose name matches the
+// argument, and hands it to openProject — the exact code path the picker runs when
+// a project is chosen — so there is one source of truth for turning a template
+// into a live workspace. This is the scriptable entry point a shell alias, a
+// keybinding, another tool, or an AI agent can call to spin up a known workspace
+// in a single shot. Like every herdr-plus command it reaches the running herdr
+// over HERDR_SOCKET_PATH, so it must run inside herdr.
+func runOpen(args []string) {
+	if len(args) < 1 || strings.TrimSpace(args[0]) == "" {
+		errExit("usage: herdr-plus open <project-name>")
+	}
+	name := strings.TrimSpace(args[0])
+
+	// Point config resolution at herdr's managed dir before loading templates —
+	// a direct invocation has no HERDR_PLUGIN_CONFIG_DIR injected for us.
+	ensureManagedConfigDir()
+
+	// Load every project template, surfacing any config error loudly.
+	projects, err := loadProjects()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Resolve the requested name to a single project (or a helpful error).
+	p, err := findProject(projects, name)
+	if err != nil {
+		errExit(err)
+	}
+
+	// Connect to the running herdr instance over its socket.
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Build the live workspace via the shared picker code path.
+	if err := openProject(client, p); err != nil {
+		errExit("could not open project:", err)
+	}
+
+	fmt.Printf("opened %s\n", p.Name)
+}
+
+// findProject resolves a project by name within the loaded set. An exact,
+// case-sensitive match wins; failing that, a case-insensitive match is accepted so
+// `open Harbor-Sysadmin` still finds "harbor-sysadmin". When nothing matches it
+// returns an error naming the miss and listing the available projects (or noting
+// that none are defined), so a mistyped name fails loudly with a usable hint
+// rather than silently doing nothing.
+func findProject(projects []Project, name string) (Project, error) {
+	// Prefer an exact match so names that differ only by case stay distinct.
+	for _, p := range projects {
+		if p.Name == name {
+			return p, nil
+		}
+	}
+
+	// Fall back to a case-insensitive match for CLI friendliness.
+	for _, p := range projects {
+		if strings.EqualFold(p.Name, name) {
+			return p, nil
+		}
+	}
+
+	if len(projects) == 0 {
+		return Project{}, fmt.Errorf("no project named %q: no projects are defined", name)
+	}
+
+	names := make([]string, len(projects))
+	for i, p := range projects {
+		names[i] = p.Name
+	}
+	return Project{}, fmt.Errorf("no project named %q; available: %s", name, strings.Join(names, ", "))
+}
+
+// ensureManagedConfigDir makes HERDR_PLUGIN_CONFIG_DIR available to a headless
+// command. herdr injects that variable whenever it runs one of our plugin commands
+// (the picker path), pointing config resolution at the managed directory herdr
+// stores our projects/ in. A direct invocation like `herdr-plus open <name>` from
+// a shell has no such injection, so configBaseDir would fall back to the standalone
+// ~/.config/herdr-plus and miss those projects. Here we ask the running herdr for
+// the managed directory and export it ourselves — doing exactly what herdr would
+// have done — so loadProjects reads the very same templates the picker would.
+//
+// Best effort: an already-set variable is left untouched, and if herdr cannot
+// answer (not running, not found) we leave it unset and config keeps its standalone
+// fallback. Setting a process env var here is safe: this is a short-lived one-shot
+// command, and openProject drives herdr over the socket rather than spawning
+// children that would inherit it.
+func ensureManagedConfigDir() {
+	if os.Getenv("HERDR_PLUGIN_CONFIG_DIR") != "" {
+		return
+	}
+	if dir := herdrManagedConfigDir(); dir != "" {
+		os.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+	}
+}
+
+// herdrManagedConfigDir asks the running herdr for the directory it manages our
+// plugin config in, via `herdr plugin config-dir <id>`. herdr owns that path, so
+// querying it is more robust than reconstructing herdr's directory layout here. It
+// returns "" when herdr is unreachable or the command fails. The herdr binary is
+// located via HERDR_BIN_PATH (set for plugin commands), falling back to "herdr" on
+// PATH.
+func herdrManagedConfigDir() string {
+	herdr := os.Getenv("HERDR_BIN_PATH")
+	if herdr == "" {
+		herdr = "herdr"
+	}
+	out, err := exec.Command(herdr, "plugin", "config-dir", pluginID).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/open_test.go
+++ b/open_test.go
@@ -1,0 +1,108 @@
+//
+// Date: 2026-07-23
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFindProject covers findProject's three resolution paths: an exact
+// case-sensitive match, a case-insensitive fallback, and a miss that reports the
+// available project names. A separate case checks the empty-set error.
+func TestFindProject(t *testing.T) {
+	projects := []Project{
+		{Name: "app.harbor.my"},
+		{Name: "harbor-sysadmin"},
+	}
+
+	// Exact match wins.
+	got, err := findProject(projects, "harbor-sysadmin")
+	if err != nil {
+		t.Fatalf("exact match: unexpected error: %v", err)
+	}
+	if got.Name != "harbor-sysadmin" {
+		t.Fatalf("exact match: got %q, want %q", got.Name, "harbor-sysadmin")
+	}
+
+	// Case-insensitive fallback resolves when the exact case differs.
+	got, err = findProject(projects, "Harbor-Sysadmin")
+	if err != nil {
+		t.Fatalf("case-insensitive match: unexpected error: %v", err)
+	}
+	if got.Name != "harbor-sysadmin" {
+		t.Fatalf("case-insensitive match: got %q, want %q", got.Name, "harbor-sysadmin")
+	}
+
+	// A miss names the bad input and lists every available project.
+	_, err = findProject(projects, "nope")
+	if err == nil {
+		t.Fatal("no match: expected an error, got nil")
+	}
+	for _, want := range []string{"nope", "app.harbor.my", "harbor-sysadmin"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("no match: error %q is missing %q", err.Error(), want)
+		}
+	}
+
+	// An empty project set returns a distinct, clear error.
+	if _, err := findProject(nil, "anything"); err == nil {
+		t.Fatal("empty set: expected an error, got nil")
+	}
+}
+
+// TestHerdrManagedConfigDir confirms herdrManagedConfigDir returns herdr's
+// (whitespace-trimmed) output on success and "" when the herdr binary fails,
+// using a fake herdr located via HERDR_BIN_PATH so the test never needs a real one.
+func TestHerdrManagedConfigDir(t *testing.T) {
+	// Success: fake herdr prints a path with surrounding whitespace.
+	t.Setenv("HERDR_BIN_PATH", writeFakeHerdr(t, "#!/bin/sh\necho '  /managed/dir  '\n"))
+	if got := herdrManagedConfigDir(); got != "/managed/dir" {
+		t.Fatalf("herdrManagedConfigDir = %q, want %q", got, "/managed/dir")
+	}
+
+	// Failure: fake herdr exits non-zero, so we get "".
+	t.Setenv("HERDR_BIN_PATH", writeFakeHerdr(t, "#!/bin/sh\nexit 1\n"))
+	if got := herdrManagedConfigDir(); got != "" {
+		t.Fatalf("herdrManagedConfigDir on failure = %q, want empty", got)
+	}
+}
+
+// TestEnsureManagedConfigDir confirms ensureManagedConfigDir exports the queried
+// directory when HERDR_PLUGIN_CONFIG_DIR is unset, and leaves an already-set value
+// untouched (never consulting herdr in that case).
+func TestEnsureManagedConfigDir(t *testing.T) {
+	t.Setenv("HERDR_BIN_PATH", writeFakeHerdr(t, "#!/bin/sh\necho /queried/dir\n"))
+
+	// Unset → the queried directory is exported.
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", "")
+	ensureManagedConfigDir()
+	if got := os.Getenv("HERDR_PLUGIN_CONFIG_DIR"); got != "/queried/dir" {
+		t.Fatalf("unset case: HERDR_PLUGIN_CONFIG_DIR = %q, want %q", got, "/queried/dir")
+	}
+
+	// Already set → left exactly as-is.
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", "/preset/dir")
+	ensureManagedConfigDir()
+	if got := os.Getenv("HERDR_PLUGIN_CONFIG_DIR"); got != "/preset/dir" {
+		t.Fatalf("preset case: HERDR_PLUGIN_CONFIG_DIR = %q, want %q", got, "/preset/dir")
+	}
+}
+
+// writeFakeHerdr writes an executable shell script that stands in for the herdr
+// binary and returns its path. The script ignores its arguments, so it serves any
+// `herdr ...` invocation the code under test makes.
+func writeFakeHerdr(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "herdr")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake herdr: %v", err)
+	}
+	return path
+}

--- a/projects.go
+++ b/projects.go
@@ -31,7 +31,7 @@ func launchProjects() {
 	}
 
 	cmd := exec.Command(herdr, "plugin", "pane", "open",
-		"--plugin", "cloudmanic.herdr-plus",
+		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("picker"),
 		"--placement", "zoomed",
 	)

--- a/quickactions.go
+++ b/quickactions.go
@@ -34,7 +34,7 @@ func launchQuickActions() {
 
 	args := []string{
 		"plugin", "pane", "open",
-		"--plugin", "cloudmanic.herdr-plus",
+		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("quick-actions-picker"),
 		"--placement", "overlay",
 		// Hand the launch context to the picker as a single shell-safe env var.

--- a/util.go
+++ b/util.go
@@ -11,6 +11,11 @@ import (
 	"os"
 )
 
+// pluginID is herdr-plus's plugin id, matching the `id` field in
+// herdr-plugin.toml. It is how herdr identifies the plugin — used when opening
+// plugin-owned panes and when asking herdr for our managed config directory.
+const pluginID = "cloudmanic.herdr-plus"
+
 // errExit prints a "herdr-plus:"-prefixed message to stderr and exits non-zero.
 func errExit(args ...any) {
 	fmt.Fprintln(os.Stderr, append([]any{"herdr-plus:"}, args...)...)


### PR DESCRIPTION
## What

Adds a headless `open <name>` subcommand so a project's workspace can be opened **by name, without the interactive fuzzy picker**:

```sh
herdr-plus open harbor-sysadmin
```

This is the scriptable entry point the picker never gave us — for shell aliases, keybindings, and AI agents that want to spin up a known workspace in one shot.

## How

- **`main.go`** — registers the `open` subcommand.
- **`open.go`** — `runOpen` loads the project templates, resolves the name via `findProject` (exact match first, then a case-insensitive fallback; a miss errors with the list of available projects), and hands the project to the existing **`openProject`** — the exact code path the picker runs on Enter. So the template → workspace layout has a **single source of truth** regardless of how it's opened.
- **Config discovery** — when herdr runs us as a plugin it injects `HERDR_PLUGIN_CONFIG_DIR`, but a direct `herdr-plus open ...` from a shell has no such injection, so config would look in the standalone `~/.config/herdr-plus` and miss the managed templates. `ensureManagedConfigDir` asks the running herdr (`herdr plugin config-dir <id>`) for its managed dir and exports it — doing exactly what herdr would have done — so `open` finds the same templates the picker shows. `configBaseDir` is intentionally left untouched (the picker path already short-circuits on the injected env var).
- **`util.go`** — a shared `pluginID` constant, also swapped into the existing `--plugin` call sites in `projects.go` / `quickactions.go`.
- **README** — documents the subcommand under Projects.

## Testing

- `open_test.go` covers `findProject` (all resolution paths) and the config-dir discovery helpers, using a fake `herdr` located via `HERDR_BIN_PATH` so the tests stay deterministic with no real herdr present.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` all pass locally.
- Manually verified end-to-end against a running herdr: usage/not-found error paths, managed-dir discovery (bogus name now lists all projects), and a real `open dotfiles` that materialized the full 4-tab workspace.

## Notes

- Version is intentionally **not** bumped — the release pipeline auto-bumps the patch on merge.
- `open` is a direct-invocation subcommand, not a manifest action (actions take fixed commands, so they can't accept a runtime `<name>`).