### PR TITLE
Add ctrl+k / ctrl+j as navigation keys in both pickers

### DIFF
--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -230,10 +230,10 @@ func (m projectsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "esc":
 			m.quitting = true
 			return m, tea.Quit
-		case "up", "ctrl+p":
+		case "up", "ctrl+p", "ctrl+k":
 			m.list.moveUp()
 			return m, nil
-		case "down", "ctrl+n":
+		case "down", "ctrl+n", "ctrl+j":
 			m.list.moveDown()
 			return m, nil
 		case "enter":

--- a/projectsmodel_test.go
+++ b/projectsmodel_test.go
@@ -377,3 +377,26 @@ func TestProjectsModelEmptyState(t *testing.T) {
 		t.Fatal("empty-state must never choose a project")
 	}
 }
+
+// TestProjectsModelVimNavKeys confirms ctrl+j / ctrl+k walk the highlight the
+// same way ctrl+n / ctrl+p do. Plain j/k cannot be used because the browser is
+// always filtering — every printable rune goes to the query.
+func TestProjectsModelVimNavKeys(t *testing.T) {
+	m := newProjectsModel(sampleProjects(), "/cfg/projects", "")
+	m = step(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if got := m.list.selectedIndex(); got != 1 {
+		t.Fatalf("after ctrl+j selected index = %d, want 1 (Bravo)", got)
+	}
+
+	m = step(t, m, tea.KeyMsg{Type: tea.KeyCtrlK})
+	if got := m.list.selectedIndex(); got != 0 {
+		t.Fatalf("after ctrl+k selected index = %d, want 0 (Alpha)", got)
+	}
+
+	// The query stays untouched: these are navigation keys, not input.
+	if got := m.list.input.Value(); got != "" {
+		t.Fatalf("ctrl+j/ctrl+k leaked into the query: %q", got)
+	}
+}

--- a/quickactionspicker.go
+++ b/quickactionspicker.go
@@ -188,10 +188,10 @@ func (m pickerModel) updateActions(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c", "esc":
 		m.quitting = true
 		return m, tea.Quit
-	case "up", "ctrl+p":
+	case "up", "ctrl+p", "ctrl+k":
 		m.actionList.moveUp()
 		return m, nil
-	case "down", "ctrl+n":
+	case "down", "ctrl+n", "ctrl+j":
 		m.actionList.moveDown()
 		return m, nil
 	case "enter":
@@ -239,10 +239,10 @@ func (m pickerModel) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.current = nil
 		m.stage = stageActions
 		return m, textinput.Blink
-	case "up", "ctrl+p":
+	case "up", "ctrl+p", "ctrl+k":
 		m.optionList.moveUp()
 		return m, nil
-	case "down", "ctrl+n":
+	case "down", "ctrl+n", "ctrl+j":
 		m.optionList.moveDown()
 		return m, nil
 	case "enter":

--- a/quickactionspicker_test.go
+++ b/quickactionspicker_test.go
@@ -133,3 +133,29 @@ func TestPickerMouseWheelMoves(t *testing.T) {
 		t.Fatalf("after wheel down selected ref = %d, want 1 (test)", got)
 	}
 }
+
+// TestPickerVimNavKeys confirms ctrl+j / ctrl+k move the highlight in the action
+// list, matching ctrl+n / ctrl+p. Plain j/k are unavailable: the launcher always
+// filters, so printable runes belong to the query.
+func TestPickerVimNavKeys(t *testing.T) {
+	actions := []Action{
+		{Name: "build", Command: "make build", origin: originGlobal},
+		{Name: "test", Command: "make test", origin: originGlobal},
+	}
+	m := newPickerModel(RunContext{}, actions)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	pm := updated.(pickerModel)
+	if got := pm.actionList.selectedIndex(); got != 1 {
+		t.Fatalf("after ctrl+j selected index = %d, want 1 (test)", got)
+	}
+	if pm.chosen != nil {
+		t.Fatal("ctrl+j should not run an action")
+	}
+
+	updated, _ = pm.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	pm = updated.(pickerModel)
+	if got := pm.actionList.selectedIndex(); got != 0 {
+		t.Fatalf("after ctrl+k selected index = %d, want 0 (build)", got)
+	}
+}

--- a/www/content/docs/projects.md
+++ b/www/content/docs/projects.md
@@ -13,6 +13,9 @@ Trigger the `cloudmanic.herdr-plus.projects` action — from herdr's action menu
 a [bound key](../keybindings/) — and herdr-plus opens a **full-screen fuzzy
 browser** of your projects.
 
+Move the highlight with `↑`/`↓` (or `ctrl+p`/`ctrl+n`, `ctrl+k`/`ctrl+j`); typing
+filters the list, so plain `j`/`k` go to the query rather than moving.
+
 Fuzzy-find a project, press `enter` (or click it), and herdr-plus spins up a whole
 workspace — every tab created, every split laid out, and every startup command
 running — then drops you straight into it. Cancel with `esc` to close the browser

--- a/www/content/docs/quick-actions.md
+++ b/www/content/docs/quick-actions.md
@@ -13,7 +13,8 @@ Trigger the `cloudmanic.herdr-plus.quick-actions` action — from herdr's action
 menu, or a [bound key](../keybindings/) — and herdr-plus opens a focused launcher
 over your workspace. The launcher is a fuzzy finder over your actions:
 
-- `↑`/`↓` (or `ctrl+p`/`ctrl+n`, or the mouse wheel) move the highlight.
+- `↑`/`↓` (or `ctrl+p`/`ctrl+n`, `ctrl+k`/`ctrl+j`, or the mouse wheel) move the
+  highlight.
 - Type to filter the list.
 - `enter` or a left-click runs the highlighted action.
 - `esc` (or `ctrl+c`) cancels.


### PR DESCRIPTION
## Problem

Both pickers move the highlight with `up`/`down` and `ctrl+p`/`ctrl+n`. Coming from vim keybindings, `ctrl+k`/`ctrl+j` is the pair my fingers reach for, and it isn't bound to anything.

Plain `j`/`k` can't be navigation here — both pickers are always filtering, so every printable rune has to go to the query. The ctrl-modified pair is free, and it's the usual answer for fuzzy finders in this situation (fzf binds `ctrl-j`/`ctrl-k` by default).

## Change

Adds `"ctrl+k"` / `"ctrl+j"` alongside the existing cases in three places:

- `projectsmodel.go` — the projects list
- `quickactionspicker.go` — the action list and the select-option list

Purely additive: every existing key keeps working. The form stage has no list, so it's untouched.

### Does this shadow `enter`?

No. bubbletea (v1.3.10, `key.go`) maps LF `0x0A` → `ctrl+j` and CR `0x0D` → `enter` as distinct key types, and terminals send CR for Return. Worth flagging only because the two share a byte lineage historically.

## Tests

Added `TestProjectsModelVimNavKeys` and `TestPickerVimNavKeys` — each walks the highlight down with `ctrl+j`, back up with `ctrl+k`, and asserts nothing leaked into the query and no action ran. `go test ./...` and `go vet ./...` pass.

(`gofmt -l` flags `shell.go` / `shell_test.go` on a clean checkout too — pre-existing, left alone.)

## Docs

Updated the nav-key line in `www/content/docs/quick-actions.md` and added the equivalent to `projects.md`, including why plain `j`/`k` aren't available.
