### PR TITLE
feat: offer projects when herdr creates a new workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ herdr-plus is an add-on for [herdr](https://herdr.dev), built as a first-class
 
 - **[Projects](#projects)** — declarative herdr-workspace templates you fuzzy-pick
   to spin up a whole workspace (every tab and pane, every startup command) in one
-  keypress.
+  keypress. Optionally, [herdr's own New button](#new-workspace--pick-a-project)
+  offers them too.
 - **[Quick Actions](#quick-actions)** — a fuzzy launcher for one-off
   actions/scripts, run in the directory you launched from.
 
@@ -82,6 +83,9 @@ placement = "zoomed" # overlay, popup, split, tab, or zoomed; default is zoomed
 
 [quick_actions]
 placement = "overlay" # overlay, popup, split, tab, or zoomed; default is overlay
+
+[new_workspace]
+mode = "picker" # "off" (default) or "picker" — see New workspace → pick a project
 ```
 
 `placement` controls how herdr opens each picker — see herdr's
@@ -233,6 +237,44 @@ ratio = 0.3
 ```
 
 A tab uses *either* `command` *or* `[[tabs.panes]]`, not both.
+
+### New workspace → pick a project
+
+herdr's sidebar **New** button (and the `new_workspace` keybinding) creates an
+empty workspace rooted at the directory you are already in. Turn this on and it
+offers your projects instead:
+
+```toml
+[new_workspace]
+mode = "picker"   # default: "off"
+```
+
+With it on, every new, empty workspace opens the projects browser over itself.
+Pick a project and herdr-plus builds that project's workspace and closes the empty
+one it replaced; **esc** keeps the empty workspace exactly as herdr made it, so a
+plain workspace is always one keypress away. **ctrl+g** still opens the highlighted
+project as a git worktree.
+
+It is deliberately conservative — herdr fires `workspace.created` for *every*
+workspace, so the handler stands down for anything that is not the blank workspace
+you just asked for:
+
+| It leaves the workspace alone when… | Why |
+| --- | --- |
+| `mode` is `"off"` (or unset) | the feature is opt-in |
+| the workspace belongs to a git worktree | [worktree layouts](#worktree-auto-layout) own those |
+| it was created in the background | a full-screen picker would be a surprise |
+| it already has tabs or panes | something already filled it |
+| herdr-plus created it | otherwise opening a project would ask again, forever |
+| no projects are defined | the browser would have nothing to offer |
+
+Every skip is logged with its reason in
+`herdr plugin log list --plugin cloudmanic.herdr-plus`.
+
+This reacts to the workspace rather than replacing the button: herdr's plugin API
+has no hook on the sidebar's New button itself, and `workspace.created` is a
+notification, not something a plugin can cancel. The visible cost is a brief flash
+of the empty workspace before the browser covers it.
 
 ## Quick Actions
 

--- a/config.go
+++ b/config.go
@@ -63,6 +63,15 @@ type PluginConfig struct {
 		// overlay.
 		Placement string `toml:"placement"`
 	} `toml:"quick_actions"`
+
+	NewWorkspace struct {
+		// Mode decides what happens when herdr creates a new, empty workspace —
+		// the sidebar's New button or the new_workspace keybinding. "off" (the
+		// default) leaves herdr alone; "picker" opens the projects browser over
+		// the new workspace and replaces it with the chosen project. See
+		// newWorkspaceMode for the validated values.
+		Mode string `toml:"mode"`
+	} `toml:"new_workspace"`
 }
 
 // resolvePlacement returns configured if it is a valid herdr pane placement,

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -95,6 +95,26 @@ platforms = ["windows"]
 # an interactive bubbletea TUI, and -NonInteractive would break its input.
 command = ["powershell", "-NoProfile", "-Command", "& .\\bin\\herdr-plus.exe projects-ui"]
 
+# new-workspace-picker — the projects browser shown over a brand-new, empty
+# workspace, opened by the workspace.created handler below (never by a keybinding).
+# It is a separate entrypoint from `picker` because it does more: choosing a
+# project here also closes the empty workspace it replaces. Cancelling keeps that
+# workspace, so herdr's plain New behaviour is always one esc away.
+[[panes]]
+id = "new-workspace-picker"
+title = "Herdr Plus: New workspace"
+placement = "zoomed"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "new-workspace-ui"]
+
+[[panes]]
+id = "new-workspace-picker-windows"
+title = "Herdr Plus: New workspace"
+placement = "zoomed"
+platforms = ["windows"]
+# Omits -NonInteractive on purpose — interactive TUI pane; see picker-windows.
+command = ["powershell", "-NoProfile", "-Command", "& .\\bin\\herdr-plus.exe new-workspace-ui"]
+
 # quick-actions — a fuzzy launcher for one-off actions/scripts (command, select,
 # or form), loaded from ~/.config/herdr-plus/quick-actions/ (plus a repo's own
 # .herdr-plus/quick-actions/). Commands template against and run in the directory
@@ -173,3 +193,23 @@ command = ["./bin/herdr-plus", "on-worktree"]
 on = "worktree.opened"
 platforms = ["windows"]
 command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe on-worktree"]
+
+# workspace.created — herdr fires this for every new workspace, including the
+# empty one its sidebar's New button (and the new_workspace keybinding) creates in
+# the current directory. herdr exposes no hook on that button itself, so this is
+# how herdr-plus offers your projects there: with `[new_workspace] mode = "picker"`
+# in config.toml the handler opens the projects browser over the new workspace and
+# swaps it for the project you choose; esc keeps the empty workspace. Without that
+# setting the handler returns immediately and logs nothing. It also stands down for
+# worktree workspaces, background workspaces, workspaces that already have tabs,
+# and the workspaces herdr-plus creates itself. herdr runs this for you — never
+# invoke it by hand. Output is captured in the plugin log.
+[[events]]
+on = "workspace.created"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "on-workspace"]
+
+[[events]]
+on = "workspace.created"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe on-workspace"]

--- a/herdr.go
+++ b/herdr.go
@@ -389,6 +389,29 @@ func (c *herdrClient) workspaceTargetPane(workspaceID, tabID string) (string, er
 	return "", fmt.Errorf("workspace %s has no panes", workspaceID)
 }
 
+// waitForWorkspaceTargetPane is workspaceTargetPane with a deadline, for callers
+// racing a workspace into existence. herdr emits workspace.created before the
+// workspace's root pane is necessarily visible to pane.list — the ordering
+// differs between the sidebar's New button and an API-driven create — so a
+// handler that looks once sees an empty workspace and gives up. Polling until the
+// root pane appears makes the handler independent of that ordering.
+//
+// It reports the last error on timeout, so a workspace that genuinely never gets
+// a pane still fails with the reason rather than a bare timeout.
+func (c *herdrClient) waitForWorkspaceTargetPane(workspaceID, tabID string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		pane, err := c.workspaceTargetPane(workspaceID, tabID)
+		if err == nil {
+			return pane, nil
+		}
+		if time.Now().After(deadline) {
+			return "", err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // paneCandidate is the slice of pane.list that choosing an anchor pane needs.
 type paneCandidate struct {
 	PaneID      string `json:"pane_id"`

--- a/herdr.go
+++ b/herdr.go
@@ -365,6 +365,60 @@ func (c *herdrClient) workspacePaneCount(workspaceID string) (int, error) {
 	return n, nil
 }
 
+// workspaceTargetPane returns the pane a new pane should be anchored to when
+// opening one into a workspace we are not running inside. herdr's zoomed and
+// split plugin panes are positioned relative to an existing pane rather than to a
+// workspace, so the new-workspace picker has to name one.
+//
+// Preference order within the workspace: the pane in the given tab (when the
+// caller knows which tab, e.g. from a workspace.created payload), then the
+// focused one — a freshly created workspace focuses its root pane — then whatever
+// herdr listed first. The tab filter is dropped rather than obeyed to the point of
+// returning nothing, so an unexpected tab id degrades to "some pane in the right
+// workspace" instead of an error.
+func (c *herdrClient) workspaceTargetPane(workspaceID, tabID string) (string, error) {
+	var out struct {
+		Panes []paneCandidate `json:"panes"`
+	}
+	if err := c.call("pane.list", map[string]any{}, &out); err != nil {
+		return "", err
+	}
+	if pane := pickTargetPane(out.Panes, workspaceID, tabID); pane != "" {
+		return pane, nil
+	}
+	return "", fmt.Errorf("workspace %s has no panes", workspaceID)
+}
+
+// paneCandidate is the slice of pane.list that choosing an anchor pane needs.
+type paneCandidate struct {
+	PaneID      string `json:"pane_id"`
+	TabID       string `json:"tab_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Focused     bool   `json:"focused"`
+}
+
+// pickTargetPane applies workspaceTargetPane's preference order to a pane list,
+// returning "" when the workspace has no panes at all. It is split out from the
+// socket call so the choice itself is testable.
+func pickTargetPane(panes []paneCandidate, workspaceID, tabID string) string {
+	first, inTab, focused := "", "", ""
+	for _, p := range panes {
+		if p.WorkspaceID != workspaceID {
+			continue
+		}
+		if first == "" {
+			first = p.PaneID
+		}
+		if p.Focused && focused == "" {
+			focused = p.PaneID
+		}
+		if tabID != "" && p.TabID == tabID && inTab == "" {
+			inTab = p.PaneID
+		}
+	}
+	return firstNonEmpty(inTab, focused, first)
+}
+
 // paneGet fetches metadata for a single pane, including its working directory
 // and the tab/workspace it belongs to.
 func (c *herdrClient) paneGet(paneID string) (paneInfo, error) {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,11 @@ import (
 //   - "on-worktree" is herdr's worktree event handler, run for both worktree.created
 //     and worktree.opened (via the [[events]] entries in herdr-plugin.toml), not the
 //     user.
+//   - "on-workspace" is herdr's workspace.created event handler: with
+//     `[new_workspace] mode = "picker"` it opens the projects browser over a new,
+//     empty workspace. Also run by herdr, never by hand.
+//   - "new-workspace-ui" is that browser; herdr runs it inside the pane the handler
+//     opens (the `new-workspace-picker` entrypoint).
 //
 // The bare binary has no launcher of its own, so it just prints usage.
 func main() {
@@ -54,6 +59,12 @@ func main() {
 			return
 		case "on-worktree":
 			runOnWorktreeEvent(os.Args[2:])
+			return
+		case "on-workspace":
+			runOnWorkspaceEvent(os.Args[2:])
+			return
+		case "new-workspace-ui":
+			runNewWorkspaceUI()
 			return
 		case "version", "--version", "-v", "-V":
 			fmt.Println("herdr-plus", version.Version)

--- a/newworkspace.go
+++ b/newworkspace.go
@@ -198,6 +198,19 @@ func projectNames(projects []Project) []string {
 // New the user makes a moment later.
 const newWorkspaceInterceptTTL = 15 * time.Second
 
+// newWorkspacePaneTimeout bounds the wait for the new workspace's root pane to
+// become visible to pane.list. herdr emits workspace.created before that pane is
+// necessarily listed — the ordering differs between the sidebar's New button and
+// an API-driven create — and the picker needs a pane to anchor to.
+//
+// It is deliberately generous. Creating a workspace wakes every plugin subscribed
+// to workspace.created at once, and under that burst the pane has been observed
+// taking several seconds to become visible to this handler even though it exists
+// almost immediately. Overshooting costs a handler process sleeping in the
+// background; undershooting means the browser never opens. The ceiling is herdr's
+// own limit on an event command, which cuts one off well before this expires.
+const newWorkspacePaneTimeout = 20 * time.Second
+
 // newWorkspaceInterceptMarker is the marker file's name inside the plugin state
 // directory.
 const newWorkspaceInterceptMarker = "suppress-new-workspace-intercept"
@@ -305,9 +318,16 @@ func runOnWorkspaceEvent(_ []string) {
 	if err != nil {
 		errExit(err)
 	}
-	target, err := client.workspaceTargetPane(ev.WorkspaceID, ev.ActiveTabID)
+	started := time.Now()
+	target, err := client.waitForWorkspaceTargetPane(ev.WorkspaceID, ev.ActiveTabID, newWorkspacePaneTimeout)
 	if err != nil {
 		errExit("could not find a pane in the new workspace:", err)
+	}
+	// Record a non-trivial wait: it is the one part of this handler whose timing
+	// depends on how busy herdr is, so the log should say when it was close to
+	// the limit.
+	if waited := time.Since(started); waited > time.Second {
+		fmt.Printf("herdr-plus: waited %s for the new workspace's root pane.\n", waited.Round(time.Millisecond))
 	}
 
 	if err := openNewWorkspacePicker(ev.WorkspaceID, target); err != nil {

--- a/newworkspace.go
+++ b/newworkspace.go
@@ -59,6 +59,10 @@ func (c PluginConfig) newWorkspaceMode() (string, error) {
 // whether it belongs to a git worktree (those are the worktree handler's job).
 type newWorkspaceEvent struct {
 	WorkspaceID string
+	// ActiveTabID is the workspace's only tab at creation time. It is not part of
+	// the intercept decision — it just anchors the picker pane (see
+	// workspaceTargetPane).
+	ActiveTabID string
 	Label       string
 	Focused     bool
 	PaneCount   int
@@ -74,6 +78,7 @@ type workspaceCreatedPayload struct {
 	Data struct {
 		Workspace struct {
 			WorkspaceID string `json:"workspace_id"`
+			ActiveTabID string `json:"active_tab_id"`
 			Label       string `json:"label"`
 			Focused     bool   `json:"focused"`
 			PaneCount   int    `json:"pane_count"`
@@ -102,6 +107,7 @@ func parseNewWorkspaceEvent(eventJSON string, getenv func(string) string) (newWo
 	ws := p.Data.Workspace
 	return newWorkspaceEvent{
 		WorkspaceID: firstNonEmpty(ws.WorkspaceID, getenv("HERDR_WORKSPACE_ID")),
+		ActiveTabID: firstNonEmpty(ws.ActiveTabID, getenv("HERDR_TAB_ID")),
 		Label:       ws.Label,
 		Focused:     ws.Focused,
 		PaneCount:   ws.PaneCount,
@@ -293,20 +299,32 @@ func runOnWorkspaceEvent(_ []string) {
 		return
 	}
 
-	if err := openNewWorkspacePicker(ev.WorkspaceID); err != nil {
+	// The picker pane is anchored to a pane in the new workspace, so we need a
+	// socket connection of our own to find one.
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+	target, err := client.workspaceTargetPane(ev.WorkspaceID, ev.ActiveTabID)
+	if err != nil {
+		errExit("could not find a pane in the new workspace:", err)
+	}
+
+	if err := openNewWorkspacePicker(ev.WorkspaceID, target); err != nil {
 		errExit("could not open the projects browser over the new workspace:", err)
 	}
 	fmt.Printf("herdr-plus: opened the projects browser over new workspace %q.\n", ev.WorkspaceID)
 }
 
 // openNewWorkspacePicker asks herdr to open the new-workspace projects browser as
-// a zoomed pane inside the workspace that was just created. Pinning it with
-// --workspace (rather than relying on which workspace happens to be focused when
-// the pane opens) keeps the picker and the workspace it will replace together,
-// and --env hands the pane that same id so it never has to guess. It shells out
-// to the herdr CLI, like the projects action does, because the event handler runs
-// server-side with no pane of its own.
-func openNewWorkspacePicker(workspaceID string) error {
+// a zoomed pane inside the workspace that was just created. A zoomed plugin pane
+// is positioned relative to an existing pane, not to a workspace, so it is pinned
+// with --target-pane (a pane in the new workspace) rather than left to land
+// wherever focus happens to be; --env hands the pane the workspace id it will
+// replace so it never has to guess. It shells out to the herdr CLI, like the
+// projects action does, because the event handler runs server-side with no pane of
+// its own.
+func openNewWorkspacePicker(workspaceID, targetPaneID string) error {
 	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
 	// call back into the CLI from a plugin command.
 	herdr := os.Getenv("HERDR_BIN_PATH")
@@ -318,7 +336,7 @@ func openNewWorkspacePicker(workspaceID string) error {
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("new-workspace-picker"),
 		"--placement", "zoomed",
-		"--workspace", workspaceID,
+		"--target-pane", targetPaneID,
 		"--focus",
 		"--env", newWorkspaceTargetEnv+"="+workspaceID,
 	)

--- a/newworkspace.go
+++ b/newworkspace.go
@@ -1,0 +1,386 @@
+//
+// Date: 2026-08-05
+// Author: Stephane Adandedjan (Stephane.Adandedjan@goline.ch)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// This file implements the "new workspace → pick a project" flow.
+//
+// herdr's sidebar has a New button (and a new_workspace keybinding) that creates
+// an empty workspace rooted at the current directory. herdr's plugin API has no
+// hook for that button — a plugin cannot decorate it with a menu, and no event is
+// cancellable — but it does fire workspace.created afterwards. So instead of
+// replacing the button we react to it: when the new workspace is still empty, we
+// open the projects browser over it and, once a project is chosen, we build that
+// project's workspace and close the empty one it replaced.
+//
+// The feature is opt-in. Without `[new_workspace] mode = "picker"` in
+// config.toml the handler is a quiet no-op, exactly like a worktree layout that
+// matches nothing.
+
+// New-workspace modes, the accepted values of `[new_workspace] mode` in
+// config.toml. "off" (the default) leaves herdr's New button alone; "picker"
+// opens the projects browser over each new, empty workspace.
+const (
+	newWorkspaceModeOff    = "off"
+	newWorkspaceModePicker = "picker"
+)
+
+// newWorkspaceMode returns the configured, validated mode. An unset value means
+// "off" so the feature stays opt-in; an unrecognized value is an error rather
+// than a silent fallback, so a typo in config.toml surfaces in the plugin log
+// instead of quietly disabling the feature the user asked for.
+func (c PluginConfig) newWorkspaceMode() (string, error) {
+	switch m := strings.ToLower(strings.TrimSpace(c.NewWorkspace.Mode)); m {
+	case "":
+		return newWorkspaceModeOff, nil
+	case newWorkspaceModeOff, newWorkspaceModePicker:
+		return m, nil
+	default:
+		return newWorkspaceModeOff, fmt.Errorf("invalid new_workspace.mode %q (want %q or %q)", c.NewWorkspace.Mode, newWorkspaceModeOff, newWorkspaceModePicker)
+	}
+}
+
+// newWorkspaceEvent is the subset of the workspace.created payload the intercept
+// decision needs: which workspace was created, how it is labeled, whether it is
+// the workspace the user is now looking at, whether it is still empty, and
+// whether it belongs to a git worktree (those are the worktree handler's job).
+type newWorkspaceEvent struct {
+	WorkspaceID string
+	Label       string
+	Focused     bool
+	PaneCount   int
+	TabCount    int
+	IsWorktree  bool
+}
+
+// workspaceCreatedPayload mirrors the JSON herdr puts in HERDR_PLUGIN_EVENT_JSON
+// for a workspace.created event. Only the fields we use are declared. worktree is
+// a pointer because herdr sends null for an ordinary (non-worktree) workspace,
+// and that null is precisely the signal we branch on.
+type workspaceCreatedPayload struct {
+	Data struct {
+		Workspace struct {
+			WorkspaceID string `json:"workspace_id"`
+			Label       string `json:"label"`
+			Focused     bool   `json:"focused"`
+			PaneCount   int    `json:"pane_count"`
+			TabCount    int    `json:"tab_count"`
+			Worktree    *struct {
+				RepoName string `json:"repo_name"`
+			} `json:"worktree"`
+		} `json:"workspace"`
+	} `json:"data"`
+}
+
+// parseNewWorkspaceEvent builds a newWorkspaceEvent from the event JSON and the
+// plugin environment. Unlike the worktree handler, the payload wins over
+// HERDR_WORKSPACE_ID: the payload names the workspace this event is *about*,
+// while the environment variable describes the caller's context — and a workspace
+// created in the background is not the focused one. The env var is only a
+// fallback for an id-less payload. getenv is injected so parsing is unit-testable
+// without touching the real environment.
+func parseNewWorkspaceEvent(eventJSON string, getenv func(string) string) (newWorkspaceEvent, error) {
+	var p workspaceCreatedPayload
+	if strings.TrimSpace(eventJSON) != "" {
+		if err := json.Unmarshal([]byte(eventJSON), &p); err != nil {
+			return newWorkspaceEvent{}, fmt.Errorf("parse HERDR_PLUGIN_EVENT_JSON: %w", err)
+		}
+	}
+	ws := p.Data.Workspace
+	return newWorkspaceEvent{
+		WorkspaceID: firstNonEmpty(ws.WorkspaceID, getenv("HERDR_WORKSPACE_ID")),
+		Label:       ws.Label,
+		Focused:     ws.Focused,
+		PaneCount:   ws.PaneCount,
+		TabCount:    ws.TabCount,
+		IsWorktree:  ws.Worktree != nil,
+	}, nil
+}
+
+// decideNewWorkspaceIntercept is the whole intercept policy in one pure function:
+// given the event, the configured mode, the known project names, and whether a
+// herdr-plus-created workspace was expected, it says whether to open the picker
+// and — when not — why. Keeping it pure makes every guard testable without a
+// running herdr, which matters because a wrong "yes" here hijacks a workspace the
+// user meant to keep.
+//
+// The guards, in order of how cheaply they settle the question:
+//
+//   - mode: the feature is opt-in.
+//   - a missing workspace id: nothing to act on.
+//   - a worktree workspace: runOnWorktreeEvent owns those, and its layouts would
+//     fight the picker for the same panes.
+//   - an unfocused workspace: created in the background (by a script or the
+//     socket API), so popping a full-screen picker into it would be a surprise.
+//   - a workspace that already has tabs or panes: not the blank workspace the New
+//     button makes, so something already filled it.
+//   - suppressed: herdr-plus itself created this workspace (see
+//     suppressNewWorkspaceIntercept) — intercepting it would loop forever.
+//   - no projects: the picker would have nothing to offer.
+//   - a label matching a project: a second, belt-and-braces guard against the
+//     loop above, for the case where the suppression marker could not be written.
+func decideNewWorkspaceIntercept(ev newWorkspaceEvent, mode string, projectNames []string, suppressed bool) (bool, string) {
+	if mode != newWorkspaceModePicker {
+		return false, "new_workspace.mode is not " + newWorkspaceModePicker
+	}
+	if strings.TrimSpace(ev.WorkspaceID) == "" {
+		return false, "the event carries no workspace id"
+	}
+	if ev.IsWorktree {
+		return false, "it is a worktree workspace (the worktree layout handles those)"
+	}
+	if !ev.Focused {
+		return false, "it was created in the background"
+	}
+	if ev.PaneCount > 1 || ev.TabCount > 1 {
+		return false, fmt.Sprintf("it is not empty (%d tab(s), %d pane(s))", ev.TabCount, ev.PaneCount)
+	}
+	if suppressed {
+		return false, "herdr-plus created it"
+	}
+	if len(projectNames) == 0 {
+		return false, "no projects are defined"
+	}
+	if matchesProjectName(ev.Label, projectNames) {
+		return false, fmt.Sprintf("its label %q matches a project", ev.Label)
+	}
+	return true, ""
+}
+
+// matchesProjectName reports whether label is (case-insensitively) one of the
+// known project names — the signature of a workspace herdr-plus opened itself.
+func matchesProjectName(label string, projectNames []string) bool {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return false
+	}
+	for _, n := range projectNames {
+		if strings.EqualFold(strings.TrimSpace(n), label) {
+			return true
+		}
+	}
+	return false
+}
+
+// projectNames extracts the names of the loaded projects, the form
+// decideNewWorkspaceIntercept wants.
+func projectNames(projects []Project) []string {
+	names := make([]string, 0, len(projects))
+	for _, p := range projects {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// newWorkspaceInterceptTTL bounds how long a suppression marker stays valid. The
+// marker is written immediately before herdr-plus asks herdr for a workspace, so
+// the matching event follows within milliseconds; a short window is enough to
+// cover it while making sure a marker whose event never arrived cannot swallow a
+// New the user makes a moment later.
+const newWorkspaceInterceptTTL = 15 * time.Second
+
+// newWorkspaceInterceptMarker is the marker file's name inside the plugin state
+// directory.
+const newWorkspaceInterceptMarker = "suppress-new-workspace-intercept"
+
+// pluginStateDir returns the directory herdr gives the plugin for its own runtime
+// state (HERDR_PLUGIN_STATE_DIR, set for every plugin command). Outside herdr —
+// running the binary directly, dev, tests — it falls back to a herdr-plus folder
+// in the system temp directory, which is the right lifetime for a marker that is
+// only ever consumed seconds after it is written.
+func pluginStateDir() string {
+	if d := os.Getenv("HERDR_PLUGIN_STATE_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join(os.TempDir(), "herdr-plus")
+}
+
+// suppressNewWorkspaceIntercept records that herdr-plus is about to create a
+// workspace itself, so the workspace.created event it triggers is not mistaken
+// for the user pressing New. Callers write it *before* asking herdr to create the
+// workspace, which is what guarantees the marker is on disk by the time the event
+// handler runs.
+//
+// Best effort by design: a state directory we cannot write to must not stop a
+// project from opening, and decideNewWorkspaceIntercept's project-name guard
+// still catches the loop this prevents.
+func suppressNewWorkspaceIntercept() {
+	if err := writeNewWorkspaceSuppression(pluginStateDir()); err != nil {
+		fmt.Fprintf(os.Stderr, "herdr-plus: could not write the new-workspace suppression marker: %v\n", err)
+	}
+}
+
+// writeNewWorkspaceSuppression drops the marker file in dir, creating dir if
+// needed. The file's content is irrelevant — its modification time is the signal.
+func writeNewWorkspaceSuppression(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, newWorkspaceInterceptMarker), []byte("1"), 0o644)
+}
+
+// consumeNewWorkspaceSuppression reports whether a suppression marker was waiting
+// in dir and removes it, so a single marker suppresses a single event. A marker
+// older than ttl is treated as stale: it is still removed (housekeeping) but does
+// not suppress anything, so a create that never produced an event cannot silently
+// disable the next real one.
+func consumeNewWorkspaceSuppression(dir string, now time.Time, ttl time.Duration) bool {
+	path := filepath.Join(dir, newWorkspaceInterceptMarker)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	os.Remove(path)
+	return now.Sub(fi.ModTime()) <= ttl
+}
+
+// runOnWorkspaceEvent is the workspace.created handler herdr invokes (via the
+// [[events]] entry in herdr-plugin.toml). It fires for every workspace, including
+// the ones herdr-plus makes itself, so nearly all of its work is deciding to do
+// nothing — see decideNewWorkspaceIntercept. When it does decide to act it opens
+// the projects browser as a zoomed pane pinned to the new workspace; that pane
+// (runNewWorkspaceUI) owns everything from there.
+//
+// Output goes to stdout/stderr, which herdr captures in the plugin log
+// (`herdr plugin log list --plugin cloudmanic.herdr-plus`).
+func runOnWorkspaceEvent(_ []string) {
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		errExit(err)
+	}
+	mode, err := cfg.newWorkspaceMode()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Leave the common case — the feature switched off — completely silent: this
+	// handler runs for every workspace anyone creates, and logging each one would
+	// bury the plugin log in noise.
+	if mode != newWorkspaceModePicker {
+		return
+	}
+
+	ev, err := parseNewWorkspaceEvent(os.Getenv("HERDR_PLUGIN_EVENT_JSON"), os.Getenv)
+	if err != nil {
+		errExit("workspace event:", err)
+	}
+
+	projects, err := loadProjects()
+	if err != nil {
+		errExit(err)
+	}
+
+	// Consume the marker for this event whatever we decide next: it was written
+	// for exactly one workspace.created, and leaving it behind would suppress
+	// somebody else's.
+	suppressed := consumeNewWorkspaceSuppression(pluginStateDir(), time.Now(), newWorkspaceInterceptTTL)
+
+	if ok, reason := decideNewWorkspaceIntercept(ev, mode, projectNames(projects), suppressed); !ok {
+		fmt.Printf("herdr-plus: leaving new workspace %q alone: %s.\n", ev.WorkspaceID, reason)
+		return
+	}
+
+	if err := openNewWorkspacePicker(ev.WorkspaceID); err != nil {
+		errExit("could not open the projects browser over the new workspace:", err)
+	}
+	fmt.Printf("herdr-plus: opened the projects browser over new workspace %q.\n", ev.WorkspaceID)
+}
+
+// openNewWorkspacePicker asks herdr to open the new-workspace projects browser as
+// a zoomed pane inside the workspace that was just created. Pinning it with
+// --workspace (rather than relying on which workspace happens to be focused when
+// the pane opens) keeps the picker and the workspace it will replace together,
+// and --env hands the pane that same id so it never has to guess. It shells out
+// to the herdr CLI, like the projects action does, because the event handler runs
+// server-side with no pane of its own.
+func openNewWorkspacePicker(workspaceID string) error {
+	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
+	// call back into the CLI from a plugin command.
+	herdr := os.Getenv("HERDR_BIN_PATH")
+	if herdr == "" {
+		herdr = "herdr"
+	}
+
+	cmd := exec.Command(herdr, "plugin", "pane", "open",
+		"--plugin", pluginID,
+		"--entrypoint", paneEntrypoint("new-workspace-picker"),
+		"--placement", "zoomed",
+		"--workspace", workspaceID,
+		"--focus",
+		"--env", newWorkspaceTargetEnv+"="+workspaceID,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// newWorkspaceTargetEnv carries the id of the empty workspace the picker was
+// opened over — the one it replaces once a project is chosen. herdr sets it on
+// the pane process via `plugin pane open --env`.
+const newWorkspaceTargetEnv = "HERDR_PLUS_TARGET_WORKSPACE"
+
+// runNewWorkspaceUI renders the projects browser over a brand-new, empty
+// workspace and then swaps that workspace for the chosen project's. It runs
+// inside the zoomed pane openNewWorkspacePicker asks herdr for.
+//
+// Cancelling is a first-class outcome, not a failure: esc leaves the empty
+// workspace exactly as herdr's New button made it, which is how you still get a
+// plain workspace with the feature enabled.
+func runNewWorkspaceUI() {
+	// The pane is opened with the target id in its environment; HERDR_WORKSPACE_ID
+	// is the fallback, since herdr also tells a pane which workspace it lives in.
+	target := firstNonEmpty(os.Getenv(newWorkspaceTargetEnv), os.Getenv("HERDR_WORKSPACE_ID"))
+
+	choice, ok := pickProject(true)
+	if !ok {
+		fmt.Println("herdr-plus: no project chosen; keeping the empty workspace.")
+		return
+	}
+
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+
+	if choice.worktree {
+		if err := openProjectAsWorktree(client, choice.project, choice.branch); err != nil {
+			// Keep the empty workspace: it is the user's only way back.
+			errExit("could not open project as worktree:", err)
+		}
+	} else if err := openProject(client, choice.project); err != nil {
+		errExit("could not open project:", err)
+	}
+
+	fmt.Printf("herdr-plus: opened %s in place of new workspace %q.\n", choice.project.Name, target)
+
+	// Last, because it takes this pane down with it: the picker lives in the
+	// workspace being closed, so herdr kills this process as it tears the
+	// workspace apart. Everything above has already completed by then.
+	closeReplacedWorkspace(client, target)
+}
+
+// closeReplacedWorkspace closes the empty workspace the picker was opened over,
+// once the chosen project's workspace exists and is focused. It is deliberately
+// non-fatal: the project is already open, so failing to tidy up the empty
+// workspace is a wart in the sidebar, not a broken outcome.
+func closeReplacedWorkspace(client *herdrClient, workspaceID string) {
+	if strings.TrimSpace(workspaceID) == "" {
+		return
+	}
+	if err := client.workspaceClose(workspaceID); err != nil {
+		fmt.Fprintf(os.Stderr, "herdr-plus: could not close the replaced workspace %s: %v\n", workspaceID, err)
+	}
+}

--- a/newworkspace_test.go
+++ b/newworkspace_test.go
@@ -36,6 +36,9 @@ func TestParseNewWorkspaceEvent(t *testing.T) {
 	if ev.WorkspaceID != "w7" {
 		t.Errorf("WorkspaceID = %q, want %q", ev.WorkspaceID, "w7")
 	}
+	if ev.ActiveTabID != "w7:t1" {
+		t.Errorf("ActiveTabID = %q, want %q", ev.ActiveTabID, "w7:t1")
+	}
 	if ev.Label != "src" {
 		t.Errorf("Label = %q, want %q", ev.Label, "src")
 	}
@@ -232,6 +235,45 @@ func TestNewWorkspaceMode(t *testing.T) {
 		if got != c.want {
 			t.Errorf("newWorkspaceMode(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestPickTargetPane covers the anchor a zoomed picker pane is opened against.
+// herdr rejects a zoomed plugin pane that names no target pane, so getting this
+// wrong means the picker never appears — the pane list always includes other
+// workspaces' panes, and a new workspace may already hold another plugin's pane.
+func TestPickTargetPane(t *testing.T) {
+	panes := []paneCandidate{
+		{PaneID: "w1:p1", TabID: "w1:t1", WorkspaceID: "w1", Focused: true},
+		{PaneID: "w7:p2", TabID: "w7:t1", WorkspaceID: "w7"},
+		{PaneID: "w7:p3", TabID: "w7:t2", WorkspaceID: "w7", Focused: true},
+	}
+
+	cases := []struct {
+		name        string
+		panes       []paneCandidate
+		workspaceID string
+		tabID       string
+		want        string
+	}{
+		{name: "pane in the named tab wins", panes: panes, workspaceID: "w7", tabID: "w7:t1", want: "w7:p2"},
+		{name: "focused pane when the tab is unknown", panes: panes, workspaceID: "w7", want: "w7:p3"},
+		{name: "unknown tab falls back rather than failing", panes: panes, workspaceID: "w7", tabID: "w7:t9", want: "w7:p3"},
+		{
+			name:        "first pane when none is focused",
+			panes:       []paneCandidate{{PaneID: "w7:p2", TabID: "w7:t1", WorkspaceID: "w7"}},
+			workspaceID: "w7",
+			want:        "w7:p2",
+		},
+		{name: "no panes in the workspace", panes: panes, workspaceID: "w9", want: ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickTargetPane(c.panes, c.workspaceID, c.tabID); got != c.want {
+				t.Errorf("pickTargetPane = %q, want %q", got, c.want)
+			}
+		})
 	}
 }
 

--- a/newworkspace_test.go
+++ b/newworkspace_test.go
@@ -1,0 +1,257 @@
+//
+// Date: 2026-08-05
+// Author: Stephane Adandedjan (Stephane.Adandedjan@goline.ch)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// plainWorkspaceEventJSON is a HERDR_PLUGIN_EVENT_JSON payload for the
+// workspace.created herdr fires when the sidebar's New button makes an empty
+// workspace: focused, one tab, one pane, and a null worktree. Its shape mirrors
+// the captured worktree.created payload in worktree_test.go, which is what keeps
+// parseNewWorkspaceEvent honest against herdr's wire format.
+const plainWorkspaceEventJSON = `{"event":"workspace_created","data":{"type":"workspace_created","workspace":{"workspace_id":"w7","number":3,"label":"src","focused":true,"pane_count":1,"tab_count":1,"active_tab_id":"w7:t1","agent_status":"unknown","worktree":null}}}`
+
+// worktreeWorkspaceEventJSON is the same event for a workspace herdr created for
+// a git worktree — the case the worktree layout handler owns.
+const worktreeWorkspaceEventJSON = `{"event":"workspace_created","data":{"type":"workspace_created","workspace":{"workspace_id":"w8","number":4,"label":"wt-probe-repo","focused":true,"pane_count":1,"tab_count":1,"active_tab_id":"w8:t1","agent_status":"unknown","worktree":{"repo_key":"/tmp/wt-probe-repo/.git","repo_name":"wt-probe-repo","repo_root":"/tmp/wt-probe-repo","checkout_path":"/tmp/wt-probe-repo-wt","is_linked_worktree":true}}}}`
+
+// TestParseNewWorkspaceEvent parses the real payload and confirms every field the
+// intercept decision relies on is extracted, including the null worktree that
+// distinguishes a plain workspace from a worktree one.
+func TestParseNewWorkspaceEvent(t *testing.T) {
+	ev, err := parseNewWorkspaceEvent(plainWorkspaceEventJSON, mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseNewWorkspaceEvent: %v", err)
+	}
+
+	if ev.WorkspaceID != "w7" {
+		t.Errorf("WorkspaceID = %q, want %q", ev.WorkspaceID, "w7")
+	}
+	if ev.Label != "src" {
+		t.Errorf("Label = %q, want %q", ev.Label, "src")
+	}
+	if !ev.Focused {
+		t.Error("Focused = false, want true")
+	}
+	if ev.PaneCount != 1 || ev.TabCount != 1 {
+		t.Errorf("TabCount/PaneCount = %d/%d, want 1/1", ev.TabCount, ev.PaneCount)
+	}
+	if ev.IsWorktree {
+		t.Error("IsWorktree = true, want false for a null worktree")
+	}
+}
+
+// TestParseNewWorkspaceEventWorktree confirms a populated worktree object is
+// recognized, since that alone sends the handler back to sleep.
+func TestParseNewWorkspaceEventWorktree(t *testing.T) {
+	ev, err := parseNewWorkspaceEvent(worktreeWorkspaceEventJSON, mapEnv(nil))
+	if err != nil {
+		t.Fatalf("parseNewWorkspaceEvent: %v", err)
+	}
+	if !ev.IsWorktree {
+		t.Error("IsWorktree = false, want true")
+	}
+}
+
+// TestParseNewWorkspaceEventIDFallback confirms the workspace id falls back to
+// HERDR_WORKSPACE_ID only when the payload has none — the payload names the
+// workspace the event is about, the environment merely describes the caller.
+func TestParseNewWorkspaceEventIDFallback(t *testing.T) {
+	env := mapEnv(map[string]string{"HERDR_WORKSPACE_ID": "w1"})
+
+	ev, err := parseNewWorkspaceEvent(plainWorkspaceEventJSON, env)
+	if err != nil {
+		t.Fatalf("parseNewWorkspaceEvent: %v", err)
+	}
+	if ev.WorkspaceID != "w7" {
+		t.Errorf("WorkspaceID = %q, want the payload's %q", ev.WorkspaceID, "w7")
+	}
+
+	ev, err = parseNewWorkspaceEvent("", env)
+	if err != nil {
+		t.Fatalf("parseNewWorkspaceEvent (empty payload): %v", err)
+	}
+	if ev.WorkspaceID != "w1" {
+		t.Errorf("WorkspaceID = %q, want the env fallback %q", ev.WorkspaceID, "w1")
+	}
+}
+
+// TestParseNewWorkspaceEventInvalidJSON confirms malformed event JSON is an error
+// rather than a zero-value event that could be acted on.
+func TestParseNewWorkspaceEventInvalidJSON(t *testing.T) {
+	if _, err := parseNewWorkspaceEvent("{not json", mapEnv(nil)); err == nil {
+		t.Fatal("parseNewWorkspaceEvent accepted malformed JSON, want an error")
+	}
+}
+
+// TestDecideNewWorkspaceIntercept walks the whole policy: the one case that
+// intercepts, and every guard that must not. A wrong "yes" here hijacks a
+// workspace the user meant to keep, so each guard gets its own case.
+func TestDecideNewWorkspaceIntercept(t *testing.T) {
+	// empty is the workspace herdr's New button produces: focused, blank, plain.
+	empty := newWorkspaceEvent{WorkspaceID: "w7", Label: "src", Focused: true, PaneCount: 1, TabCount: 1}
+	names := []string{"Options Cafe", "Harbor"}
+
+	cases := []struct {
+		name       string
+		ev         newWorkspaceEvent
+		mode       string
+		names      []string
+		suppressed bool
+		want       bool
+	}{
+		{name: "empty focused workspace", ev: empty, mode: newWorkspaceModePicker, names: names, want: true},
+		{name: "mode off", ev: empty, mode: newWorkspaceModeOff, names: names},
+		{name: "no workspace id", ev: newWorkspaceEvent{Focused: true, PaneCount: 1, TabCount: 1}, mode: newWorkspaceModePicker, names: names},
+		{
+			name:  "worktree workspace",
+			ev:    newWorkspaceEvent{WorkspaceID: "w8", Focused: true, PaneCount: 1, TabCount: 1, IsWorktree: true},
+			mode:  newWorkspaceModePicker,
+			names: names,
+		},
+		{
+			name:  "background workspace",
+			ev:    newWorkspaceEvent{WorkspaceID: "w9", PaneCount: 1, TabCount: 1},
+			mode:  newWorkspaceModePicker,
+			names: names,
+		},
+		{
+			name:  "workspace already filled",
+			ev:    newWorkspaceEvent{WorkspaceID: "w9", Focused: true, PaneCount: 3, TabCount: 2},
+			mode:  newWorkspaceModePicker,
+			names: names,
+		},
+		{name: "suppressed", ev: empty, mode: newWorkspaceModePicker, names: names, suppressed: true},
+		{name: "no projects", ev: empty, mode: newWorkspaceModePicker, names: nil},
+		{
+			name:  "label matches a project",
+			ev:    newWorkspaceEvent{WorkspaceID: "w7", Label: "options cafe", Focused: true, PaneCount: 1, TabCount: 1},
+			mode:  newWorkspaceModePicker,
+			names: names,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, reason := decideNewWorkspaceIntercept(c.ev, c.mode, c.names, c.suppressed)
+			if got != c.want {
+				t.Fatalf("decideNewWorkspaceIntercept = %v (%s), want %v", got, reason, c.want)
+			}
+			if !got && reason == "" {
+				t.Error("declined without a reason; the plugin log would say nothing useful")
+			}
+		})
+	}
+}
+
+// TestNewWorkspaceSuppressionConsumedOnce confirms one marker suppresses exactly
+// one event: the first read reports it and removes it, the next sees nothing.
+func TestNewWorkspaceSuppressionConsumedOnce(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := writeNewWorkspaceSuppression(dir); err != nil {
+		t.Fatalf("writeNewWorkspaceSuppression: %v", err)
+	}
+	if !consumeNewWorkspaceSuppression(dir, time.Now(), newWorkspaceInterceptTTL) {
+		t.Fatal("a freshly written marker did not suppress")
+	}
+	if consumeNewWorkspaceSuppression(dir, time.Now(), newWorkspaceInterceptTTL) {
+		t.Fatal("the marker suppressed twice; it must be consumed on read")
+	}
+}
+
+// TestNewWorkspaceSuppressionExpires confirms a marker older than the TTL neither
+// suppresses nor lingers — a create whose event never arrived must not swallow the
+// next New the user presses.
+func TestNewWorkspaceSuppressionExpires(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := writeNewWorkspaceSuppression(dir); err != nil {
+		t.Fatalf("writeNewWorkspaceSuppression: %v", err)
+	}
+	path := filepath.Join(dir, newWorkspaceInterceptMarker)
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("os.Chtimes: %v", err)
+	}
+
+	if consumeNewWorkspaceSuppression(dir, time.Now(), newWorkspaceInterceptTTL) {
+		t.Fatal("a stale marker suppressed")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a stale marker was left behind")
+	}
+}
+
+// TestNewWorkspaceSuppressionMissing confirms the common case — no marker at all —
+// does not suppress.
+func TestNewWorkspaceSuppressionMissing(t *testing.T) {
+	if consumeNewWorkspaceSuppression(t.TempDir(), time.Now(), newWorkspaceInterceptTTL) {
+		t.Fatal("an absent marker suppressed")
+	}
+}
+
+// TestNewWorkspaceMode covers the config surface: unset means off (the feature is
+// opt-in), the two documented values pass through case-insensitively, and a typo
+// is an error instead of a silent "off".
+func TestNewWorkspaceMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "", want: newWorkspaceModeOff},
+		{in: "off", want: newWorkspaceModeOff},
+		{in: "picker", want: newWorkspaceModePicker},
+		{in: "  PICKER  ", want: newWorkspaceModePicker},
+		{in: "pickr", want: newWorkspaceModeOff, wantErr: true},
+	}
+
+	for _, c := range cases {
+		var cfg PluginConfig
+		cfg.NewWorkspace.Mode = c.in
+
+		got, err := cfg.newWorkspaceMode()
+		if c.wantErr && err == nil {
+			t.Errorf("newWorkspaceMode(%q) = %q, want an error", c.in, got)
+			continue
+		}
+		if !c.wantErr && err != nil {
+			t.Errorf("newWorkspaceMode(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("newWorkspaceMode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestNewWorkspacePickerPresentation confirms the new-workspace presentation
+// changes the wording — and only the wording — so esc reads as "keep the empty
+// workspace" rather than a dead end.
+func TestNewWorkspacePickerPresentation(t *testing.T) {
+	base := newProjectsModel([]Project{{Name: "Options Cafe"}}, "/tmp/projects", "")
+	picker := base.asNewWorkspacePicker()
+
+	if base.headerTitle() != projectsTitle {
+		t.Errorf("default headerTitle = %q, want %q", base.headerTitle(), projectsTitle)
+	}
+	if picker.headerTitle() != newWorkspaceTitle {
+		t.Errorf("new-workspace headerTitle = %q, want %q", picker.headerTitle(), newWorkspaceTitle)
+	}
+	if base.cancelHint() == picker.cancelHint() {
+		t.Errorf("cancelHint is %q in both presentations; the new-workspace one must say what esc keeps", base.cancelHint())
+	}
+	if len(picker.projects) != len(base.projects) {
+		t.Error("asNewWorkspacePicker changed the project list; it must only change wording")
+	}
+}

--- a/newworkspace_test.go
+++ b/newworkspace_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -289,6 +290,9 @@ func TestNewWorkspacePickerPresentation(t *testing.T) {
 	}
 	if picker.headerTitle() != newWorkspaceTitle {
 		t.Errorf("new-workspace headerTitle = %q, want %q", picker.headerTitle(), newWorkspaceTitle)
+	}
+	if view := picker.pathView(80, 24); !strings.Contains(view, newWorkspaceTitle) {
+		t.Errorf("new-workspace path prompt does not contain title %q", newWorkspaceTitle)
 	}
 	if base.cancelHint() == picker.cancelHint() {
 		t.Errorf("cancelHint is %q in both presentations; the new-workspace one must say what esc keeps", base.cancelHint())

--- a/projects.go
+++ b/projects.go
@@ -54,6 +54,47 @@ func launchProjects() {
 // terminal), loads the projects, and — when one is chosen — spins up its
 // workspace. On cancel it simply exits and herdr tears the pane down.
 func runProjectsUI() {
+	choice, ok := pickProject(false)
+	if !ok {
+		// Cancelled — nothing to do; herdr closes the pane when this process exits.
+		return
+	}
+
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+	if choice.worktree {
+		if err := openProjectAsWorktree(client, choice.project, choice.branch); err != nil {
+			errExit("could not open project as worktree:", err)
+		}
+		return
+	}
+	if err := openProject(client, choice.project); err != nil {
+		errExit("could not open project:", err)
+	}
+}
+
+// projectChoice is what the projects browser hands back: the project the user
+// picked, and whether they asked for it as a git worktree (ctrl+g) on which
+// branch.
+type projectChoice struct {
+	project  Project
+	worktree bool
+	branch   string
+}
+
+// pickProject loads the projects, runs the full-screen browser, and returns the
+// user's choice. The second return value is false when the user cancelled or the
+// program produced no model, which every caller treats as "do nothing".
+//
+// newWorkspace switches the browser into its new-workspace presentation — same
+// list and keys, wording that says the empty workspace is what esc keeps. Both
+// picker entry points share this function so there is one place that knows how to
+// turn config into a running browser.
+//
+// A config error exits non-zero without closing the pane, so the user can read it.
+func pickProject(newWorkspace bool) (projectChoice, bool) {
 	projects, err := loadProjects()
 	if err != nil {
 		// Leave the pane open so the user can read the config error.
@@ -67,10 +108,15 @@ func runProjectsUI() {
 
 	dir, _ := projectsConfigDir()
 
+	model := newProjectsModel(projects, dir, cfg.Worktree.BranchPrefix)
+	if newWorkspace {
+		model = model.asNewWorkspacePicker()
+	}
+
 	// WithMouseCellMotion enables click/release/wheel events so a project can be
 	// opened with the mouse. herdr forwards these to us once we ask for them;
 	// until then it keeps the mouse for its own pane focus/selection.
-	p := tea.NewProgram(newProjectsModel(projects, dir, cfg.Worktree.BranchPrefix), tea.WithAltScreen(), tea.WithMouseCellMotion())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	result, err := p.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "herdr-plus:", err)
@@ -78,24 +124,9 @@ func runProjectsUI() {
 
 	m, ok := result.(projectsModel)
 	if !ok || m.chosen == nil {
-		// Cancelled (or the program never produced a model) — nothing to do; herdr
-		// closes the pane when this process exits.
-		return
+		return projectChoice{}, false
 	}
-
-	client, err := newHerdrClient()
-	if err != nil {
-		errExit(err)
-	}
-	if m.worktree {
-		if err := openProjectAsWorktree(client, *m.chosen, m.branch); err != nil {
-			errExit("could not open project as worktree:", err)
-		}
-		return
-	}
-	if err := openProject(client, *m.chosen); err != nil {
-		errExit("could not open project:", err)
-	}
+	return projectChoice{project: *m.chosen, worktree: m.worktree, branch: m.branch}, true
 }
 
 // openProject turns a project into a live herdr workspace: it creates a focused
@@ -118,6 +149,12 @@ func openProject(client *herdrClient, p Project) error {
 	if err := checkTabDirs(dir, p.Tabs); err != nil {
 		return err
 	}
+
+	// Tell the workspace.created handler this next workspace is ours, so the
+	// new-workspace picker does not offer to replace a workspace it just built.
+	// It must be recorded before the create call, not after, or the event can
+	// reach the handler first.
+	suppressNewWorkspaceIntercept()
 
 	ws, rootTab, rootPane, err := client.workspaceCreate(dir, p.Name, true)
 	if err != nil {
@@ -154,6 +191,12 @@ func openProjectAsWorktree(client *herdrClient, p Project, branch string) error 
 	if !isInsideGitWorkTree(dir) {
 		return fmt.Errorf("not a git repository: %s (opening as a worktree requires one)", dir)
 	}
+
+	// A worktree gets a workspace too, so claim its workspace.created the same way
+	// openProject does. The event's own worktree field already tells the handler to
+	// stand down; this simply does not depend on that.
+	suppressNewWorkspaceIntercept()
+
 	return client.worktreeCreate(dir, branch, true)
 }
 

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -21,6 +21,11 @@ import (
 // projectsTitle is the heading shown across the top of the projects browser.
 const projectsTitle = "Herdr Plus · Projects"
 
+// newWorkspaceTitle replaces it when the browser is shown over a brand-new,
+// empty workspace, so it is obvious the choice is about what that workspace
+// becomes rather than an extra workspace appearing from nowhere.
+const newWorkspaceTitle = "Herdr Plus · New workspace"
+
 // docsURL is where the empty-state points for "more documentation". Full docs
 // live elsewhere later; for now the repo is the home of everything.
 const docsURL = "https://github.com/cloudmanic/herdr-plus"
@@ -116,6 +121,36 @@ type projectsModel struct {
 	pathInput       textinput.Model
 	pathErr         string
 	branchAfterPath bool
+
+	// newWorkspace marks the browser as the one shown over a brand-new, empty
+	// workspace (see asNewWorkspacePicker). It changes only the wording — the
+	// list, the keys, and the choice it produces are identical.
+	newWorkspace bool
+}
+
+// asNewWorkspacePicker returns the model presented as the new-workspace picker:
+// its own title, and a footer that spells out what esc leaves behind — the empty
+// workspace herdr just made. Cancelling has to read as a real option there, since
+// it is how you still get a plain workspace with the feature enabled.
+func (m projectsModel) asNewWorkspacePicker() projectsModel {
+	m.newWorkspace = true
+	return m
+}
+
+// headerTitle is the heading for the current presentation.
+func (m projectsModel) headerTitle() string {
+	if m.newWorkspace {
+		return newWorkspaceTitle
+	}
+	return projectsTitle
+}
+
+// cancelHint describes what esc does in the current presentation.
+func (m projectsModel) cancelHint() string {
+	if m.newWorkspace {
+		return "esc keep empty workspace"
+	}
+	return "esc quit"
 }
 
 // ungroupedHeading labels the catch-all bucket for projects that declare no
@@ -507,12 +542,12 @@ func (m projectsModel) View() string {
 // top, the fuzzy list below it, and the highlighted project's detail bar pinned
 // just above the footer at the bottom of the screen.
 func (m projectsModel) browserView(w, h int) string {
-	header := headerBarStyle.Width(w).Render(projectsTitle)
+	header := headerBarStyle.Width(w).Render(m.headerTitle())
 
 	body := m.list.view("no matching projects")
 
 	detail := m.detailBar(w)
-	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · ctrl+g worktree · esc quit")
+	footer := footerStyle.Render("  ↑/↓ move · type to filter · click/enter open · ctrl+g worktree · " + m.cancelHint())
 
 	top := header + "\n\n" + body
 	bottom := detail + "\n" + footer
@@ -529,7 +564,7 @@ func (m projectsModel) browserView(w, h int) string {
 // working directory above a single-line input for the optional branch name, with
 // a footer explaining enter/esc. It backs the modeBranch state.
 func (m projectsModel) branchView(w, h int) string {
-	header := headerBarStyle.Width(w).Render(projectsTitle)
+	header := headerBarStyle.Width(w).Render(m.headerTitle())
 
 	name, dir := "", ""
 	if m.chosen != nil {

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -590,7 +590,7 @@ func (m projectsModel) branchView(w, h int) string {
 // expand like working_dir), plus any validation error from the last attempt.
 // It backs the modePath state.
 func (m projectsModel) pathView(w, h int) string {
-	header := headerBarStyle.Width(w).Render(projectsTitle)
+	header := headerBarStyle.Width(w).Render(m.headerTitle())
 
 	name := ""
 	if m.chosen != nil {


### PR DESCRIPTION
## What

herdr's sidebar **New** button (and the `new_workspace` keybinding) always creates an empty workspace rooted at the current directory. This PR lets herdr-plus offer your projects there instead, behind an opt-in setting:

```toml
[new_workspace]
mode = "picker"   # default: "off"
```

With it on, every new, empty workspace opens the projects browser over itself. Choosing a project builds that project's workspace and closes the empty one it replaced. **esc** keeps the empty workspace exactly as herdr made it, so herdr's plain behaviour is always one keypress away. **ctrl+g** still opens the highlighted project as a worktree.

## Why this shape

herdr's plugin API has no hook on the sidebar's New button itself — a plugin cannot decorate it with a menu, and `workspace.created` is a notification rather than something a plugin can cancel. Reacting to the event is the only way to reach that button, so the flow is: let herdr make its workspace, cover it with the browser, then swap it out. The visible cost is a brief flash of the empty workspace before the browser covers it.

Choosing a project reuses `openProject` unchanged, so the picker, `open <name>`, and this path all build a workspace through one code path.

## Not intercepting is the common case

The handler fires for **every** workspace anyone creates, so `decideNewWorkspaceIntercept` is a pure function that declines — with a reason logged to the plugin log — unless the workspace really is the blank one the user just asked for:

| Declines when… | Why |
| --- | --- |
| `mode` is `"off"` / unset | opt-in; the handler returns before logging anything |
| the workspace belongs to a git worktree | `runOnWorktreeEvent` owns those, and its layouts would fight the picker |
| it was created in the background | a full-screen picker there would be a surprise |
| it already has tabs or panes | something already filled it |
| herdr-plus created it | otherwise opening a project would ask again, forever |
| no projects are defined | the browser would have nothing to offer |

That "herdr-plus created it" guard is the load-bearing one. `openProject` writes a consume-once marker (15s TTL) into `HERDR_PLUGIN_STATE_DIR` *before* asking herdr for a workspace — which is what guarantees it is on disk by the time the handler runs — and a project-name check on the workspace label backs it up if the marker could not be written.

## Changes

- `newworkspace.go` — event parsing, the intercept policy, the suppression marker, the `on-workspace` handler, and the `new-workspace-ui` pane.
- `herdr-plugin.toml` — `new-workspace-picker` pane and `workspace.created` events (both with their Windows twins).
- `projects.go` — the two picker entry points now share `pickProject()`; `openProject` / `openProjectAsWorktree` record the suppression marker.
- `projectsmodel.go` — a new-workspace presentation of the browser: its own title, and a footer that says what **esc** keeps. Wording only; same list, same keys.
- `config.go` — `[new_workspace] mode`.
- README — a "New workspace → pick a project" section under Projects.

## Testing

`go test ./...` and `go vet ./...` pass. `newworkspace_test.go` covers event parsing (including the `worktree: null` vs populated distinction and the id fallback), every branch of the intercept policy, the marker's consume-once and TTL behaviour, `mode` validation, and that the new presentation changes wording only.

Two pre-existing failures (`TestHerdrManagedConfigDir`, `TestEnsureManagedConfigDir`) reproduce on `main` when run on Windows — they fake `herdr` with a POSIX shell script — and are untouched by this branch.

End-to-end behaviour was reasoned from herdr 0.8.0-preview's API schema (`workspace_created` carries `focused` / `pane_count` / `tab_count` / `worktree`, and `plugin pane open` takes `--workspace` and `--env`). Happy to adjust if you'd rather have a different default, a different config key, or the empty workspace reused in place instead of created-and-closed.
