### PR TITLE
feat: make picker pane placement configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,20 @@ Optional global settings live in `config.toml` in that same directory:
 ```toml
 [worktree]
 branch_prefix = "your-name/" # used verbatim; include your own trailing /
+
+[projects]
+placement = "zoomed" # overlay, popup, split, tab, or zoomed; default is zoomed
+
+[quick_actions]
+placement = "overlay" # overlay, popup, split, tab, or zoomed; default is overlay
 ```
+
+`placement` controls how herdr opens each picker — see herdr's
+[`plugin pane open --placement`](https://herdr.dev/docs/plugins/#panes) for what
+each value does. `popup` is a good fit for either picker if you want a small
+floating window that leaves your tiled layout untouched, rather than the default
+zoomed/overlay takeover. An empty or invalid value falls back to the built-in
+default and prints a warning to stderr rather than being passed through to herdr.
 
 ## Projects
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,17 @@ import (
 //go:embed examples
 var embeddedExamples embed.FS
 
+// validPanePlacements are the values herdr's `plugin pane open --placement`
+// accepts. Kept in sync with herdr's own CLI (src/cli/spec.rs / src/cli/plugin.rs
+// upstream) since we pass the configured value straight through.
+var validPanePlacements = map[string]bool{
+	"overlay": true,
+	"popup":   true,
+	"split":   true,
+	"tab":     true,
+	"zoomed":  true,
+}
+
 // PluginConfig holds herdr-plus's optional global settings, read from config.toml
 // at the config root (alongside projects/ and quick-actions/). Every field is
 // optional; an absent file yields the zero value.
@@ -36,6 +47,39 @@ type PluginConfig struct {
 		// is left untouched (see resolveWorktreeBranch).
 		BranchPrefix string `toml:"branch_prefix"`
 	} `toml:"worktree"`
+
+	Projects struct {
+		// Placement overrides the pane placement used to open the projects
+		// browser, one of overlay, popup, split, tab, or zoomed (see herdr's
+		// `plugin pane open --placement`). Empty keeps the built-in default,
+		// zoomed.
+		Placement string `toml:"placement"`
+	} `toml:"projects"`
+
+	QuickActions struct {
+		// Placement overrides the pane placement used to open the quick-actions
+		// picker, one of overlay, popup, split, tab, or zoomed (see herdr's
+		// `plugin pane open --placement`). Empty keeps the built-in default,
+		// overlay.
+		Placement string `toml:"placement"`
+	} `toml:"quick_actions"`
+}
+
+// resolvePlacement returns configured if it is a valid herdr pane placement,
+// otherwise fallback (the feature's built-in default). An empty configured
+// value — the common case, nothing set in config.toml — silently keeps the
+// default. An invalid non-empty value also falls back rather than handing
+// herdr a value it will reject, but is reported to stderr so a typo in
+// config.toml doesn't silently do nothing.
+func resolvePlacement(configured, fallback string) string {
+	if configured == "" {
+		return fallback
+	}
+	if !validPanePlacements[configured] {
+		fmt.Fprintf(os.Stderr, "herdr-plus: config.toml: placement %q is not a valid herdr pane placement (overlay, popup, split, tab, zoomed); using %q\n", configured, fallback)
+		return fallback
+	}
+	return configured
 }
 
 // configBaseDir returns the root configuration directory for herdr-plus's

--- a/config_test.go
+++ b/config_test.go
@@ -94,3 +94,50 @@ func TestLoadPluginConfigRejectsMalformedFile(t *testing.T) {
 		t.Fatal("expected malformed config.toml to error")
 	}
 }
+
+// TestLoadPluginConfigParsesPlacements confirms config.toml can set the optional
+// per-picker pane placement overrides.
+func TestLoadPluginConfigParsesPlacements(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+
+	toml := "[projects]\nplacement = \"popup\"\n\n[quick_actions]\nplacement = \"split\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		t.Fatalf("loadPluginConfig: %v", err)
+	}
+	if cfg.Projects.Placement != "popup" {
+		t.Fatalf("Projects.Placement = %q, want popup", cfg.Projects.Placement)
+	}
+	if cfg.QuickActions.Placement != "split" {
+		t.Fatalf("QuickActions.Placement = %q, want split", cfg.QuickActions.Placement)
+	}
+}
+
+// TestResolvePlacement covers the fallback rules: empty config keeps the
+// default, a valid override is used as-is, and an invalid value falls back
+// rather than being passed through to herdr.
+func TestResolvePlacement(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured string
+		fallback   string
+		want       string
+	}{
+		{"empty uses fallback", "", "overlay", "overlay"},
+		{"valid override is used", "popup", "overlay", "popup"},
+		{"another valid override is used", "zoomed", "overlay", "zoomed"},
+		{"invalid value falls back", "not-a-placement", "zoomed", "zoomed"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolvePlacement(c.configured, c.fallback); got != c.want {
+				t.Fatalf("resolvePlacement(%q, %q) = %q, want %q", c.configured, c.fallback, got, c.want)
+			}
+		})
+	}
+}

--- a/launch_test.go
+++ b/launch_test.go
@@ -1,0 +1,119 @@
+//
+// Date: 2026-08-10
+// Author: idoga
+//
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeArgRecordingHerdr writes a fake herdr binary that appends its argv to
+// recordPath (one arg per line, invocations separated by a blank line) and
+// exits 0. Used to confirm launchProjects/launchQuickActions pass the
+// expected --placement value through to `herdr plugin pane open`.
+func writeArgRecordingHerdr(t *testing.T, recordPath string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "herdr")
+	script := "#!/bin/sh\nfor a in \"$@\"; do echo \"$a\" >> \"" + recordPath + "\"; done\necho >> \"" + recordPath + "\"\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake herdr: %v", err)
+	}
+	return path
+}
+
+// TestLaunchProjectsPlacement confirms launchProjects defaults to zoomed with
+// no config, and passes through a valid [projects].placement override.
+func TestLaunchProjectsPlacement(t *testing.T) {
+	cases := []struct {
+		name       string
+		configToml string
+		want       string
+	}{
+		{"no config defaults to zoomed", "", "zoomed"},
+		{"valid override is passed through", "[projects]\nplacement = \"popup\"\n", "popup"},
+		{"invalid value falls back to zoomed", "[projects]\nplacement = \"bogus\"\n", "zoomed"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configDir := t.TempDir()
+			t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+			if c.configToml != "" {
+				if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(c.configToml), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+
+			record := filepath.Join(t.TempDir(), "args.txt")
+			t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+			launchProjects()
+
+			got, err := os.ReadFile(record)
+			if err != nil {
+				t.Fatalf("read recorded args: %v", err)
+			}
+			args := strings.Split(string(got), "\n")
+			if !containsPlacement(args, c.want) {
+				t.Fatalf("recorded args %v do not contain --placement %q", args, c.want)
+			}
+		})
+	}
+}
+
+// TestLaunchQuickActionsPlacement mirrors TestLaunchProjectsPlacement for the
+// quick-actions picker, whose built-in default is overlay rather than zoomed.
+func TestLaunchQuickActionsPlacement(t *testing.T) {
+	cases := []struct {
+		name       string
+		configToml string
+		want       string
+	}{
+		{"no config defaults to overlay", "", "overlay"},
+		{"valid override is passed through", "[quick_actions]\nplacement = \"popup\"\n", "popup"},
+		{"invalid value falls back to overlay", "[quick_actions]\nplacement = \"bogus\"\n", "overlay"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			configDir := t.TempDir()
+			t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+			if c.configToml != "" {
+				if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(c.configToml), 0o644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+
+			record := filepath.Join(t.TempDir(), "args.txt")
+			t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+			launchQuickActions()
+
+			got, err := os.ReadFile(record)
+			if err != nil {
+				t.Fatalf("read recorded args: %v", err)
+			}
+			args := strings.Split(string(got), "\n")
+			if !containsPlacement(args, c.want) {
+				t.Fatalf("recorded args %v do not contain --placement %q", args, c.want)
+			}
+		})
+	}
+}
+
+// containsPlacement reports whether args contains "--placement" immediately
+// followed by want.
+func containsPlacement(args []string, want string) bool {
+	for i, a := range args {
+		if a == "--placement" && i+1 < len(args) && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/projects.go
+++ b/projects.go
@@ -19,10 +19,17 @@ import (
 
 // launchProjects is the Projects action's entry point. herdr runs it server-side
 // (from the plugin action / keybinding), so it has no terminal of its own. It
-// asks herdr to open the projects browser as a zoomed plugin pane (the `picker`
-// entrypoint in herdr-plugin.toml). herdr creates and tears down that pane for
+// asks herdr to open the projects browser as a pane (the `picker` entrypoint in
+// herdr-plugin.toml) — zoomed by default, or the placement set by
+// [projects].placement in config.toml. herdr creates and tears down that pane for
 // us, so — unlike the old design — there is no throwaway workspace to manage.
 func launchProjects() {
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		errExit(err)
+	}
+	placement := resolvePlacement(cfg.Projects.Placement, "zoomed")
+
 	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
 	// call back into the CLI from a plugin command.
 	herdr := os.Getenv("HERDR_BIN_PATH")
@@ -33,7 +40,7 @@ func launchProjects() {
 	cmd := exec.Command(herdr, "plugin", "pane", "open",
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("picker"),
-		"--placement", "zoomed",
+		"--placement", placement,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/quickactions.go
+++ b/quickactions.go
@@ -14,9 +14,10 @@ import (
 // launchQuickActions is the Quick Actions action's entry point. herdr runs it
 // server-side (from the plugin action / keybinding), so it has no terminal of its
 // own. It captures the focused pane's context (working directory, workspace) from
-// the env herdr injects, then asks herdr to open the action picker as an overlay
-// pane — passing the encoded context along so the chosen command runs in the
-// directory you launched from, not the picker's. herdr creates the overlay and,
+// the env herdr injects, then asks herdr to open the action picker as a pane —
+// overlay by default, or the placement set by [quick_actions].placement in
+// config.toml — passing the encoded context along so the chosen command runs in
+// the directory you launched from, not the picker's. herdr creates the pane and,
 // when the picker exits, tears it down and restores your previous focus.
 func launchQuickActions() {
 	ctx := contextFromPluginEnv()
@@ -24,6 +25,12 @@ func launchQuickActions() {
 	if err != nil {
 		errExit("could not encode run context:", err)
 	}
+
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		errExit(err)
+	}
+	placement := resolvePlacement(cfg.QuickActions.Placement, "overlay")
 
 	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
 	// call back into the CLI from a plugin command.
@@ -36,7 +43,7 @@ func launchQuickActions() {
 		"plugin", "pane", "open",
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("quick-actions-picker"),
-		"--placement", "overlay",
+		"--placement", placement,
 		// Hand the launch context to the picker as a single shell-safe env var.
 		"--env", "HERDR_PLUS_CTX=" + enc,
 	}


### PR DESCRIPTION
## What

`launchProjects` and `launchQuickActions` each hardcode the `--placement` passed to `herdr plugin pane open` — `zoomed` for Projects, `overlay` for Quick Actions. There's no way for a user to get either picker as a small floating popup instead of the tab takeover, even though `herdr plugin pane open --placement` already accepts `popup` (documented at https://herdr.dev/docs/plugins/#panes, alongside `overlay`, `split`, `tab`, `zoomed`).

Ran into this wanting Quick Actions as a popup rather than a full-tab overlay, and there was no config surface to change it short of patching the binary.

## Fix

- New optional `config.toml` sections:
  ```toml
  [projects]
  placement = "popup"   # overlay, popup, split, tab, or zoomed; default zoomed

  [quick_actions]
  placement = "popup"   # overlay, popup, split, tab, or zoomed; default overlay
  ```
- Both fields are optional and default to the current hardcoded behavior, so nothing changes for existing users who don't set them.
- `resolvePlacement(configured, fallback)` centralizes the fallback: empty → default, valid → passed through, invalid → default with a stderr warning (so a typo produces a clear message instead of herdr silently rejecting an unrecognized value downstream).
- README updated with the new fields and a pointer to herdr's placement docs.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build .` — succeeds
- [x] `go test ./...` — all existing tests pass, no regressions
- [x] New tests added and passing:
  - `TestLoadPluginConfigParsesPlacements` — config.toml parses both new fields
  - `TestResolvePlacement` — table-driven coverage of the fallback rules (empty, valid, invalid)
  - `TestLaunchProjectsPlacement` / `TestLaunchQuickActionsPlacement` — end-to-end: a fake `herdr` binary (via `HERDR_BIN_PATH`) records the argv each launcher actually builds, asserting `--placement` carries the configured/default/fallback value correctly in each case
