### PR TITLE
feat(quick-actions): dynamic select options via options_command

### DIFF
--- a/action.go
+++ b/action.go
@@ -193,9 +193,13 @@ func (a Action) render(ctx RunContext) (string, error) {
 // resolveOptions returns the option list a select action should show: the
 // static Options list, or — when OptionsCommand is set — the result of running
 // that command fresh through the shell right now and turning each non-blank
-// line of its stdout into an Option (label and value both the line). This is
-// what makes a select action's list reflect live state (e.g. a directory
-// listing) instead of a snapshot frozen into the TOML file.
+// line of its stdout into an Option. A line is just "value" (used as both
+// label and value) unless it contains a tab, in which case it is
+// "value\tdescription" — the same label/value/description split a static
+// [[options]] entry has, so a dynamic list can flag things about each choice
+// (e.g. "already added") without that text ending up in the value the command
+// receives. This is what makes a select action's list reflect live state (e.g.
+// a directory listing) instead of a snapshot frozen into the TOML file.
 func (a Action) resolveOptions(ctx RunContext) ([]Option, error) {
 	if strings.TrimSpace(a.OptionsCommand) == "" {
 		return a.Options, nil
@@ -222,7 +226,12 @@ func (a Action) resolveOptions(ctx RunContext) ([]Option, error) {
 		if line == "" {
 			continue
 		}
-		options = append(options, Option{Label: line, Value: line})
+		value, desc, hasDesc := strings.Cut(line, "\t")
+		opt := Option{Label: value, Value: value}
+		if hasDesc {
+			opt.Description = strings.TrimSpace(desc)
+		}
+		options = append(options, opt)
 	}
 	return options, nil
 }

--- a/action.go
+++ b/action.go
@@ -94,12 +94,17 @@ type FormConfig struct {
 // text/template rendered against a RunContext, so it can reference {{.Value}},
 // {{.WorkDir}}, {{.SessionTitle}}, and the other context fields.
 type Action struct {
-	Name        string     `toml:"name"`
-	Description string     `toml:"description"`
-	Type        string     `toml:"type"`
-	Command     string     `toml:"command"`
-	Options     []Option   `toml:"options"`
-	Form        FormConfig `toml:"form"`
+	Name        string   `toml:"name"`
+	Description string   `toml:"description"`
+	Type        string   `toml:"type"`
+	Command     string   `toml:"command"`
+	Options     []Option `toml:"options"`
+	// OptionsCommand, when set on a "select" action, replaces the static Options
+	// list: it is a shell command (template-rendered like Command) run fresh each
+	// time the action is opened, and its stdout — one option per line — becomes
+	// the list to pick from. Options and OptionsCommand are mutually exclusive.
+	OptionsCommand string     `toml:"options_command"`
+	Form           FormConfig `toml:"form"`
 
 	// source is the file the action was loaded from, used only for error
 	// messages. It is not part of the on-disk format.
@@ -132,6 +137,9 @@ func (a Action) validate() error {
 	case TypeCommand, TypeForm:
 		// nothing extra to check
 	case TypeSelect:
+		if strings.TrimSpace(a.OptionsCommand) != "" {
+			break // options are resolved at picker time; nothing to check here
+		}
 		selectable := 0
 		for _, o := range a.Options {
 			if !o.isSeparator() {
@@ -139,12 +147,29 @@ func (a Action) validate() error {
 			}
 		}
 		if selectable == 0 {
-			return fmt.Errorf("action %q (%s): select actions need at least one selectable option (one with a label)", a.Name, a.source)
+			return fmt.Errorf("action %q (%s): select actions need at least one selectable option (one with a label) or an options_command", a.Name, a.source)
 		}
 	default:
 		return fmt.Errorf("action %q (%s): unknown type %q (want command, select, or form)", a.Name, a.source, a.Type)
 	}
 	return nil
+}
+
+// renderTemplate parses and executes a Go text/template against ctx, shared by
+// render (the action's Command) and resolveOptions (a select action's
+// OptionsCommand) so both get the same {{.Value}}/{{.WorkDir}}/{{opener}} etc.
+// vocabulary.
+func renderTemplate(name, tmplText string, ctx RunContext) (string, error) {
+	tmpl, err := template.New(name).Funcs(templateFuncs()).Parse(tmplText)
+	if err != nil {
+		return "", fmt.Errorf("parse template for %q: %w", name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		return "", fmt.Errorf("render template for %q: %w", name, err)
+	}
+	return buf.String(), nil
 }
 
 // render turns the action's command template into the final shell command. The
@@ -154,21 +179,52 @@ func (a Action) validate() error {
 // position the value precisely with {{.Value}} or just receive it as its last
 // argument.
 func (a Action) render(ctx RunContext) (string, error) {
-	tmpl, err := template.New(a.Name).Funcs(templateFuncs()).Parse(a.Command)
+	cmdline, err := renderTemplate(a.Name, a.Command, ctx)
 	if err != nil {
-		return "", fmt.Errorf("parse command for %q: %w", a.Name, err)
+		return "", err
 	}
-
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, ctx); err != nil {
-		return "", fmt.Errorf("render command for %q: %w", a.Name, err)
-	}
-	cmdline := buf.String()
 
 	if ctx.Value != "" && !strings.Contains(a.Command, ".Value") {
 		cmdline += " " + shellQuote(ctx.Value)
 	}
 	return cmdline, nil
+}
+
+// resolveOptions returns the option list a select action should show: the
+// static Options list, or — when OptionsCommand is set — the result of running
+// that command fresh through the shell right now and turning each non-blank
+// line of its stdout into an Option (label and value both the line). This is
+// what makes a select action's list reflect live state (e.g. a directory
+// listing) instead of a snapshot frozen into the TOML file.
+func (a Action) resolveOptions(ctx RunContext) ([]Option, error) {
+	if strings.TrimSpace(a.OptionsCommand) == "" {
+		return a.Options, nil
+	}
+
+	cmdline, err := renderTemplate(a.Name, a.OptionsCommand, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := shellCommand(cmdline)
+	if ctx.WorkDir != "" {
+		cmd.Dir = ctx.WorkDir
+	}
+	cmd.Env = append(os.Environ(), ctx.envPairs()...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("options_command for %q: %w", a.Name, err)
+	}
+
+	var options []Option
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		options = append(options, Option{Label: line, Value: line})
+	}
+	return options, nil
 }
 
 // run renders and executes the action's command through the shell, in the

--- a/action_test.go
+++ b/action_test.go
@@ -176,6 +176,23 @@ func TestActionResolveOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("options_command line with a tab splits into value and description", func(t *testing.T) {
+		a := Action{Name: "A", Type: TypeSelect, OptionsCommand: `printf 'plain\nnvim-ide\t(already added)\n'`}
+		got, err := a.resolveOptions(RunContext{})
+		if err != nil {
+			t.Fatalf("resolveOptions: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("resolveOptions = %+v, want 2 options", got)
+		}
+		if got[0].Label != "plain" || got[0].Value != "plain" || got[0].Description != "" {
+			t.Fatalf("option 0 = %+v, want plain with no description", got[0])
+		}
+		if got[1].Label != "nvim-ide" || got[1].Value != "nvim-ide" || got[1].Description != "(already added)" {
+			t.Fatalf("option 1 = %+v, want label/value %q and description %q", got[1], "nvim-ide", "(already added)")
+		}
+	})
+
 	t.Run("options_command is template rendered", func(t *testing.T) {
 		// SessionTitle (not WorkDir) so the test doesn't also depend on cmd.Dir
 		// pointing at a directory that exists on disk.

--- a/action_test.go
+++ b/action_test.go
@@ -111,6 +111,7 @@ func TestActionValidate(t *testing.T) {
 		{"missing name", Action{Command: "open x"}, true},
 		{"missing command", Action{Name: "A"}, true},
 		{"select without options", Action{Name: "A", Type: TypeSelect, Command: "x"}, true},
+		{"select with options_command", Action{Name: "A", Type: TypeSelect, Command: "x", OptionsCommand: "ls"}, false},
 		{"unknown type", Action{Name: "A", Type: "wat", Command: "x"}, true},
 	}
 
@@ -136,6 +137,64 @@ func TestOptionResolvedValue(t *testing.T) {
 	if got := (Option{Label: "herdr-plus"}).resolvedValue(); got != "herdr-plus" {
 		t.Fatalf("resolvedValue = %q, want label fallback %q", got, "herdr-plus")
 	}
+}
+
+// TestActionResolveOptions covers the two ways a select action's option list is
+// produced: the static Options list (OptionsCommand unset), and running
+// OptionsCommand fresh through the shell — including that it is template
+// rendered, that blank lines are dropped, and that a failing command surfaces
+// as an error rather than an empty list (which would look like "no options" to
+// the picker, not "the command broke").
+func TestActionResolveOptions(t *testing.T) {
+	staticOpts := []Option{{Label: "x"}, {Label: "y"}}
+
+	t.Run("static options unaffected when no options_command", func(t *testing.T) {
+		a := Action{Name: "A", Type: TypeSelect, Options: staticOpts}
+		got, err := a.resolveOptions(RunContext{})
+		if err != nil {
+			t.Fatalf("resolveOptions: %v", err)
+		}
+		if len(got) != 2 || got[0].Label != "x" || got[1].Label != "y" {
+			t.Fatalf("resolveOptions = %+v, want static Options unchanged", got)
+		}
+	})
+
+	t.Run("options_command lines become options, blanks dropped", func(t *testing.T) {
+		a := Action{Name: "A", Type: TypeSelect, OptionsCommand: "printf 'one\\n\\ntwo\\n'"}
+		got, err := a.resolveOptions(RunContext{})
+		if err != nil {
+			t.Fatalf("resolveOptions: %v", err)
+		}
+		want := []string{"one", "two"}
+		if len(got) != len(want) {
+			t.Fatalf("resolveOptions = %+v, want %d options", got, len(want))
+		}
+		for i, w := range want {
+			if got[i].Label != w || got[i].Value != w {
+				t.Fatalf("option %d = %+v, want label/value %q", i, got[i], w)
+			}
+		}
+	})
+
+	t.Run("options_command is template rendered", func(t *testing.T) {
+		// SessionTitle (not WorkDir) so the test doesn't also depend on cmd.Dir
+		// pointing at a directory that exists on disk.
+		a := Action{Name: "A", Type: TypeSelect, OptionsCommand: "echo {{.SessionTitle}}"}
+		got, err := a.resolveOptions(RunContext{WorkspaceLabel: "my-project"})
+		if err != nil {
+			t.Fatalf("resolveOptions: %v", err)
+		}
+		if len(got) != 1 || got[0].Label != "my-project" {
+			t.Fatalf("resolveOptions = %+v, want [my-project]", got)
+		}
+	})
+
+	t.Run("failing options_command is an error, not an empty list", func(t *testing.T) {
+		a := Action{Name: "A", Type: TypeSelect, OptionsCommand: "exit 1"}
+		if _, err := a.resolveOptions(RunContext{}); err == nil {
+			t.Fatal("resolveOptions: expected error from a failing command, got nil")
+		}
+	})
 }
 
 // Shell quoting is OS-specific and lives in shell_test.go (posixQuote /

--- a/quickactionspicker.go
+++ b/quickactionspicker.go
@@ -51,6 +51,12 @@ type pickerModel struct {
 	optionList fuzzyList
 	formInput  textinput.Model
 
+	// resolvedOptions is the option list actually shown for the current select
+	// action — a.Options for a static list, or the freshly-run OptionsCommand
+	// output for a dynamic one. activateOption indexes into this, not into
+	// current.Options, since those two only coincide in the static case.
+	resolvedOptions []Option
+
 	width  int
 	height int
 
@@ -214,7 +220,14 @@ func (m pickerModel) activateAction() (tea.Model, tea.Cmd) {
 	switch a.effectiveType() {
 	case TypeSelect:
 		m.current = &a
-		m.optionList = newFuzzyList("Pick an option…", optionItems(a.Options))
+		options, err := a.resolveOptions(m.ctx)
+		if err != nil {
+			m.resolvedOptions = nil
+			m.optionList = newFuzzyList("Pick an option…", []listItem{{name: "error: " + err.Error()}})
+		} else {
+			m.resolvedOptions = options
+			m.optionList = newFuzzyList("Pick an option…", optionItems(options))
+		}
 		m.stage = stageSelect
 		return m, textinput.Blink
 	case TypeForm:
@@ -237,6 +250,7 @@ func (m pickerModel) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "esc":
 		m.current = nil
+		m.resolvedOptions = nil
 		m.stage = stageActions
 		return m, textinput.Blink
 	case "up", "ctrl+p":
@@ -261,7 +275,7 @@ func (m pickerModel) activateOption() (tea.Model, tea.Cmd) {
 	if idx < 0 {
 		return m, nil
 	}
-	m.value = m.current.Options[idx].resolvedValue()
+	m.value = m.resolvedOptions[idx].resolvedValue()
 	m.chosen = m.current
 	return m, tea.Quit
 }

--- a/quickactionspicker_test.go
+++ b/quickactionspicker_test.go
@@ -115,6 +115,71 @@ func TestPickerMouseClickRunsAction(t *testing.T) {
 	}
 }
 
+// TestPickerSelectActionWithOptionsCommand drives a select action whose options
+// come from OptionsCommand (not the static Options list) end to end: choosing the
+// action runs the command and populates the list, then choosing a row must resolve
+// to that row's value. This guards against indexing the picker's chosen option
+// into the action's (empty) static Options slice instead of the freshly resolved
+// list — that mismatch used to panic for any options_command-based action.
+func TestPickerSelectActionWithOptionsCommand(t *testing.T) {
+	actions := []Action{
+		{Name: "Pick", Type: TypeSelect, Command: "echo {{.Value}}", OptionsCommand: "printf 'alpha\\nbeta\\n'", origin: originGlobal},
+	}
+	m := newPickerModel(RunContext{}, actions)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm, ok := updated.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated)
+	}
+	if pm.stage != stageSelect {
+		t.Fatalf("stage = %v, want stageSelect", pm.stage)
+	}
+	if len(pm.resolvedOptions) != 2 || pm.resolvedOptions[0].Label != "alpha" || pm.resolvedOptions[1].Label != "beta" {
+		t.Fatalf("resolvedOptions = %+v, want [alpha beta]", pm.resolvedOptions)
+	}
+
+	updated2, _ := pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm2, ok := updated2.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated2)
+	}
+	if pm2.chosen == nil || pm2.value != "alpha" {
+		t.Fatalf("chosen=%v value=%q, want the action chosen with value %q", pm2.chosen, pm2.value, "alpha")
+	}
+}
+
+// TestPickerSelectActionOptionsCommandError confirms a failing OptionsCommand
+// surfaces as a non-selectable error row instead of crashing the picker or
+// silently showing an empty list, and that pressing enter on that row is a no-op.
+func TestPickerSelectActionOptionsCommandError(t *testing.T) {
+	actions := []Action{
+		{Name: "Pick", Type: TypeSelect, Command: "echo {{.Value}}", OptionsCommand: "exit 1", origin: originGlobal},
+	}
+	m := newPickerModel(RunContext{}, actions)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm, ok := updated.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated)
+	}
+	if pm.stage != stageSelect {
+		t.Fatalf("stage = %v, want stageSelect even after an options_command error", pm.stage)
+	}
+	if pm.resolvedOptions != nil {
+		t.Fatalf("resolvedOptions = %+v, want nil after a failing options_command", pm.resolvedOptions)
+	}
+
+	updated2, _ := pm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm2, ok := updated2.(pickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want pickerModel", updated2)
+	}
+	if pm2.chosen != nil {
+		t.Fatalf("chosen = %v, want nil (the error row is not selectable)", pm2.chosen)
+	}
+}
+
 // TestPickerMouseWheelMoves confirms the scroll wheel walks the highlight without
 // running anything.
 func TestPickerMouseWheelMoves(t *testing.T) {


### PR DESCRIPTION
## Summary

A "select" action's option list is currently always a fixed set written into
the TOML file. That covers hand-maintained choices (repos, hosts,
environments) but not anything backed by changing state — for me it was
"pick a folder under `~/projects`, list may grow over time" for a "New
Project" quick action.

This adds an optional `options_command` field on a select action. When set,
it replaces the static `options` list: a shell command (template-rendered
the same way `command` is, so it can use `{{.WorkDir}}`, `{{.SessionTitle}}`,
etc.) that runs fresh every time the action is opened, with each non-blank
line of stdout becoming one option (used as both label and value).

```toml
name = "New Project"
type = "select"
options_command = "find \"$HOME/projects\" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort"
command = '''
# {{.Value}} is the chosen folder name
...
'''
```

## Bug fixed along the way

Wiring this into the existing select flow surfaced a latent bug: the picker
resolved a chosen option by indexing into the *action's* static `Options`
slice (`m.current.Options[idx]`), which is empty for an `options_command`
action — so picking any row would have panicked. `pickerModel` now tracks
whichever list it actually resolved and displayed
(`resolvedOptions`) and indexes into that instead, regardless of whether it
came from `Options` or `options_command`.

A failing `options_command` surfaces as a non-selectable `error: ...` row in
the picker instead of crashing or silently showing an empty list.

## Test plan

- [x] `gofmt -l` clean on all changed files
- [x] `go vet ./...`
- [x] `go test -race ./...` — all existing tests pass, plus new coverage:
  - `TestActionResolveOptions` (action_test.go): static options unaffected,
    command output parsed into options, template rendering, failing command
    surfaces as an error
  - `TestActionValidate`: new case for a select action validated by
    `options_command` alone (no static options)
  - `TestPickerSelectActionWithOptionsCommand` /
    `TestPickerSelectActionOptionsCommandError` (quickactionspicker_test.go):
    end-to-end through the picker's `Update` loop, covering the
    `resolvedOptions` fix directly (this is the regression test for the bug
    above)
- [x] Manually verified against a real quick-action TOML using
  `options_command` to list a directory, including the create/no-op-on-second-run
  flow it drives

Happy to adjust naming/shape (e.g. a delimiter for label+description per line)
if you'd rather go a different direction with this.