### PR TITLE
Add an optional pane ratio to split tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ A tab can hold up to **4 panes**. Instead of a single `command`, give it
 `[[tabs.panes]]` entries. Each pane after the first sets `split` to `"down"`
 (stacked) or `"right"` (side by side) — how it splits off the previous pane. An
 omitted `split` defaults to `"down"`.
+A pane may also set `ratio` — how much of that split it takes, between `0` and
+`1`, leaving the rest to the pane it splits off. Omitted, the split is even.
 Each pane may also set an optional `label` — the name herdr shows on the pane
 border (when `show_agent_labels_on_pane_borders` is on). A blank or omitted
 `label` leaves the pane's default name untouched.
@@ -170,6 +172,7 @@ command = "php artisan serve"
 label = "Assets"
 command = "npm run dev"
 split = "down"
+ratio = 0.3
 ```
 
 A tab uses *either* `command` *or* `[[tabs.panes]]`, not both.

--- a/examples/projects/example.toml
+++ b/examples/projects/example.toml
@@ -26,6 +26,7 @@ command = "spiceedit"
 # A tab can be split into up to 4 panes. Instead of a single `command`, give it
 # [[tabs.panes]]. Each pane after the first sets `split = "down"` (stacked) or
 # "right" (side by side) — how it splits off the previous pane (default "down").
+# Add `ratio` for how much of that split the pane takes (default: an even split).
 [[tabs]]
 name = "server"
 
@@ -37,6 +38,7 @@ command = "php artisan serve"
 label = "Assets"
 command = "npm run dev"
 split = "down"
+ratio = 0.3   # the assets pane takes the bottom 30%, the server keeps 70%
 
 [[tabs]]
 name = "terminal"   # no command — just an empty shell

--- a/herdr.go
+++ b/herdr.go
@@ -110,21 +110,33 @@ func (c *herdrClient) worktreeCreate(cwd, branch string, focus bool) error {
 	return c.call("worktree.create", worktreeCreateParams(cwd, branch, focus), nil)
 }
 
+// paneSplitParams builds the pane.split payload. A zero ratio is omitted so herdr
+// applies its own even split; any other value is the share of the space the target
+// pane keeps.
+func paneSplitParams(targetPaneID, direction string, ratio float64, focus bool) map[string]any {
+	params := map[string]any{
+		"target_pane_id": targetPaneID,
+		"direction":      direction,
+		"focus":          focus,
+	}
+	if ratio > 0 {
+		params["ratio"] = ratio
+	}
+	return params
+}
+
 // paneSplit splits the target pane in the given direction ("down" for a new pane
 // beneath it, "right" for one beside it), creating a new pane, and returns the
-// new pane's id. When focus is true the new pane becomes the focused pane (the
+// new pane's id. ratio is the share of the space the target pane keeps, zero for
+// an even split. When focus is true the new pane becomes the focused pane (the
 // socket API does not focus new panes by default).
-func (c *herdrClient) paneSplit(targetPaneID, direction string, focus bool) (string, error) {
+func (c *herdrClient) paneSplit(targetPaneID, direction string, ratio float64, focus bool) (string, error) {
 	var out struct {
 		Pane struct {
 			PaneID string `json:"pane_id"`
 		} `json:"pane"`
 	}
-	err := c.call("pane.split", map[string]any{
-		"target_pane_id": targetPaneID,
-		"direction":      direction,
-		"focus":          focus,
-	}, &out)
+	err := c.call("pane.split", paneSplitParams(targetPaneID, direction, ratio, focus), &out)
 	if err != nil {
 		return "", err
 	}

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -40,3 +40,38 @@ func TestWorktreeCreateParams(t *testing.T) {
 		})
 	}
 }
+
+// TestPaneSplitParams confirms the pane.split contract: the target, direction and
+// focus always ride along, while a zero ratio is left out so herdr splits evenly.
+func TestPaneSplitParams(t *testing.T) {
+	cases := []struct {
+		name    string
+		ratio   float64
+		wantKey bool
+	}{
+		{"unset", 0, false},
+		{"negative", -0.5, false},
+		{"set", 0.75, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := paneSplitParams("w1:p1", SplitRight, c.ratio, false)
+			if got["target_pane_id"] != "w1:p1" {
+				t.Fatalf("target_pane_id = %v, want w1:p1", got["target_pane_id"])
+			}
+			if got["direction"] != SplitRight {
+				t.Fatalf("direction = %v, want %q", got["direction"], SplitRight)
+			}
+			if got["focus"] != false {
+				t.Fatalf("focus = %v, want false", got["focus"])
+			}
+			ratio, ok := got["ratio"]
+			if ok != c.wantKey {
+				t.Fatalf("ratio key present = %v, want %v (params=%v)", ok, c.wantKey, got)
+			}
+			if ok && ratio != c.ratio {
+				t.Fatalf("ratio = %v, want %v", ratio, c.ratio)
+			}
+		})
+	}
+}

--- a/project.go
+++ b/project.go
@@ -30,11 +30,25 @@ const maxPanesPerTab = 4
 // ProjectPane is one pane within a tab. Command, when set, runs in the pane on
 // startup. Split is how the pane is created relative to the previous pane in the
 // tab — "down" or "right"; it is ignored for the first pane (the tab's root) and
-// defaults to "down" when omitted.
+// defaults to "down" when omitted. Ratio is the share of the split this pane
+// takes, between 0 and 1; omitting it splits the space evenly, and it is ignored
+// for the first pane, which has nothing to split off.
 type ProjectPane struct {
-	Command string `toml:"command"`
-	Split   string `toml:"split"`
-	Label   string `toml:"label"`
+	Command string  `toml:"command"`
+	Split   string  `toml:"split"`
+	Label   string  `toml:"label"`
+	Ratio   float64 `toml:"ratio"`
+}
+
+// splitRatio translates the pane's authored ratio — the share of the split it
+// takes — into the ratio herdr's pane.split expects, which is the share kept by
+// the pane being split. A zero ratio means the pane did not ask for one, and is
+// passed through as zero so the caller can leave it out of the request.
+func (p ProjectPane) splitRatio() float64 {
+	if p.Ratio <= 0 {
+		return 0
+	}
+	return 1 - p.Ratio
 }
 
 // ProjectTab is one tab in a project's workspace, in the order it should be
@@ -49,9 +63,9 @@ type ProjectTab struct {
 }
 
 // effectivePanes returns the tab's panes in creation order, normalizing the two
-// authoring forms into one list. The first pane is the tab's root (its split is
-// cleared); each later pane carries the direction it splits off the previous
-// one, defaulting to "down".
+// authoring forms into one list. The first pane is the tab's root (its split and
+// ratio are cleared); each later pane carries the direction it splits off the
+// previous one, defaulting to "down".
 func (t ProjectTab) effectivePanes() []ProjectPane {
 	if len(t.Panes) == 0 {
 		return []ProjectPane{{Command: t.Command}}
@@ -61,6 +75,7 @@ func (t ProjectTab) effectivePanes() []ProjectPane {
 		panes[i] = p
 		if i == 0 {
 			panes[i].Split = ""
+			panes[i].Ratio = 0
 			continue
 		}
 		if panes[i].Split == "" {
@@ -185,8 +200,9 @@ func (p Project) validate() error {
 // validateTabs checks the per-tab rules shared by projects and worktree layouts:
 // every tab needs a name; a tab uses either a single command or [[tabs.panes]],
 // never both; a tab holds at most maxPanesPerTab panes; and every non-root pane's
-// split is "down" or "right". label and source identify the owning config in
-// error messages — a project's name or a layout's repo, and the file it came from.
+// split is "down" or "right" with a ratio inside 0..1. label and source identify
+// the owning config in error messages — a project's name or a layout's repo, and
+// the file it came from.
 func validateTabs(label, source string, tabs []ProjectTab) error {
 	for i, t := range tabs {
 		if strings.TrimSpace(t.Name) == "" {
@@ -207,6 +223,12 @@ func validateTabs(label, source string, tabs []ProjectTab) error {
 				// ok — an empty split defaults to "down"
 			default:
 				return fmt.Errorf("%q (%s): tab %q pane %d has split %q; must be %q or %q", label, source, t.Name, j+1, pane.Split, SplitDown, SplitRight)
+			}
+			// A zero ratio is an omitted one — an even split. herdr silently clamps
+			// anything outside its own range, so a typo like ratio = 30 would open a
+			// workspace that looks nothing like the config; catch it at load time.
+			if pane.Ratio < 0 || pane.Ratio >= 1 {
+				return fmt.Errorf("%q (%s): tab %q pane %d has ratio %v; must be greater than 0 and less than 1", label, source, t.Name, j+1, pane.Ratio)
 			}
 		}
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -177,6 +177,11 @@ func TestProjectValidate(t *testing.T) {
 		{"too many panes", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: fivePanes}}}, true},
 		{"bad split", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Split: "sideways"}}}}}, true},
 		{"first pane split ignored", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{Split: "sideways"}}}}}, false},
+		{"ok ratio", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Ratio: 0.3}}}}}, false},
+		{"ratio as percentage", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Ratio: 30}}}}}, true},
+		{"ratio of one", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Ratio: 1}}}}}, true},
+		{"negative ratio", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{}, {Ratio: -0.2}}}}}, true},
+		{"first pane ratio ignored", Project{Name: "A", Tabs: []ProjectTab{{Name: "t", Panes: []ProjectPane{{Ratio: 30}}}}}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -229,6 +234,41 @@ func TestEffectivePanes(t *testing.T) {
 	}
 	if labeled[2].Label != "Empty" {
 		t.Fatalf("pane 2 label = %q, want Empty", labeled[2].Label)
+	}
+
+	// The root pane has nothing to split off, so its ratio is dropped; later panes
+	// keep theirs.
+	sized := ProjectTab{Name: "editor", Panes: []ProjectPane{
+		{Command: "nvim", Ratio: 0.4},
+		{Command: "lazygit", Split: "right", Ratio: 0.3},
+	}}.effectivePanes()
+	if sized[0].Ratio != 0 {
+		t.Fatalf("root pane ratio = %v, want 0", sized[0].Ratio)
+	}
+	if sized[1].Ratio != 0.3 {
+		t.Fatalf("pane 2 ratio = %v, want 0.3", sized[1].Ratio)
+	}
+}
+
+// TestSplitRatio confirms an authored ratio is flipped into the share herdr's
+// pane.split keeps for the pane being split, and that an unset ratio stays zero
+// so the request omits it.
+func TestSplitRatio(t *testing.T) {
+	cases := []struct {
+		name string
+		pane ProjectPane
+		want float64
+	}{
+		{"unset", ProjectPane{}, 0},
+		{"third", ProjectPane{Ratio: 0.25}, 0.75},
+		{"half", ProjectPane{Ratio: 0.5}, 0.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.pane.splitRatio(); got != c.want {
+				t.Fatalf("splitRatio() = %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/projects.go
+++ b/projects.go
@@ -193,7 +193,7 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []Projec
 		for j, pane := range t.effectivePanes() {
 			paneID := tabRoot
 			if j > 0 {
-				paneID, err = client.paneSplit(prev, pane.Split, false)
+				paneID, err = client.paneSplit(prev, pane.Split, pane.splitRatio(), false)
 				if err != nil {
 					return fmt.Errorf("split pane %d in tab %q: %w", j+1, t.Name, err)
 				}

--- a/www/content/docs/examples.md
+++ b/www/content/docs/examples.md
@@ -233,6 +233,7 @@ command = "make api"
 [[tabs.panes]]
 command = "make web"
 split = "right"   # beside the first pane, not below
+ratio = 0.35      # and narrower than it — `make api` keeps 65%
 
 [[tabs]]
 name = "shell"   # an empty terminal to poke around in

--- a/www/content/docs/projects.md
+++ b/www/content/docs/projects.md
@@ -133,9 +133,33 @@ Each pane:
   - `"down"` — stacked below (top/bottom).
   - `"right"` — beside it (side by side).
   - Omitted — defaults to `"down"`.
+- `ratio` — optional. How much of the split this pane takes, between `0` and `1`.
+  Omitted, the split is even.
 
-The **first pane is the tab's root**, so its `split` is ignored. Each later pane
-splits off the one before it.
+The **first pane is the tab's root**, so its `split` and `ratio` are ignored.
+Each later pane splits off the one before it.
+
+### Sizing a split
+
+`ratio` is the share the pane it is written on gets; the pane it splits off keeps
+the rest. Here the editor fills three quarters of the tab and lazygit sits in the
+last quarter:
+
+```toml
+[[tabs]]
+name = "editor"
+
+[[tabs.panes]]
+command = "nvim"
+
+[[tabs.panes]]
+command = "lazygit"
+split = "right"
+ratio = 0.25
+```
+
+A ratio outside `0`–`1` (a percentage like `30`, say) is a load-time error rather
+than a silently clamped layout.
 
 ### `command` vs. `[[tabs.panes]]` are mutually exclusive
 

--- a/www/content/docs/worktrees.md
+++ b/www/content/docs/worktrees.md
@@ -91,8 +91,9 @@ command = "./scripts/release.sh"
 
 The `[[tabs]]` format is identical to a project's. A tab can run a single
 `command`, or hold up to four panes via `[[tabs.panes]]` with `split = "down"` or
-`"right"`. See [Split panes within a tab](../projects/#split-panes-within-a-tab)
-for the full vocabulary.
+`"right"` and an optional `ratio`. See
+[Split panes within a tab](../projects/#split-panes-within-a-tab) for the full
+vocabulary.
 
 ## When nothing matches
 


### PR DESCRIPTION
Split panes are always even today, so a tab that pairs a wide editor with a narrow lazygit or log pane can't be expressed as a template — it has to be resized by hand on every open. herdr's `pane.split` already accepts a `ratio`; this exposes it in `[[tabs.panes]]`.

```toml
[[tabs]]
name = "editor"

[[tabs.panes]]
command = "nvim"

[[tabs.panes]]
command = "lazygit"
split = "right"
ratio = 0.25   # lazygit takes a quarter, nvim keeps the rest
```

### Semantics

`ratio` is the share of the split taken by the pane it is written on, so it reads off its own entry (the tmux/zellij reading). herdr's ratio is the share kept by the pane being split, so `splitRatio()` flips the value on the way out. The first pane of a tab is the tab's root and has nothing to split off, so its `ratio` is ignored — same as its `split`.

An omitted `ratio` is left out of the `pane.split` payload entirely rather than sent as `0`, so herdr keeps applying its own even split and existing projects behave exactly as before.

### Validation

herdr silently clamps an out-of-range ratio, so a typo like `ratio = 30` would open a workspace that looks nothing like the file. `validateTabs` rejects anything outside 0..1 at load time instead, in the same shape as the existing split error:

```
"Config" (Config.toml): tab "editor" pane 2 has ratio 30; must be greater than 0 and less than 1
```

Worktree auto-layouts share `validateTabs` and `layoutTabs`, so they get the same key for free.

### Testing

`make test` (with `-race`) and `go vet ./...` pass. Verified against a live herdr 0.8.0: a project with `ratio = 0.25` on a `right` split and `ratio = 0.8` on a `down` split laid out at 66/198 columns and 53/66 rows respectively, and a project with no ratios is unchanged.