### PR TITLE
projects: allow a working_dir per tab and per pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,50 @@ name = "terminal"   # no command — just an empty shell
 Tabs open in file order. The first tab reuses the workspace's root tab; the rest
 are created behind it. A tab with no `command` is just an empty shell.
 
+### A directory per tab
+
+The project's `working_dir` is where every tab starts. A tab — or a single pane —
+can override it with its own `working_dir`, which is what a monorepo usually wants:
+
+```toml
+name = "Shop"
+working_dir = "~/dev/shop"
+
+[[tabs]]
+name = "web"
+working_dir = "frontend"   # relative to the project → ~/dev/shop/frontend
+command = "npm run dev"
+
+[[tabs]]
+name = "api"
+working_dir = "backend"    # → ~/dev/shop/backend
+command = "make run"
+
+[[tabs]]
+name = "shell"             # no working_dir → the project's ~/dev/shop
+```
+
+A relative path is resolved against the project's `working_dir`, so `"frontend"`
+means what it looks like. Absolute paths, `~`, and `$VARS` work the same as they do
+at the project level. Panes inherit their tab's directory unless they set their own:
+
+```toml
+[[tabs]]
+name = "stack"
+working_dir = "frontend"
+
+[[tabs.panes]]
+command = "npm run dev"          # frontend/
+
+[[tabs.panes]]
+command = "psql shop"
+split = "right"
+working_dir = "../backend/db"    # its own directory instead
+```
+
+Every directory must exist. A missing one is reported before anything opens, so a
+typo never leaves you a half-built workspace to clean up.
+
 ### Opening by name (headless)
 
 The picker is interactive, but a project can also be opened directly — no browser,

--- a/examples/projects/example.toml
+++ b/examples/projects/example.toml
@@ -40,5 +40,13 @@ command = "npm run dev"
 split = "down"
 ratio = 0.3   # the assets pane takes the bottom 30%, the server keeps 70%
 
+# A tab — or a single pane — can override the project's working_dir. A relative
+# path is resolved against it, which is what a monorepo wants:
+#
+#   [[tabs]]
+#   name = "docs"
+#   working_dir = "docs"   # → <the project's working_dir>/docs
+#   command = "make serve"
+#
 [[tabs]]
 name = "terminal"   # no command — just an empty shell

--- a/herdr.go
+++ b/herdr.go
@@ -112,8 +112,9 @@ func (c *herdrClient) worktreeCreate(cwd, branch string, focus bool) error {
 
 // paneSplitParams builds the pane.split payload. A zero ratio is omitted so herdr
 // applies its own even split; any other value is the share of the space the target
-// pane keeps.
-func paneSplitParams(targetPaneID, direction string, ratio float64, focus bool) map[string]any {
+// pane keeps. An empty cwd is omitted too, which leaves the new pane inheriting
+// the directory of the pane it was split from.
+func paneSplitParams(targetPaneID, direction string, ratio float64, cwd string, focus bool) map[string]any {
 	params := map[string]any{
 		"target_pane_id": targetPaneID,
 		"direction":      direction,
@@ -122,21 +123,25 @@ func paneSplitParams(targetPaneID, direction string, ratio float64, focus bool) 
 	if ratio > 0 {
 		params["ratio"] = ratio
 	}
+	if strings.TrimSpace(cwd) != "" {
+		params["cwd"] = cwd
+	}
 	return params
 }
 
 // paneSplit splits the target pane in the given direction ("down" for a new pane
 // beneath it, "right" for one beside it), creating a new pane, and returns the
 // new pane's id. ratio is the share of the space the target pane keeps, zero for
-// an even split. When focus is true the new pane becomes the focused pane (the
+// an even split. cwd is the directory the new pane starts in; empty inherits the
+// split pane's. When focus is true the new pane becomes the focused pane (the
 // socket API does not focus new panes by default).
-func (c *herdrClient) paneSplit(targetPaneID, direction string, ratio float64, focus bool) (string, error) {
+func (c *herdrClient) paneSplit(targetPaneID, direction string, ratio float64, cwd string, focus bool) (string, error) {
 	var out struct {
 		Pane struct {
 			PaneID string `json:"pane_id"`
 		} `json:"pane"`
 	}
-	err := c.call("pane.split", paneSplitParams(targetPaneID, direction, ratio, focus), &out)
+	err := c.call("pane.split", paneSplitParams(targetPaneID, direction, ratio, cwd, focus), &out)
 	if err != nil {
 		return "", err
 	}
@@ -428,11 +433,27 @@ func (c *herdrClient) workspaceCreate(cwd, label string, focus bool) (workspaceI
 	return out.Workspace.WorkspaceID, out.Tab.TabID, out.RootPane.PaneID, nil
 }
 
+// tabCreateParams builds the tab.create payload. An empty cwd is omitted so the
+// tab's root pane inherits the workspace's directory, which is what a tab that
+// declares no working_dir of its own should do.
+func tabCreateParams(workspaceID, label, cwd string, focus bool) map[string]any {
+	params := map[string]any{
+		"workspace_id": workspaceID,
+		"label":        label,
+		"focus":        focus,
+	}
+	if strings.TrimSpace(cwd) != "" {
+		params["cwd"] = cwd
+	}
+	return params
+}
+
 // tabCreate adds a tab to an existing workspace and returns the new tab's id and
-// its root pane's id. focus controls whether the new tab is brought to the front
-// — a project's later tabs are created with focus=false so the first tab stays
-// active while the rest spin up behind it.
-func (c *herdrClient) tabCreate(workspaceID, label string, focus bool) (tabID, paneID string, err error) {
+// its root pane's id. cwd is the directory the tab's root pane starts in; empty
+// inherits the workspace's. focus controls whether the new tab is brought to the
+// front — a project's later tabs are created with focus=false so the first tab
+// stays active while the rest spin up behind it.
+func (c *herdrClient) tabCreate(workspaceID, label, cwd string, focus bool) (tabID, paneID string, err error) {
 	var out struct {
 		Tab struct {
 			TabID string `json:"tab_id"`
@@ -441,11 +462,7 @@ func (c *herdrClient) tabCreate(workspaceID, label string, focus bool) (tabID, p
 			PaneID string `json:"pane_id"`
 		} `json:"root_pane"`
 	}
-	err = c.call("tab.create", map[string]any{
-		"workspace_id": workspaceID,
-		"label":        label,
-		"focus":        focus,
-	}, &out)
+	err = c.call("tab.create", tabCreateParams(workspaceID, label, cwd, focus), &out)
 	if err != nil {
 		return "", "", err
 	}
@@ -458,6 +475,16 @@ func (c *herdrClient) tabRename(tabID, label string) error {
 	return c.call("tab.rename", map[string]any{
 		"tab_id": tabID,
 		"label":  label,
+	}, nil)
+}
+
+// tabClose removes a tab and everything in it. Its only caller replaces a
+// workspace's root tab with one rooted at a different directory: herdr has no way
+// to change a tab's directory after the fact, so the tab is rebuilt and the
+// original closed.
+func (c *herdrClient) tabClose(tabID string) error {
+	return c.call("tab.close", map[string]any{
+		"tab_id": tabID,
 	}, nil)
 }
 

--- a/herdr_test.go
+++ b/herdr_test.go
@@ -55,7 +55,7 @@ func TestPaneSplitParams(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := paneSplitParams("w1:p1", SplitRight, c.ratio, false)
+			got := paneSplitParams("w1:p1", SplitRight, c.ratio, "", false)
 			if got["target_pane_id"] != "w1:p1" {
 				t.Fatalf("target_pane_id = %v, want w1:p1", got["target_pane_id"])
 			}
@@ -73,5 +73,38 @@ func TestPaneSplitParams(t *testing.T) {
 				t.Fatalf("ratio = %v, want %v", ratio, c.ratio)
 			}
 		})
+	}
+}
+
+// TestPaneSplitParamsCwd confirms a pane's directory rides along only when it has
+// one: an empty cwd is left out of the payload so the new pane inherits the
+// directory of the pane it was split from, which is what a config that says
+// nothing about directories has always done.
+func TestPaneSplitParamsCwd(t *testing.T) {
+	if _, ok := paneSplitParams("w1:p1", SplitDown, 0, "", false)["cwd"]; ok {
+		t.Fatal("an empty cwd should be omitted from the pane.split payload")
+	}
+	if _, ok := paneSplitParams("w1:p1", SplitDown, 0, "   ", false)["cwd"]; ok {
+		t.Fatal("a blank cwd should be omitted from the pane.split payload")
+	}
+	got := paneSplitParams("w1:p1", SplitDown, 0, "/src/web", false)
+	if got["cwd"] != "/src/web" {
+		t.Fatalf("cwd = %v, want /src/web", got["cwd"])
+	}
+}
+
+// TestTabCreateParams confirms the tab.create contract: the workspace, label and
+// focus always ride along, and a directory is sent only when the tab has one so
+// an unset working_dir keeps inheriting the workspace's.
+func TestTabCreateParams(t *testing.T) {
+	got := tabCreateParams("w1", "editor", "", true)
+	if got["workspace_id"] != "w1" || got["label"] != "editor" || got["focus"] != true {
+		t.Fatalf("params = %v, want the workspace, label and focus carried through", got)
+	}
+	if _, ok := got["cwd"]; ok {
+		t.Fatal("an empty cwd should be omitted from the tab.create payload")
+	}
+	if got := tabCreateParams("w1", "editor", "/src/api", false); got["cwd"] != "/src/api" {
+		t.Fatalf("cwd = %v, want /src/api", got["cwd"])
 	}
 }

--- a/project.go
+++ b/project.go
@@ -32,12 +32,14 @@ const maxPanesPerTab = 4
 // tab — "down" or "right"; it is ignored for the first pane (the tab's root) and
 // defaults to "down" when omitted. Ratio is the share of the split this pane
 // takes, between 0 and 1; omitting it splits the space evenly, and it is ignored
-// for the first pane, which has nothing to split off.
+// for the first pane, which has nothing to split off. WorkingDir overrides the
+// directory the pane starts in, falling back to its tab's and then the project's.
 type ProjectPane struct {
-	Command string  `toml:"command"`
-	Split   string  `toml:"split"`
-	Label   string  `toml:"label"`
-	Ratio   float64 `toml:"ratio"`
+	Command    string  `toml:"command"`
+	Split      string  `toml:"split"`
+	Label      string  `toml:"label"`
+	Ratio      float64 `toml:"ratio"`
+	WorkingDir string  `toml:"working_dir"`
 }
 
 // splitRatio translates the pane's authored ratio — the share of the split it
@@ -60,19 +62,29 @@ type ProjectTab struct {
 	Name    string        `toml:"name"`
 	Command string        `toml:"command"`
 	Panes   []ProjectPane `toml:"panes"`
+
+	// WorkingDir overrides the directory this tab's panes start in, falling back
+	// to the project's working_dir when empty. A monorepo's frontend and backend
+	// tabs can each sit in their own subdirectory this way.
+	WorkingDir string `toml:"working_dir"`
 }
 
 // effectivePanes returns the tab's panes in creation order, normalizing the two
 // authoring forms into one list. The first pane is the tab's root (its split and
 // ratio are cleared); each later pane carries the direction it splits off the
-// previous one, defaulting to "down".
+// previous one, defaulting to "down". A pane that sets no working_dir of its own
+// inherits the tab's, so the whole tab lands in one directory unless a pane says
+// otherwise.
 func (t ProjectTab) effectivePanes() []ProjectPane {
 	if len(t.Panes) == 0 {
-		return []ProjectPane{{Command: t.Command}}
+		return []ProjectPane{{Command: t.Command, WorkingDir: t.WorkingDir}}
 	}
 	panes := make([]ProjectPane, len(t.Panes))
 	for i, p := range t.Panes {
 		panes[i] = p
+		if strings.TrimSpace(panes[i].WorkingDir) == "" {
+			panes[i].WorkingDir = t.WorkingDir
+		}
 		if i == 0 {
 			panes[i].Split = ""
 			panes[i].Ratio = 0
@@ -285,6 +297,29 @@ func expandPath(s string) (string, error) {
 		dir = filepath.Join(home, dir[2:])
 	}
 	return filepath.Clean(os.ExpandEnv(dir)), nil
+}
+
+// resolveNestedDir resolves a tab's or pane's working_dir against the workspace
+// root. An empty value returns "", meaning "say nothing and inherit" — herdr then
+// starts the tab or pane in the workspace's own directory, which is the behavior
+// a config without the key has always had.
+//
+// A relative path is joined onto root rather than left for herdr to interpret
+// against its own process directory, which makes the common monorepo shape —
+// working_dir = "web" under a project rooted at the repo — mean what it looks
+// like. ~ and $VARS expand exactly as they do in a project's working_dir.
+func resolveNestedDir(raw, root string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", nil
+	}
+	dir, err := expandPath(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve working_dir %q: %w", raw, err)
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(root, dir)
+	}
+	return dir, nil
 }
 
 // displayWorkingDir resolves the working directory for UI contexts that have no

--- a/project_test.go
+++ b/project_test.go
@@ -320,3 +320,125 @@ func TestExpandedWorkingDir(t *testing.T) {
 		}
 	}
 }
+
+// TestEffectivePanesInheritsTabWorkingDir confirms the directory fallback inside a
+// tab: a pane with no working_dir of its own takes the tab's, a pane that sets one
+// keeps it, and the single-command shorthand carries the tab's directory too.
+func TestEffectivePanesInheritsTabWorkingDir(t *testing.T) {
+	split := ProjectTab{Name: "app", WorkingDir: "~/src/web", Panes: []ProjectPane{
+		{Command: "npm run dev"},
+		{Command: "npm test", Split: SplitDown},
+		{Command: "psql", Split: SplitRight, WorkingDir: "~/src/db"},
+	}}.effectivePanes()
+
+	if split[0].WorkingDir != "~/src/web" || split[1].WorkingDir != "~/src/web" {
+		t.Fatalf("panes 1-2 dirs = %q/%q, want the tab's ~/src/web", split[0].WorkingDir, split[1].WorkingDir)
+	}
+	if split[2].WorkingDir != "~/src/db" {
+		t.Fatalf("pane 3 dir = %q, want its own ~/src/db", split[2].WorkingDir)
+	}
+
+	// The single-command shorthand is one pane, and it belongs in the tab's dir.
+	shorthand := ProjectTab{Name: "api", Command: "make run", WorkingDir: "~/src/api"}.effectivePanes()
+	if len(shorthand) != 1 || shorthand[0].WorkingDir != "~/src/api" {
+		t.Fatalf("shorthand panes = %+v, want one pane in ~/src/api", shorthand)
+	}
+
+	// A tab that says nothing about directories still produces empty ones, so the
+	// workspace's own directory is inherited exactly as before.
+	plain := ProjectTab{Name: "shell"}.effectivePanes()
+	if plain[0].WorkingDir != "" {
+		t.Fatalf("plain tab pane dir = %q, want empty", plain[0].WorkingDir)
+	}
+}
+
+// TestResolveNestedDir covers how a tab or pane's working_dir is resolved against
+// the workspace root: an empty value stays empty (inherit), a relative one is
+// joined onto the root so "web" means the repo's web/ directory, and an absolute
+// or ~-rooted one is used as written.
+func TestResolveNestedDir(t *testing.T) {
+	root := t.TempDir()
+
+	if got, err := resolveNestedDir("", root); err != nil || got != "" {
+		t.Fatalf("resolveNestedDir(\"\") = %q, %v; want an empty dir and no error", got, err)
+	}
+	if got, err := resolveNestedDir("   ", root); err != nil || got != "" {
+		t.Fatalf("resolveNestedDir(blank) = %q, %v; want an empty dir and no error", got, err)
+	}
+
+	got, err := resolveNestedDir("web", root)
+	if err != nil {
+		t.Fatalf("resolveNestedDir: %v", err)
+	}
+	if want := filepath.Join(root, "web"); got != want {
+		t.Fatalf("relative dir = %q, want %q", got, want)
+	}
+
+	abs := filepath.Join(root, "api")
+	if got, err := resolveNestedDir(abs, root); err != nil || got != abs {
+		t.Fatalf("absolute dir = %q, %v; want %q unchanged", got, err, abs)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory on this machine")
+	}
+	if got, err := resolveNestedDir("~/src", root); err != nil || got != filepath.Join(home, "src") {
+		t.Fatalf("~-rooted dir = %q, %v; want %q", got, err, filepath.Join(home, "src"))
+	}
+}
+
+// TestResolvePaneDirs confirms the pre-flight pass layoutTabs runs before it
+// touches a workspace: it resolves each pane's directory in the order the tabs are
+// laid out, leaves an unset one empty so the workspace's is inherited, and refuses
+// a directory that does not exist rather than building half a workspace.
+func TestResolvePaneDirs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "web"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tabs := []ProjectTab{
+		{Name: "shell"},
+		{Name: "app", WorkingDir: "web", Panes: []ProjectPane{{Command: "a"}, {Command: "b", Split: SplitDown}}},
+	}
+	dirs, err := resolvePaneDirs(root, tabs)
+	if err != nil {
+		t.Fatalf("resolvePaneDirs: %v", err)
+	}
+	if len(dirs) != 2 || len(dirs[0]) != 1 || len(dirs[1]) != 2 {
+		t.Fatalf("dirs shape = %v, want one entry per pane per tab", dirs)
+	}
+	if dirs[0][0] != root {
+		t.Fatalf("tab with no working_dir = %q, want the workspace root %q", dirs[0][0], root)
+	}
+	web := filepath.Join(root, "web")
+	if dirs[1][0] != web || dirs[1][1] != web {
+		t.Fatalf("tab dirs = %q/%q, want both %q", dirs[1][0], dirs[1][1], web)
+	}
+
+	// With no root to anchor to, an undeclared directory stays empty so herdr's own
+	// inheritance keeps working — the behavior every config had before this key.
+	rootless, err := resolvePaneDirs("", []ProjectTab{{Name: "shell"}})
+	if err != nil {
+		t.Fatalf("resolvePaneDirs with no root: %v", err)
+	}
+	if rootless[0][0] != "" {
+		t.Fatalf("dir with no root = %q, want empty", rootless[0][0])
+	}
+
+	// A directory that is not there fails up front, naming the tab and pane.
+	missing := []ProjectTab{{Name: "api", WorkingDir: "nope"}}
+	if _, err := resolvePaneDirs(root, missing); err == nil {
+		t.Fatal("expected a missing working_dir to be rejected")
+	}
+
+	// So does a path that exists but is a file rather than a directory.
+	file := filepath.Join(root, "README")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := resolvePaneDirs(root, []ProjectTab{{Name: "api", WorkingDir: "README"}}); err == nil {
+		t.Fatal("expected a file working_dir to be rejected")
+	}
+}

--- a/projects.go
+++ b/projects.go
@@ -112,13 +112,21 @@ func openProject(client *herdrClient, p Project) error {
 		return fmt.Errorf("working directory does not exist: %s", dir)
 	}
 
+	// Check every tab and pane directory now, while backing out still costs
+	// nothing. layoutTabs would catch the same problem, but only after the
+	// workspace exists — leaving the user an empty workspace to close by hand.
+	if err := checkTabDirs(dir, p.Tabs); err != nil {
+		return err
+	}
+
 	ws, rootTab, rootPane, err := client.workspaceCreate(dir, p.Name, true)
 	if err != nil {
 		return fmt.Errorf("create workspace: %w", err)
 	}
 
-	// Lay the project's tabs into the new workspace.
-	return layoutTabs(client, ws, rootTab, rootPane, p.Tabs)
+	// Lay the project's tabs into the new workspace. dir anchors any per-tab or
+	// per-pane working_dir written relative to the project.
+	return layoutTabs(client, ws, rootTab, rootPane, dir, p.Tabs)
 }
 
 // openProjectAsWorktree creates a git worktree from the project's working
@@ -167,14 +175,66 @@ func isInsideGitWorkTree(dir string) bool {
 	return strings.TrimSpace(string(out)) == "true"
 }
 
+// resolvePaneDirs resolves the directory every pane of every tab should start in,
+// returning a table indexed the same way layoutTabs walks them: dirs[i][j] is tab
+// i pane j. A pane that declares no working_dir of its own gets root, the
+// workspace's own directory.
+//
+// Every pane gets an explicit directory rather than being left to inherit one:
+// herdr starts a new tab in the directory of the tab that was active when it was
+// created, not the workspace's, so a tab declaring no working_dir would otherwise
+// drift into whichever directory the tab before it happened to use. Naming the
+// directory every time makes each tab depend only on its own config.
+//
+// It runs as one pass up front so a mistyped path fails before any tab is
+// created, rather than stranding the user with half a workspace. Each resolved
+// directory must already exist — herdr would either error or silently start
+// somewhere unexpected, and a clear message naming the tab is far more useful.
+func resolvePaneDirs(root string, tabs []ProjectTab) ([][]string, error) {
+	dirs := make([][]string, len(tabs))
+	for i, t := range tabs {
+		panes := t.effectivePanes()
+		dirs[i] = make([]string, len(panes))
+		for j, pane := range panes {
+			dir, err := resolveNestedDir(pane.WorkingDir, root)
+			if err != nil {
+				return nil, fmt.Errorf("tab %q pane %d: %w", t.Name, j+1, err)
+			}
+			if dir == "" {
+				// Nothing declared, so the workspace's own directory it is. A caller
+				// with no root to offer passes "", which omits the key and leaves
+				// herdr's inheritance in charge exactly as it was before.
+				dirs[i][j] = root
+				continue
+			}
+			if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+				return nil, fmt.Errorf("tab %q pane %d: working directory does not exist: %s", t.Name, j+1, dir)
+			}
+			dirs[i][j] = dir
+		}
+	}
+	return dirs, nil
+}
+
+// checkTabDirs reports whether every tab and pane directory in tabs resolves and
+// exists, without creating anything. It lets a caller fail before committing to a
+// workspace it would then have to tear down.
+func checkTabDirs(root string, tabs []ProjectTab) error {
+	_, err := resolvePaneDirs(root, tabs)
+	return err
+}
+
 // layoutTabs lays an ordered list of tabs — each with its panes and optional
 // startup commands — into an existing workspace whose root tab and root pane are
-// rootTab and rootPane. tab[0] reuses the root tab (renamed) and root pane; each
-// later tab is created without focus so the first stays in front while the rest
-// spin up. Within a tab the first pane is the tab's root and each later pane is
-// split off the previous one. Every startup command is run last, once all panes
-// exist, paced to its freshly spawned shell.
-func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []ProjectTab) error {
+// rootTab and rootPane, and whose own directory is root. tab[0] reuses the root
+// tab (renamed) and root pane; each later tab is created without focus so the
+// first stays in front while the rest spin up. Within a tab the first pane is the
+// tab's root and each later pane is split off the previous one. Every startup
+// command is run last, once all panes exist, paced to its freshly spawned shell.
+//
+// root anchors the optional per-tab and per-pane working_dir: a relative one is
+// resolved against it, and a tab or pane that declares none simply inherits it.
+func layoutTabs(client *herdrClient, ws, rootTab, rootPane, root string, tabs []ProjectTab) error {
 	// pendingRun pairs a pane with the command it should run once all panes exist.
 	type pendingRun struct {
 		pane    string
@@ -183,14 +243,34 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []Projec
 	var runs []pendingRun
 	var err error
 
+	// Resolve every pane's directory before touching the workspace. A bad path
+	// found halfway through would otherwise leave a half-built workspace behind,
+	// which is worse than not starting. dirs[i][j] is tab i pane j's directory.
+	dirs, err := resolvePaneDirs(root, tabs)
+	if err != nil {
+		return err
+	}
+
 	for i, t := range tabs {
 		tabRoot := rootPane
 		if i == 0 {
-			if err = client.tabRename(rootTab, t.Name); err != nil {
+			// The root tab already exists at the workspace's directory. When this tab
+			// wants a different one there is nothing to change it with — herdr has no
+			// "set a tab's cwd" call — so the tab is rebuilt where it belongs and the
+			// original closed, leaving the new one first in the workspace.
+			if dir := dirs[i][0]; dir != "" && dir != root {
+				_, tabRoot, err = client.tabCreate(ws, t.Name, dir, true)
+				if err != nil {
+					return fmt.Errorf("create tab %q: %w", t.Name, err)
+				}
+				if err = client.tabClose(rootTab); err != nil {
+					return fmt.Errorf("close the replaced root tab: %w", err)
+				}
+			} else if err = client.tabRename(rootTab, t.Name); err != nil {
 				return fmt.Errorf("rename root tab: %w", err)
 			}
 		} else {
-			_, tabRoot, err = client.tabCreate(ws, t.Name, false)
+			_, tabRoot, err = client.tabCreate(ws, t.Name, dirs[i][0], false)
 			if err != nil {
 				return fmt.Errorf("create tab %q: %w", t.Name, err)
 			}
@@ -200,7 +280,7 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane string, tabs []Projec
 		for j, pane := range t.effectivePanes() {
 			paneID := tabRoot
 			if j > 0 {
-				paneID, err = client.paneSplit(prev, pane.Split, pane.splitRatio(), false)
+				paneID, err = client.paneSplit(prev, pane.Split, pane.splitRatio(), dirs[i][j], false)
 				if err != nil {
 					return fmt.Errorf("split pane %d in tab %q: %w", j+1, t.Name, err)
 				}

--- a/worktree.go
+++ b/worktree.go
@@ -286,7 +286,7 @@ func runOnWorktreeEvent(_ []string) {
 		return
 	}
 
-	if err := layoutTabs(client, ev.WorkspaceID, ev.RootTabID, ev.RootPaneID, layout.Tabs); err != nil {
+	if err := layoutTabs(client, ev.WorkspaceID, ev.RootTabID, ev.RootPaneID, ev.CheckoutPath, layout.Tabs); err != nil {
 		errExit("apply worktree layout:", err)
 	}
 

--- a/www/content/docs/projects.md
+++ b/www/content/docs/projects.md
@@ -104,9 +104,43 @@ order. Each tab has:
 - `name` — **required**, the tab's label.
 - `command` — optional. The startup command, run as if typed at the prompt. A
   tab with no `command` (and no panes) is just an empty shell.
+- `working_dir` — optional. The directory this tab starts in, overriding the
+  project's. See [A directory per tab](#a-directory-per-tab).
 
 The first tab reuses the workspace's root tab (it's renamed to the tab's name);
 every later tab is created behind it.
+
+## A directory per tab
+
+The project's `working_dir` is where every tab starts. A tab can override it,
+which is what a monorepo usually wants — the frontend and the backend each in
+their own subdirectory:
+
+```toml
+name = "Shop"
+working_dir = "~/dev/shop"
+
+[[tabs]]
+name = "web"
+working_dir = "frontend"   # relative to the project → ~/dev/shop/frontend
+command = "npm run dev"
+
+[[tabs]]
+name = "api"
+working_dir = "backend"    # → ~/dev/shop/backend
+command = "make run"
+
+[[tabs]]
+name = "shell"             # no working_dir → the project's ~/dev/shop
+```
+
+A **relative** path is resolved against the project's `working_dir`, so
+`"frontend"` means what it looks like rather than something relative to wherever
+herdr happens to be running. Absolute paths, `~`, and `$VARS` behave exactly as
+they do at the project level.
+
+Every directory must already exist. A missing one is reported *before* anything
+opens, so a typo never leaves a half-built workspace behind.
 
 ## Split panes within a tab
 
@@ -135,6 +169,8 @@ Each pane:
   - Omitted — defaults to `"down"`.
 - `ratio` — optional. How much of the split this pane takes, between `0` and `1`.
   Omitted, the split is even.
+- `working_dir` — optional. The directory this pane starts in. Omitted, it
+  inherits its tab's. See [A pane in its own directory](#a-pane-in-its-own-directory).
 
 The **first pane is the tab's root**, so its `split` and `ratio` are ignored.
 Each later pane splits off the one before it.
@@ -160,6 +196,28 @@ ratio = 0.25
 
 A ratio outside `0`–`1` (a percentage like `30`, say) is a load-time error rather
 than a silently clamped layout.
+
+### A pane in its own directory
+
+Panes start in their tab's directory. A pane that wants a different one says so,
+and the rest of the tab is unaffected:
+
+```toml
+[[tabs]]
+name = "stack"
+working_dir = "frontend"
+
+[[tabs.panes]]
+command = "npm run dev"          # frontend/
+
+[[tabs.panes]]
+command = "psql shop"
+split = "right"
+working_dir = "../backend/db"    # its own directory instead
+```
+
+A pane's `working_dir` resolves the same way a tab's does — relative to the
+project's `working_dir`, with `~` and `$VARS` expanded.
 
 ### `command` vs. `[[tabs.panes]]` are mutually exclusive
 

--- a/www/content/docs/worktrees.md
+++ b/www/content/docs/worktrees.md
@@ -91,9 +91,13 @@ command = "./scripts/release.sh"
 
 The `[[tabs]]` format is identical to a project's. A tab can run a single
 `command`, or hold up to four panes via `[[tabs.panes]]` with `split = "down"` or
-`"right"` and an optional `ratio`. See
+`"right"` and an optional `ratio`, and either can set a `working_dir`. See
 [Split panes within a tab](../projects/#split-panes-within-a-tab) for the full
 vocabulary.
+
+A layout has no `working_dir` of its own — the worktree's checkout is the root — so
+a tab's relative `working_dir` is resolved against the worktree, which is what makes
+one layout work for every worktree of the repo.
 
 ## When nothing matches
 


### PR DESCRIPTION
Closes #35.

A project's `working_dir` is the whole workspace's directory today, so a monorepo has to be split across several project files just to put its frontend and backend tabs in different places. This lets a tab — or a single pane — set its own.

```toml
name = "Shop"
working_dir = "~/dev/shop"

[[tabs]]
name = "web"
working_dir = "frontend"   # relative to the project → ~/dev/shop/frontend
command = "npm run dev"

[[tabs]]
name = "api"
working_dir = "backend"
command = "make run"

[[tabs]]
name = "shell"             # no working_dir → the project's ~/dev/shop
```

### Semantics

A **relative** path resolves against the project's `working_dir`, so `"frontend"` means what it looks like rather than something relative to wherever herdr happens to be running. Absolute paths, `~`, and `$VARS` behave as they do at the project level. Panes inherit their tab's directory unless they set their own. Worktree layouts share `layoutTabs`, so they get the key too, anchored at the worktree checkout.

### Two things worth calling out

**Every pane is now given an explicit directory, even when it declares none.** herdr starts a new tab in the directory of the tab that was *active when it was created*, not the workspace's. So relying on inheritance meant a tab with no `working_dir` drifted into whichever directory the tab before it happened to use — I hit exactly that while testing: a plain tab following a `frontend` tab opened in `frontend/`. Naming the directory every time makes each tab depend only on its own config.

**The first tab is rebuilt when it wants its own directory.** It reuses the workspace's root tab, and herdr has no call to change a tab's directory after the fact — so it is recreated where it belongs and the original root tab closed, which leaves the new one first in the workspace. Only paid when the first tab actually sets a `working_dir`.

Directories are resolved and checked *before* `workspace.create`, so a typo fails with nothing to clean up rather than leaving an empty workspace behind.

### Testing

`go vet ./...` and `go test -race ./...` pass. New unit coverage for the tab→pane inheritance, relative/absolute/`~` resolution, the pre-flight pass, and the `cwd` key being omitted from the `tab.create` / `pane.split` payloads when empty.

Verified against a live herdr 0.8.2 with a four-tab project (relative tab dir, second relative tab dir, no dir, and a split tab with per-pane dirs): all panes landed in the right directory, repeated five times to rule out ordering flakiness. A missing directory fails with `tab "nope" pane 1: working directory does not exist: …` and creates no workspace.

Docs: README, the projects and worktrees pages on the site, and the seeded example.