### PR TITLE
site: add Harbor sponsor banner above the nav

### DIFF
--- a/www/assets/css/app.css
+++ b/www/assets/css/app.css
@@ -212,6 +212,9 @@
   .card {
     background: var(--color-surface); border: 1px solid var(--color-line);
     border-radius: var(--radius-lg); box-shadow: var(--shadow-card);
+    /* Grid/flex items default to min-width:auto, which would let a card's
+       nowrap contents (a codebox command) widen its track past the viewport. */
+    min-width: 0;
   }
   .card-hover { transition: transform .2s ease, box-shadow .25s ease, border-color .2s ease; }
   .card-hover:hover { transform: translateY(-3px); box-shadow: var(--shadow-lift); border-color: var(--color-line-strong); }
@@ -251,7 +254,9 @@
     font-family: var(--font-mono); font-size: .9rem; overflow: hidden;
   }
   .codebox .prompt { color: var(--color-accent); user-select: none; }
-  .codebox code { color: var(--color-ink); white-space: nowrap; overflow-x: auto; flex: 1; scrollbar-width: none; }
+  /* min-width:0 lets the flex item shrink past its content so the nowrap command
+     scrolls inside the box instead of pushing the page wider on narrow screens. */
+  .codebox code { color: var(--color-ink); white-space: nowrap; overflow-x: auto; flex: 1; min-width: 0; scrollbar-width: none; }
   .codebox code::-webkit-scrollbar { display: none; }
   .copy-btn {
     display: inline-flex; align-items: center; gap: .35rem; flex: none;
@@ -341,6 +346,22 @@
   .toc a { display: block; padding: .25rem 0; font-size: .85rem; color: var(--color-muted); border-left: 2px solid var(--color-line); padding-left: .8rem; transition: all .12s ease; }
   .toc a:hover { color: var(--color-ink); border-color: var(--color-accent); }
   .toc ul ul a { padding-left: 1.6rem; }
+
+  /* ---- sponsor strip (above the nav) --------------------------------- */
+  /* An accent tint rather than a surface fill, so the strip reads as a note
+     about the site instead of a piece of the nav sitting under it. */
+  .sponsor-bar {
+    background: var(--color-accent-soft);
+    border-bottom: 1px solid var(--color-line);
+  }
+  .sponsor-bar-link { display: block; color: var(--color-ink); transition: background-color .18s ease; }
+  .sponsor-bar-link:hover { background: color-mix(in srgb, var(--color-accent) 12%, transparent); }
+  /* Inset so the ring stays inside the strip instead of being clipped by it. */
+  .sponsor-bar-link:focus-visible { outline-offset: -3px; border-radius: 0; }
+  .sponsor-bar-mark { color: var(--color-accent-ink); }
+  .sponsor-bar-name { font-weight: 600; color: var(--color-accent-ink); }
+  .sponsor-bar-tail { color: var(--color-muted); }
+  .sponsor-bar-arrow { color: var(--color-accent-ink); margin-left: .1rem; }
 
   /* ---- misc ----------------------------------------------------------- */
   .link-accent { color: var(--color-accent-ink); font-weight: 600; }

--- a/www/hugo.toml
+++ b/www/hugo.toml
@@ -63,6 +63,11 @@ disableKinds = ["taxonomy", "term", "RSS"]
   company  = "Cloudmanic Labs, LLC"
   location = "Newberg, Oregon"
 
+  # Sponsor strip above the nav. Clearing either param hides the strip sitewide.
+  # The URL carries UTM params so Harbor can attribute the referral.
+  sponsorName = "Harbor"
+  sponsorUrl  = "https://harbor.my/?utm_source=herdrplus&utm_medium=referral&utm_campaign=oss-sponsorship&utm_content=top-banner"
+
 # Allow raw HTML in markdown (used sparingly in docs) and configure the TOC.
 [markup]
   [markup.goldmark.renderer]

--- a/www/layouts/_default/baseof.html
+++ b/www/layouts/_default/baseof.html
@@ -20,6 +20,7 @@
   {{ if .IsHome }}{{ partial "schema.html" . }}{{ end }}
 </head>
 <body class="min-h-screen antialiased">
+  {{ partial "sponsor-banner.html" . }}
   {{ partial "nav.html" . }}
   <main id="main">
     {{ block "main" . }}{{ end }}

--- a/www/layouts/partials/icon.html
+++ b/www/layouts/partials/icon.html
@@ -35,4 +35,6 @@
 <svg class="{{ $c }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
 {{- else if eq $n "sparkle" -}}
 <svg class="{{ $c }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M18.4 5.6l-2.8 2.8M8.4 15.6l-2.8 2.8"/></svg>
+{{- else if eq $n "anchor" -}}
+<svg class="{{ $c }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="4.2" r="1.9"/><path d="M12 6v14"/><path d="M6.5 10.5h11"/><path d="M4.5 13c0 4.2 3.4 7 7.5 7s7.5-2.8 7.5-7"/><path d="M4.5 13l-1.8.9M19.5 13l1.8.9"/></svg>
 {{- end -}}

--- a/www/layouts/partials/sponsor-banner.html
+++ b/www/layouts/partials/sponsor-banner.html
@@ -1,0 +1,34 @@
+{{- /*
+  sponsor-banner.html — slim sitewide strip crediting the project's sponsor.
+  Created on 2026-08-27. Copyright © 2026 Cloudmanic Labs, LLC.
+
+  Sits above the sticky nav and scrolls away with the page, so the sponsor is
+  seen on arrival without permanently eating vertical space. The whole strip is
+  the link — a bigger target than one word — and carries its own aria-label, so
+  the trailing arrow is decoration rather than the only cue that it navigates.
+
+  Renders nothing unless both sponsor params are set in hugo.toml.
+*/ -}}
+{{- $p := .Site.Params -}}
+{{- if and $p.sponsorUrl $p.sponsorName -}}
+<div class="sponsor-bar">
+  <a href="{{ $p.sponsorUrl }}"
+     class="sponsor-bar-link group"
+     aria-label="{{ $p.sponsorName }} sponsors herdr-plus — visit {{ $p.sponsorName }}, the private notes app you own for life">
+    <p class="container-x flex flex-wrap items-center justify-center gap-x-2 gap-y-1 py-2 text-center text-[13px] leading-snug">
+      <span class="inline-flex items-center gap-1.5 whitespace-nowrap">
+        {{ partial "icon.html" (dict "name" "anchor" "class" "h-[15px] w-[15px] shrink-0 sponsor-bar-mark") }}
+        {{- /* Full sentence on desktop, a trimmed one where the strip gets tight. */ -}}
+        <span class="hidden sm:inline">herdr-plus is free and open source, sponsored by</span>
+        <span class="sm:hidden">Sponsored by</span>
+        <span class="sponsor-bar-name group-hover:underline underline-offset-4">{{ $p.sponsorName }}</span>
+      </span>
+      <span class="sponsor-bar-tail whitespace-nowrap">
+        <span class="hidden sm:inline">— the private notes app you own for life.</span>
+        <span class="sm:hidden">— notes you own for life</span>
+        <span class="sponsor-bar-arrow" aria-hidden="true">&rarr;</span>
+      </span>
+    </p>
+  </a>
+</div>
+{{- end -}}


### PR DESCRIPTION
Adds a slim sitewide strip above the nav crediting Harbor as the sponsor of this open-source project, linking to harbor.my with UTM attribution.

## What it looks like

**Dark**

![Sponsor banner, dark theme](https://screen-capture-osx.s3.us-east-1.amazonaws.com/public/e1bc97842c1d51e9a6b0b633db617e86.png)

**Light**

![Sponsor banner, light theme](https://screen-capture-osx.s3.us-east-1.amazonaws.com/public/9ab693b3ac9b531bf8114dfdb1c3ee81.png)

**Mobile (375px)** — still one line, on the trimmed copy

![Sponsor banner on mobile](https://screen-capture-osx.s3.us-east-1.amazonaws.com/public/3b3be6d6e5faff4ec7221d9eb7370a0c.png)

## Details

- **Placement** — `layouts/partials/sponsor-banner.html`, rendered from `baseof.html` above the nav partial, so it appears on every page including docs. It scrolls away with the page; the nav keeps the only sticky spot at the top.
- **Design** — styled entirely from the site's own tokens (`--color-accent-soft` fill, `--color-line` hairline, `--color-accent-ink` for the name and mark), so it reads as native in both themes with no Harbor palette pasted in. 35px tall, one line from 320px up.
- **Copy** — full sentence on desktop, trimmed on narrow screens:
  - `>=640px` — herdr-plus is free and open source, sponsored by **Harbor** — the private notes app you own for life. →
  - `<640px` — Sponsored by **Harbor** — notes you own for life →
- **Logo** — Harbor's anchor mark added to the inline icon set (`icon.html`), so it inherits `currentColor` and needs no per-theme asset.
- **Accessibility** — the whole strip is the link with its own `aria-label`, so the arrow is decoration rather than the only cue that it navigates. The focus ring is inset so it isn't clipped by the strip.
- **Config** — `sponsorName` and `sponsorUrl` are `hugo.toml` params. Clearing either one hides the strip sitewide.

## Drive-by fix

The narrow-viewport check turned up an unrelated pre-existing bug: `.card` is a grid item, and a grid item's default `min-width: auto` let a codebox's `nowrap` command widen its grid track past the viewport, so the whole page scrolled sideways below ~360px. `.card` and `.codebox code` now set `min-width: 0`, and the command scrolls inside its own box as intended. Verified no visual change at desktop widths.
