### PR TITLE
site: add Feasible analytics alongside Plausible

### DIFF
--- a/www/layouts/partials/head.html
+++ b/www/layouts/partials/head.html
@@ -50,3 +50,6 @@
   window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
   plausible.init()
 </script>
+
+{{- /* Second analytics source: Feasible, running alongside Plausible */ -}}
+<script defer src="https://app.feasible.lol/js/fs-iftkunmtcsxt2dml.js"></script>


### PR DESCRIPTION
Adds the Feasible tracking snippet to the site head partial, right after the existing Plausible script. Both analytics tools now run side by side.

Verified with a local `hugo` build: the `<script defer src="https://app.feasible.lol/js/fs-iftkunmtcsxt2dml.js">` tag renders inside `<head>` on all 14 generated pages.