### PR TITLE
site: add Fathom analytics alongside Plausible and Feasible

### DIFF
--- a/www/layouts/partials/head.html
+++ b/www/layouts/partials/head.html
@@ -53,3 +53,6 @@
 
 {{- /* Second analytics source: Feasible, running alongside Plausible */ -}}
 <script defer src="https://app.feasible.lol/js/fs-iftkunmtcsxt2dml.js"></script>
+
+{{- /* Third analytics source: Fathom, running alongside Plausible and Feasible */ -}}
+<script src="https://cdn.usefathom.com/script.js" data-site="BIINRIBP" defer></script>


### PR DESCRIPTION
Adds the Fathom tracking snippet to the site head partial, next to the existing Plausible and Feasible scripts. All three now run side by side.

No custom analytics events were mirrored because the site does not track any — Plausible and Feasible are both pageview-only, with no `plausible()` goal calls or event attributes anywhere in the repo. Fathom therefore matches their coverage exactly.

Verified with a local `hugo` build: the Fathom tag renders inside `<head>` on all 14 generated pages.