### PR TITLE
fix: send --target-pane only where the placement accepts one

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,8 @@
 # cross-compiles the binary, archives it, attaches it to a GitHub Release, and
 # pushes an updated Homebrew formula into Formula/ in this same repo.
 #
-# These prebuilt archives are also what `herdr plugin install` downloads when the
-# machine has no Go toolchain (see scripts/build.sh).
+# These prebuilt archives support standalone installation. Plugin installation
+# builds the checked-out source with Go (see scripts/build.sh).
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,47 @@ so this applies to projects whose `working_dir` is a git checkout root. A projec
 pointing at a plain (non-git) directory, or at a *subdirectory* of a checkout,
 has no such provenance and keeps the old behavior — a new workspace every time.
 
+## Shared worktree policy
+
+The optional `worktree` action and Projects' Ctrl+G share a planner with external
+callers such as an issue picker. Configure one policy per primary repository:
+
+```toml
+[worktree]
+branch_prefix = "your-name/"
+
+[[worktree.projects]]
+name = "project"
+repository = "~/code/project"
+root = "~/code/worktrees/project"
+max_tail = 29
+# base = "develop" # optional remote branch override
+```
+
+The picker shows the resulting branch and checkout path before applying it.
+Existing branches and registered paths are preserved. Issue matches use complete
+identifiers, so `IC-177` cannot select `IC-1770`; multiple matching branches remain
+explicit choices. New descriptions become lowercase kebab case within `max_tail`.
+New checkout directories replace branch slashes with `--` under the configured root.
+
+New branches use the remote's current default branch, or the configured override.
+Missing or unreadable remote defaults produce an error. Existing branches need
+neither a base query nor a fetch. The primary project must already be open with
+native checkout provenance; applying a selection never creates an implicit parent.
+
+For external callers, `plan-worktree --cwd /absolute/checkout --name "description"
+--issue IC-177` returns versioned JSON with `candidates` and a `fingerprint`.
+Planning reads Git and remote metadata without creating directories, fetching, or
+changing branches. Pass the same inputs plus `--candidate <id> --fingerprint <hash>`
+to `apply-worktree`. It rebuilds the plan, refuses stale or absent selections, and
+delegates native creation/opening to `ensure-worktree`. Its `result` preserves the
+native workspace, pane and checkout fields. Cancelling means never invoking apply.
+
+The W action requires Herdr's explicit invoking-pane context and opens a temporary
+overlay picker. It never chooses a project from another client's current focus.
+`ensure-worktree` also accepts an optional `--workspace` for an explicitly verified
+primary workspace; the older explicit-cwd interface remains available.
+
 ## Quick Actions
 
 A fuzzy launcher for one-off commands. Trigger it (action

--- a/README.md
+++ b/README.md
@@ -412,7 +412,15 @@ leaves its tabs, panes and running commands untouched; the next open then finds
 it. If that binding fails you are told so at the time, and the workspace itself
 is left alone and perfectly usable.
 
-Two consequences worth knowing:
+Whether a project is a Git checkout at all is herdr's answer, not a guess: if
+herdr says the directory is not inside a Git work tree, the project opens as it
+always has. If Git itself cannot be read — no `git` on `PATH`, a corrupt or
+unreadable registry, a listing that contradicts herdr — you get an error *before*
+anything is created, because at that point nobody can tell whether the project is
+already open, and a wrong guess is the duplicate workspace this is meant to
+prevent.
+
+Three consequences worth knowing:
 
 - Binding a **linked worktree** asks herdr to act from the repository's primary
   checkout, which is what herdr requires. If that primary checkout is not open,

--- a/README.md
+++ b/README.md
@@ -502,7 +502,10 @@ delegates native creation/opening to `ensure-worktree`. Its `result` preserves t
 native workspace, pane and checkout fields. Cancelling means never invoking apply.
 
 The W action requires Herdr's explicit invoking-pane context and opens a temporary
-overlay picker. It never chooses a project from another client's current focus.
+overlay picker. It never chooses a project from another client's current focus: the
+checkout it plans against is the verified invoking pane's, and an invoking pane that
+has moved refuses the launch. Herdr places an overlay over the active pane itself, so
+that part is native's choice, not this plugin's.
 `ensure-worktree` also accepts an optional `--workspace` for an explicitly verified
 primary workspace. In that mode Plus checks its native repository provenance and
 sends `workspace_id` without `cwd` to native create/open; the older explicit-cwd
@@ -512,10 +515,14 @@ interface remains available.
 
 A fuzzy launcher for one-off commands. Trigger it (action
 `cloudmanic.herdr-plus.quick-actions`), fuzzy-pick an action, and it runs in the
-directory you launched from. The picker opens over the pane the action fired
-from — verified against herdr, not read from live focus, so another client
-moving focus cannot land it somewhere else — and an invoking pane that cannot be
-established is reported as a notification instead of opening a picker. Actions are TOML files in the `quick-actions/` subdir
+directory you launched from. That directory is the pane the action fired from,
+verified against herdr rather than read from live focus, so another client
+moving focus cannot make the picker run commands somewhere else; an invoking
+pane that cannot be established is reported as a notification instead of
+opening a picker. Where the picker is *drawn* follows the placement: a `split`,
+`tab` or `zoomed` picker is opened over that same verified pane, while
+`overlay` and `popup` cover whichever pane is active, because Herdr 0.9 places
+those itself and refuses an explicit target pane for them. Actions are TOML files in the `quick-actions/` subdir
 of [herdr-plus's config dir](#configuration) (seeded with editable examples on
 first run). A repo can also ship its own in `<repo>/.herdr-plus/quick-actions/`, shown
 under a **Project** heading above your **Global** ones — this repo ships

--- a/README.md
+++ b/README.md
@@ -420,17 +420,24 @@ anything is created, because at that point nobody can tell whether the project i
 already open, and a wrong guess is the duplicate workspace this is meant to
 prevent.
 
-Three consequences worth knowing:
+Binding has these limits:
 
 - Binding a **linked worktree** asks herdr to act from the repository's primary
-  checkout, which is what herdr requires. If that primary checkout is not open,
-  herdr opens it as a background workspace of its own — its normal grouping.
-- If a workspace already has your project's checkout open but carries no
-  provenance (it was made by an older version of this plugin, say), the open is
+  checkout, which is what herdr requires. Open the primary-checkout project
+  first. Otherwise this plugin refuses before creating anything: native grouping
+  would create an empty parent that could later shadow the primary project's
+  configured layout. Binding names the verified parent workspace explicitly, so
+  closing it during the operation produces an error, not another parent.
+- If herdr reports an open workspace in your project's checkout but it carries no
+  provenance (including a scratch workspace whose shell entered that checkout), the open is
   **refused** with a message naming it. Nothing is created and nothing is
   changed: that workspace cannot be verified as your project, and guessing is
-  exactly what this feature refuses to do. Close it, or open the checkout through
-  herdr's own worktree open, and try again.
+  exactly what this feature refuses to do. Inspect it and close it when safe, or
+  open the checkout through herdr's own worktree open, and try again.
+- Reuse requires a repository herdr can list and a non-bare primary checkout.
+  Bare-main repositories are unsupported with this opt-in setting; turn it off
+  to retain the original project-opening behavior. Repository trust errors are
+  reported without granting trust automatically.
 
 **Limitations:** identity comes from the checkout herdr records for a workspace,
 so this applies to projects whose `working_dir` is a git checkout root. A project

--- a/README.md
+++ b/README.md
@@ -466,15 +466,25 @@ max_tail = 29
 ```
 
 The picker shows the resulting branch and checkout path before applying it.
+Shared policies require a nonempty `branch_prefix` ending in `/` and a
+`max_tail` between 1 and 200 for each project. Legacy worktree creation still
+allows an empty prefix when that repository has no shared policy.
 Existing branches and registered paths are preserved. Issue matches use complete
 identifiers, so `IC-177` cannot select `IC-1770`; multiple matching branches remain
 explicit choices. New descriptions become lowercase kebab case within `max_tail`.
 New checkout directories replace branch slashes with `--` under the configured root.
+When an issue already has matching branches, the picker offers those existing
+branches. To deliberately create an additional branch for the same issue, use
+the explicit `ensure-worktree` command.
 
 New branches use the remote's current default branch, or the configured override.
 Missing or unreadable remote defaults produce an error. Existing branches need
-neither a base query nor a fetch. The primary project must already be open with
-native checkout provenance; applying a selection never creates an implicit parent.
+neither a base query nor a fetch. Plus requires an open primary project with
+verified native checkout provenance before submitting creation to Herdr, and
+addresses that workspace explicitly. Keep the primary open until creation
+finishes: Herdr 0.9 can select or create a replacement parent if it disappears
+during the asynchronous Git operation. Plus does not control that native
+completion behavior or run a second creation attempt.
 
 For external callers, `plan-worktree --cwd /absolute/checkout --name "description"
 --issue IC-177` returns versioned JSON with `candidates` and a `fingerprint`.
@@ -487,7 +497,9 @@ native workspace, pane and checkout fields. Cancelling means never invoking appl
 The W action requires Herdr's explicit invoking-pane context and opens a temporary
 overlay picker. It never chooses a project from another client's current focus.
 `ensure-worktree` also accepts an optional `--workspace` for an explicitly verified
-primary workspace; the older explicit-cwd interface remains available.
+primary workspace. In that mode Plus checks its native repository provenance and
+sends `workspace_id` without `cwd` to native create/open; the older explicit-cwd
+interface remains available.
 
 ## Quick Actions
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,59 @@ is the scriptable entry point for spinning up a known workspace in one shot — 
 for shell aliases, scripts, and AI agents. (To get `herdr-plus` on your `PATH`, see
 [Just the binary](#just-the-binary).)
 
+### Ensuring a worktree (headless API)
+
+```sh
+herdr-plus ensure-worktree --cwd /absolute/repo --branch feature/a \
+  --base main --path '/absolute/worktrees/new checkout' [--focus]
+```
+
+`--cwd` and `--branch` are required. The command resolves symlinks and the Git
+repository root from the explicit cwd; it does not select another client's
+focused pane or load project configuration. Branch names are literal Git branch
+names. `--base` is a remote branch tail under `origin` (for example, `main` or
+`release/stable`), not a revision expression or fetch refspec. `--path` must be
+absolute. Supplied values are validated even when existing state makes them
+unnecessary. Duplicate string flags and positional arguments are rejected.
+
+| Git state for the exact branch | Native operation |
+| --- | --- |
+| Registered checkout | `worktree.open` with cwd, branch, and focus; Git's registered path wins over any supplied path. |
+| Local branch without a checkout | `worktree.create` with cwd, branch, focus, and path if supplied; preserves the branch without fetching or passing a base. |
+| Neither | Requires base and path; runs `git fetch origin BASE`, then `worktree.create` with base `origin/BASE` and the explicit path. |
+
+An existing target file, directory, or dangling symlink is refused before creating
+a checkout. An existing registered checkout needs neither base nor path. Focus is
+false by default; `--focus` opts in. Plus does not create or remove Git worktrees,
+reset branches, retry native refusals, or apply a layout itself. Native Herdr owns
+the create/open operation and any resulting event handling.
+
+Success writes exactly one JSON object to stdout, preserving the native result:
+
+```json
+{"result":{"workspace":{"workspace_id":"w1"},"root_pane":{"pane_id":"w1:p1"},"worktree":{"path":"/absolute/worktrees/new checkout","branch":"feature/a"},"already_open":true}}
+```
+
+The example IDs are illustrative. Actual workspace and root-pane IDs must come
+from Herdr; the command validates them and the returned worktree path/branch
+before emitting success. Additional native fields, including `already_open` when
+native open supplies it, pass through. Failures write stderr and exit nonzero
+without a success object. Git queries have 10-second limits, fetch has a 2-minute
+limit, and native IPC has a 30-second limit. A timed-out native mutation has an
+unknown outcome and is never automatically retried.
+
+Run `go test -run 'TestEnsureWorktree' ./...` for the API verification recipe,
+then `go test ./...` and `git diff --check`. The focused suite builds and executes
+the real CLI, uses disposable Git repositories with isolated Git configuration,
+and checks calls through a synthetic Unix socket. Fetch is intercepted by a
+controlled executable; tests never fetch a remote or mutate live Herdr. Fixtures,
+sockets, and owned processes are cleaned up. The Unix socket suite is skipped on
+Windows; named-pipe and installed/native acceptance remain separate gates.
+
+Naming policy, issue-ID lookup, contextual P, W/G/L caller migration, and
+installed/native acceptance are separate dependent slices. This command does not
+change those callers or their existing behavior.
+
 ### Grouping
 
 A project may set an optional `group` to cluster related projects under a heading

--- a/README.md
+++ b/README.md
@@ -493,7 +493,10 @@ primary workspace; the older explicit-cwd interface remains available.
 
 A fuzzy launcher for one-off commands. Trigger it (action
 `cloudmanic.herdr-plus.quick-actions`), fuzzy-pick an action, and it runs in the
-directory you launched from. Actions are TOML files in the `quick-actions/` subdir
+directory you launched from. The picker opens over the pane the action fired
+from — verified against herdr, not read from live focus, so another client
+moving focus cannot land it somewhere else — and an invoking pane that cannot be
+established is reported as a notification instead of opening a picker. Actions are TOML files in the `quick-actions/` subdir
 of [herdr-plus's config dir](#configuration) (seeded with editable examples on
 first run). A repo can also ship its own in `<repo>/.herdr-plus/quick-actions/`, shown
 under a **Project** heading above your **Global** ones — this repo ships

--- a/README.md
+++ b/README.md
@@ -663,3 +663,5 @@ make vet       # go vet ./...
 
 The marketing + docs site lives in `www/` (Hugo + Tailwind). Build it with
 `make site`, or run it locally with live reload via `make site-dev`.
+
+Projects and Worktree action failures appear as a Herdr notification and in the plugin log. Notification delivery is best effort when the server is unavailable or notifications are suppressed. This fork requires Herdr 0.9.0 or newer.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ herdr-plus is an add-on for [herdr](https://herdr.dev), built as a first-class
 
 ## Install
 
-herdr-plus is a herdr plugin (requires **herdr ≥ 0.7.0**). Installing it registers
+herdr-plus is a herdr plugin (requires **herdr ≥ 0.9.0**). Installing it registers
 the plugin's actions with herdr — no editing of your `config.toml`.
 
 ```bash
@@ -106,8 +106,12 @@ tab instead of opening the browser — see
 [Returning to work you already have open](#returning-to-work-you-already-have-open).)
 Inside the browser, **Enter** opens the highlighted project as a normal workspace;
 **ctrl+g** opens it as a git worktree. The worktree prompt accepts an optional
-branch name: empty lets herdr generate `worktree/...`, bare names get the optional
-`[worktree] branch_prefix`, and names containing `/` are used as-is.
+branch name. Without a [shared worktree policy](#shared-worktree-policy)
+configured, empty lets herdr generate `worktree/...`, bare names get the optional
+`[worktree] branch_prefix`, and names containing `/` are used as-is. With a
+policy configured for the project's repository, the name goes to the shared
+planner exactly as typed — it applies `branch_prefix` itself, and shows the
+branch and checkout path for confirmation before anything is created.
 
 Opening as a worktree fills its tabs from a matching
 [worktree auto-layout](#worktree-auto-layout) — a file in `worktrees/` whose `repo`

--- a/README.md
+++ b/README.md
@@ -430,8 +430,9 @@ Binding has these limits:
   checkout, which is what herdr requires. Open the primary-checkout project
   first. Otherwise this plugin refuses before creating anything: native grouping
   would create an empty parent that could later shadow the primary project's
-  configured layout. Binding names the verified parent workspace explicitly, so
-  closing it during the operation produces an error, not another parent.
+  configured layout. Binding names the verified parent workspace explicitly.
+  Keep it open until completion: Herdr 0.9 may recreate a parent closed while
+  its asynchronous Git operation is running.
 - If herdr reports an open workspace in your project's checkout but it carries no
   provenance (including a scratch workspace whose shell entered that checkout), the open is
   **refused** with a message naming it. Nothing is created and nothing is
@@ -485,6 +486,12 @@ addresses that workspace explicitly. Keep the primary open until creation
 finishes: Herdr 0.9 can select or create a replacement parent if it disappears
 during the asynchronous Git operation. Plus does not control that native
 completion behavior or run a second creation attempt.
+
+Plus rechecks branch presence and checkout registration after preparation, just
+before submission. Herdr 0.9 does not atomically reserve that Git state: another
+actor creating the same branch during native execution can cause Herdr to reuse
+that branch instead of the supplied base commit. Avoid concurrent creation of the
+same branch until the operation finishes; Plus never resets it or retries.
 
 For external callers, `plan-worktree --cwd /absolute/checkout --name "description"
 --issue IC-177` returns versioned JSON with `candidates` and a `fingerprint`.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ herdr plugin install cloudmanic/herdr-plus
 ```
 
 herdr clones the repo, runs the manifest's `[[build]]` step, and registers the
-actions. That step **prefers a local Go toolchain** (an exact build of the source)
-and **falls back to downloading the latest prebuilt release binary**, so it works
-**with or without Go**. Manage it with `herdr plugin list`,
+actions. That step builds **the source herdr just checked out**, so **Go must be
+on your `PATH`** — there is no fallback to a prebuilt release binary, which would
+not contain the code in that checkout. A missing toolchain fails the install with
+instructions rather than quietly installing something else. Manage it with
+`herdr plugin list`,
 `herdr plugin action list --plugin cloudmanic.herdr-plus`, and
 `herdr plugin uninstall cloudmanic.herdr-plus`.
 
 > **Windows** (herdr's Windows support is in preview): the plugin installs and
-> runs on Windows, but its build step compiles straight from source with the Go
-> toolchain — there's **no prebuilt-binary fallback** like the Linux/macOS `sh`
-> script has — so **Go must be on your `PATH`** to `herdr plugin install`. The
-> plugin talks to herdr over a named pipe there instead of a unix socket; it's
-> validated against the herdr Windows beta.
+> runs on Windows the same way — its build step compiles straight from source, so
+> **Go must be on your `PATH`**. The plugin talks to herdr over a named pipe there
+> instead of a unix socket; it's validated against the herdr Windows beta.
 
 **Local development:** build the binary and link your checkout in place:
 
@@ -78,11 +78,16 @@ Optional global settings live in `config.toml` in that same directory:
 branch_prefix = "your-name/" # used verbatim; include your own trailing /
 
 [projects]
-placement = "zoomed" # overlay, popup, split, tab, or zoomed; default is zoomed
+placement = "zoomed"     # overlay, popup, split, tab, or zoomed; default is zoomed
+crew_tab = ""            # empty (default) off; a tab label turns on "return to my task tab"
+reuse_checkout = false   # default false; true focuses an already-open checkout
 
 [quick_actions]
 placement = "overlay" # overlay, popup, split, tab, or zoomed; default is overlay
 ```
+
+`crew_tab` and `reuse_checkout` are both off by default, and both are described
+under [Returning to work you already have open](#returning-to-work-you-already-have-open).
 
 `placement` controls how herdr opens each picker — see herdr's
 [`plugin pane open --placement`](https://herdr.dev/docs/plugins/#panes) for what
@@ -96,6 +101,9 @@ default and prints a warning to stderr rather than being passed through to herdr
 Pick a project from a full-screen fuzzy browser and herdr-plus builds its whole
 workspace. Trigger it from herdr's plugin action menu, or
 [bind a key](#binding-a-key) — the action is `cloudmanic.herdr-plus.projects`.
+(With `[projects].crew_tab` configured the action returns to your current task
+tab instead of opening the browser — see
+[Returning to work you already have open](#returning-to-work-you-already-have-open).)
 Inside the browser, **Enter** opens the highlighted project as a normal workspace;
 **ctrl+g** opens it as a git worktree. The worktree prompt accepts an optional
 branch name: empty lets herdr generate `worktree/...`, bare names get the optional
@@ -296,6 +304,110 @@ ratio = 0.3
 ```
 
 A tab uses *either* `command` *or* `[[tabs.panes]]`, not both.
+
+#### Choosing which pane to split
+
+By default each pane splits the one created just before it, which is a chain: A,
+then B off A, then C off B. Some arrangements cannot be written that way. A tab
+with a full-height pane down one edge and a stack of panes beside it needs the
+stacked panes to split *each other*, not the edge — otherwise the edge pane is
+cut in half by the second split.
+
+`split_from` says which pane to split, as a 1-based index of an **earlier pane in
+the same tab**. Omitted (or `0`) keeps the previous-pane default, so existing
+configs are unchanged.
+
+```toml
+[[tabs]]
+name = "Work"
+
+[[tabs.panes]]
+label = "Notes"          # pane 1, the tab's root
+
+[[tabs.panes]]
+label = "Editor"         # pane 2 splits pane 1, keeping Notes full height
+split = "right"
+split_from = 1
+ratio = 0.75
+
+[[tabs.panes]]
+label = "Tests"          # pane 3 splits pane 2, stacking under the editor
+split = "down"
+split_from = 2
+```
+
+The first pane is the tab's root and splits nothing, so it must leave `split_from`
+unset. A value that is not an earlier pane — its own index, a later pane, one that
+does not exist — is refused when the file is read, before any workspace is
+created. Creation order can differ from the visual arrangement; `label`, `ratio`,
+`working_dir` and startup commands all behave exactly as they did.
+
+## Returning to work you already have open
+
+Both settings below are opt-in and off by default. They exist for the same
+situation: you already have the thing you are about to open, and creating a
+second copy of it is not what you meant.
+
+Neither one ever re-runs a layout, re-creates a tab or pane, or types into a
+pane. Returning to work leaves that work exactly as you left it.
+
+### `crew_tab` — the Projects key returns to your task tab
+
+Set `crew_tab` to the label of the tab you work in:
+
+```toml
+[projects]
+crew_tab = "Crew"
+```
+
+With it set, the Projects action checks the pane it was invoked from. If that
+pane is in a workspace herdr opened for a **linked git worktree**, and that
+workspace has exactly one tab with this label, the action focuses that tab
+instead of opening the browser. Pressing the key again just focuses it again.
+
+Anywhere else — a plain folder, a repository's main checkout, no context at all —
+the browser opens exactly as before.
+
+If the tab has been renamed, closed, or exists more than once, you get a message
+saying so and **nothing is created**: herdr-plus will not invent a second task
+tab or guess which of two is yours. A failed lookup is likewise an error, never
+silently treated as "not a task workspace".
+
+The tab label is entirely yours — no name is built into the plugin. Leaving
+`crew_tab` empty keeps the plain picker-only behavior.
+
+To open a *different* project from inside one you are working in, use the
+separate `cloudmanic.herdr-plus.projects-pick` action (or run the binary with
+`projects --pick`). It always opens the browser.
+
+### `reuse_checkout` — opening a project focuses it if it is already open
+
+```toml
+[projects]
+reuse_checkout = true
+```
+
+With it on, choosing a project first asks herdr whether any open workspace
+already has that exact directory checked out. If one does, it is focused, and no
+workspace, tab, pane or startup command is created.
+
+"Exact" means the canonical filesystem path, so a symlinked alias of an open
+checkout counts as the same checkout. Two worktrees of the same repository do
+**not**: they share a repository, not a checkout, so opening the second one
+builds it. Matching never uses a workspace's title.
+
+If two workspaces somehow hold the same checkout, you are asked which one, by
+herdr's own workspace id — nothing is picked for you, and cancelling does
+nothing at all. If herdr cannot be asked, or the directory cannot be resolved,
+that is an error rather than an assumption that nothing matched.
+
+Headless `herdr-plus open <name>` honors the same setting, except that it has
+nobody to ask: several matching workspaces is an error naming them.
+
+**Limitation:** identity comes from the checkout herdr records for a workspace,
+so this applies to projects whose `working_dir` is a git checkout herdr opened.
+A project pointing at a plain (non-git) directory has no such provenance and
+keeps the old behavior — a new workspace every time.
 
 ## Quick Actions
 

--- a/README.md
+++ b/README.md
@@ -404,10 +404,30 @@ that is an error rather than an assumption that nothing matched.
 Headless `herdr-plus open <name>` honors the same setting, except that it has
 nobody to ask: several matching workspaces is an error naming them.
 
-**Limitation:** identity comes from the checkout herdr records for a workspace,
-so this applies to projects whose `working_dir` is a git checkout herdr opened.
-A project pointing at a plain (non-git) directory has no such provenance and
-keeps the old behavior — a new workspace every time.
+Because herdr records checkout provenance only for workspaces it opened as a
+worktree — not for the ones this plugin creates — a project workspace is bound to
+its checkout right after it is built, by asking herdr to open the checkout it
+already has open. herdr recognizes the workspace, records the checkout, and
+leaves its tabs, panes and running commands untouched; the next open then finds
+it. If that binding fails you are told so at the time, and the workspace itself
+is left alone and perfectly usable.
+
+Two consequences worth knowing:
+
+- Binding a **linked worktree** asks herdr to act from the repository's primary
+  checkout, which is what herdr requires. If that primary checkout is not open,
+  herdr opens it as a background workspace of its own — its normal grouping.
+- If a workspace already has your project's checkout open but carries no
+  provenance (it was made by an older version of this plugin, say), the open is
+  **refused** with a message naming it. Nothing is created and nothing is
+  changed: that workspace cannot be verified as your project, and guessing is
+  exactly what this feature refuses to do. Close it, or open the checkout through
+  herdr's own worktree open, and try again.
+
+**Limitations:** identity comes from the checkout herdr records for a workspace,
+so this applies to projects whose `working_dir` is a git checkout root. A project
+pointing at a plain (non-git) directory, or at a *subdirectory* of a checkout,
+has no such provenance and keeps the old behavior — a new workspace every time.
 
 ## Quick Actions
 

--- a/README.md
+++ b/README.md
@@ -206,17 +206,24 @@ herdr-plus ensure-worktree --cwd /absolute/repo --branch feature/a \
 
 `--cwd` and `--branch` are required. The command resolves symlinks and the Git
 repository root from the explicit cwd; it does not select another client's
-focused pane or load project configuration. Branch names are literal Git branch
+focused pane or load project configuration. Inherited Git repository, index,
+and object selectors cannot override that cwd; Git transport, authentication,
+and configuration settings remain available. Branch names are literal Git branch
 names. `--base` is a remote branch tail under `origin` (for example, `main` or
-`release/stable`), not a revision expression or fetch refspec. `--path` must be
-absolute. Supplied values are validated even when existing state makes them
-unnecessary. Duplicate string flags and positional arguments are rejected.
+`release/stable`), not a revision expression or fetch refspec; a leading `+` is
+rejected. `--path` must be absolute. Supplied values are validated even when
+existing state makes them unnecessary. Duplicate string flags and positional
+arguments are rejected.
 
 | Git state for the exact branch | Native operation |
 | --- | --- |
 | Registered checkout | `worktree.open` with cwd, branch, and focus; Git's registered path wins over any supplied path. |
 | Local branch without a checkout | `worktree.create` with cwd, branch, focus, and path if supplied; preserves the branch without fetching or passing a base. |
-| Neither | Requires base and path; runs `git fetch origin BASE`, then `worktree.create` with base `origin/BASE` and the explicit path. |
+| Neither | Requires base and path; runs `git fetch origin refs/heads/BASE:refs/remotes/origin/BASE`, then `worktree.create` with base `origin/BASE` and the explicit path. |
+
+The explicit fetch destination refreshes `origin/BASE` even when
+`remote.origin.fetch` excludes BASE. A failed fetch stops before native create
+and is never retried; local branches are never force-updated or reset.
 
 An existing target file, directory, or dangling symlink is refused before creating
 a checkout. An existing registered checkout needs neither base nor path. Focus is
@@ -241,10 +248,13 @@ unknown outcome and is never automatically retried.
 Run `go test -run 'TestEnsureWorktree' ./...` for the API verification recipe,
 then `go test ./...` and `git diff --check`. The focused suite builds and executes
 the real CLI, uses disposable Git repositories with isolated Git configuration,
-and checks calls through a synthetic Unix socket. Fetch is intercepted by a
-controlled executable; tests never fetch a remote or mutate live Herdr. Fixtures,
-sockets, and owned processes are cleaned up. The Unix socket suite is skipped on
-Windows; named-pipe and installed/native acceptance remain separate gates.
+and checks calls through a synthetic Unix socket. A controlled executable
+intercepts fetch except for an explicitly allowed temporary local-file origin
+that verifies actual remote-tracking ref freshness with a narrowed fetch mapping.
+That fixture allows only the file protocol; tests never fetch over the network
+or mutate live Herdr. Additional real Git queries check index/object isolation.
+Fixtures, sockets, and owned processes are cleaned up. The Unix socket suite is
+skipped on Windows; named-pipe and installed/native acceptance remain separate gates.
 
 Naming policy, issue-ID lookup, contextual P, W/G/L caller migration, and
 installed/native acceptance are separate dependent slices. This command does not

--- a/actionerror.go
+++ b/actionerror.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Plugin actions run without a terminal. Herdr records their stderr in a log,
+// so also show their failure in the UI. A notification failure must never retry
+// the action or hide its original diagnostic.
+func actionErrExit(args ...any) {
+	if client, err := newHerdrClient(); err == nil {
+		client.timeout = 2 * time.Second
+		message := []rune(strings.TrimSpace(fmt.Sprintln(args...)))
+		if len(message) > 1000 {
+			message = append(message[:997], '.', '.', '.')
+		}
+		var result struct{}
+		_ = client.call("notification.show", map[string]any{
+			"title": "Herdr Plus", "body": string(message),
+		}, &result)
+	}
+	errExit(args...)
+}

--- a/actionerror_test.go
+++ b/actionerror_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestActionFailureIsVisibleAndNotificationIsBounded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix socket fixture")
+	}
+	bin := filepath.Join(t.TempDir(), "herdr-plus")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	for _, tc := range []struct{ action, reply string }{
+		{"projects", `{"result":{}}`},
+		{"worktree", `{"result":{}}`},
+		{"worktree", `{"error":{"code":"unavailable","message":"notifications unavailable"}}`},
+		{"worktree", ""},
+	} {
+		t.Run(tc.action+tc.reply, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "action-error-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("[projects]\ncrew_tab=\"Crew\"\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			socket := filepath.Join(dir, "s")
+			listener, err := net.Listen("unix", socket)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			type request struct {
+				Method string
+				Params map[string]any
+			}
+			seen := make(chan request, 1)
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				conn, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				_ = conn.SetDeadline(time.Now().Add(4 * time.Second))
+				var req request
+				if json.NewDecoder(conn).Decode(&req) != nil {
+					return
+				}
+				seen <- req
+				if tc.reply != "" {
+					_, _ = conn.Write([]byte(tc.reply + "\n"))
+				} else {
+					// Wait for the client's deadline to close this connection.
+					_, _ = conn.Read(make([]byte, 1))
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, tc.action)
+			cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + dir,
+				"HERDR_PLUGIN_CONFIG_DIR=" + dir, "HERDR_SOCKET_PATH=" + socket,
+				"HERDR_PLUGIN_CONTEXT_JSON={invalid"}
+			out, err := cmd.CombinedOutput()
+			if err == nil || ctx.Err() != nil || !strings.Contains(string(out), "herdr-plus:") {
+				t.Fatalf("original action failure was lost or unbounded: %v, %v, %s", err, ctx.Err(), out)
+			}
+			_ = listener.Close()
+			<-done
+			select {
+			case req := <-seen:
+				if req.Method != "notification.show" || req.Params["title"] != "Herdr Plus" {
+					t.Fatalf("unexpected action instead of notification: %+v", req)
+				}
+				body, ok := req.Params["body"].(string)
+				if !ok || body == "" || !strings.Contains(string(out), body) {
+					t.Fatalf("notification did not preserve the original failure: %+v, %s", req, out)
+				}
+			default:
+				t.Fatal("action failed silently")
+			}
+		})
+	}
+}

--- a/actionerror_test.go
+++ b/actionerror_test.go
@@ -30,7 +30,9 @@ func TestActionFailureIsVisibleAndNotificationIsBounded(t *testing.T) {
 	for _, tc := range []struct{ action, reply string }{
 		{"projects", shown},
 		{"worktree", shown},
+		{"quick-actions", shown},
 		{"worktree", `{"error":{"code":"unavailable","message":"notifications unavailable"}}`},
+		{"quick-actions", `{"error":{"code":"unavailable","message":"notifications unavailable"}}`},
 		{"worktree", ""},
 	} {
 		t.Run(tc.action+tc.reply, func(t *testing.T) {

--- a/actionerror_test.go
+++ b/actionerror_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -21,9 +22,14 @@ func TestActionFailureIsVisibleAndNotificationIsBounded(t *testing.T) {
 	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
 		t.Fatalf("build: %v\n%s", err, out)
 	}
+	// The first two replies are what a delivered notification actually looks
+	// like: the request's own id echoed back — the client rejects any other as a
+	// mismatched reply — and the notification_show result herdr sends. The rest
+	// cover a refusal and a reply that never arrives.
+	const shown = `{"id":%q,"result":{"type":"notification_show","shown":true,"reason":"shown"}}`
 	for _, tc := range []struct{ action, reply string }{
-		{"projects", `{"result":{}}`},
-		{"worktree", `{"result":{}}`},
+		{"projects", shown},
+		{"worktree", shown},
 		{"worktree", `{"error":{"code":"unavailable","message":"notifications unavailable"}}`},
 		{"worktree", ""},
 	} {
@@ -43,6 +49,7 @@ func TestActionFailureIsVisibleAndNotificationIsBounded(t *testing.T) {
 			}
 			defer listener.Close()
 			type request struct {
+				ID     string
 				Method string
 				Params map[string]any
 			}
@@ -61,7 +68,9 @@ func TestActionFailureIsVisibleAndNotificationIsBounded(t *testing.T) {
 					return
 				}
 				seen <- req
-				if tc.reply != "" {
+				if tc.reply == shown {
+					_, _ = fmt.Fprintf(conn, tc.reply+"\n", req.ID)
+				} else if tc.reply != "" {
 					_, _ = conn.Write([]byte(tc.reply + "\n"))
 				} else {
 					// Wait for the client's deadline to close this connection.

--- a/buildscript_test.go
+++ b/buildscript_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The Unix plugin build entrypoint is a shell script, so this suite runs the
+// real scripts/build.sh rather than a Go restatement of it. Each fixture is a
+// disposable copy of a plugin root whose PATH holds nothing but the two
+// coreutils the script legitimately needs and deliberate fakes: a `go` that
+// records its argv and can be told to fail, plus stand-ins for the standalone
+// installer and every downloader the retired release-binary fallback reached
+// for. Nothing here compiles Go, touches the network, or inherits the
+// developer's PATH — a build that tried to fetch a prebuilt binary would leave
+// a recorded attempt instead of succeeding quietly.
+
+// wantBuildArgv is the exact command the plugin build must run: an in-place
+// build of this checkout into the path the manifest's actions and panes invoke.
+var wantBuildArgv = []string{"build", "-o", "bin/herdr-plus", "."}
+
+// fakeGoScript is the stand-in toolchain. It records its argv NUL-separated
+// (so an unexpected empty or embedded-newline argument is still visible),
+// honours FAKE_GO_EXIT to simulate a failed compile, and otherwise emulates
+// just enough of `go build -o <path>` to prove the script produced the binary.
+const fakeGoScript = `set -eu
+printf '%s\0' "$@" >"$HERDR_TEST_DIR/go-argv"
+if [ "${FAKE_GO_EXIT:-0}" -ne 0 ]; then
+	echo "fake go: deliberate build failure" >&2
+	exit "$FAKE_GO_EXIT"
+fi
+out=""
+prev=""
+for arg in "$@"; do
+	if [ "$prev" = "-o" ]; then
+		out="$arg"
+	fi
+	prev="$arg"
+done
+if [ -z "$out" ]; then
+	echo "fake go: no -o argument" >&2
+	exit 9
+fi
+printf 'fake herdr-plus binary\n' >"$out"
+`
+
+// attemptsFile records every forbidden fetch helper the script invoked.
+const attemptsFile = "network-attempts"
+
+type buildFixture struct {
+	t      *testing.T
+	dir    string // disposable plugin root; the script's working directory
+	bin    string // the process's sole PATH entry
+	sh     string // real POSIX shell, resolved once outside the fixture PATH
+	goExit string // FAKE_GO_EXIT for the fake toolchain, empty when unset
+	hasGo  bool
+}
+
+// newBuildFixture copies the real build script into a temporary plugin root and
+// walls it off from the host: only sh and mkdir are reachable, install.sh and
+// the usual downloaders are recording stand-ins, and there is no Go toolchain
+// until a test installs one.
+func newBuildFixture(t *testing.T) *buildFixture {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("scripts/build.sh is the POSIX build entrypoint; the Windows manifest step runs `go build` directly")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Fatalf("no POSIX shell available: %v", err)
+	}
+	f := &buildFixture{t: t, dir: t.TempDir(), sh: sh}
+	f.bin = filepath.Join(f.dir, "fakebin")
+	if err := os.MkdirAll(filepath.Join(f.dir, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(f.bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	script, err := os.ReadFile(filepath.Join("scripts", "build.sh"))
+	if err != nil {
+		t.Fatalf("read the script under test: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(f.dir, "scripts", "build.sh"), script, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The script may legitimately reach for these; anything else on PATH is a
+	// fake. sh is present so the retired `sh install.sh` fallback would still
+	// run (and be recorded) rather than failing for want of a shell.
+	for _, tool := range []string{"sh", "mkdir"} {
+		real, err := exec.LookPath(tool)
+		if err != nil {
+			t.Fatalf("look up %s: %v", tool, err)
+		}
+		if err := os.Symlink(real, filepath.Join(f.bin, tool)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Fetching a prebuilt binary is the behaviour that was removed: record any
+	// attempt instead of performing one.
+	for _, name := range []string{"curl", "wget", "fetch", "ftp"} {
+		f.forbid(filepath.Join(f.bin, name), name)
+	}
+	f.forbid(filepath.Join(f.dir, "install.sh"), "install.sh")
+	return f
+}
+
+// forbid installs an executable stand-in that records its own invocation and
+// exits successfully, so a script that calls it gets no error to hide behind.
+func (f *buildFixture) forbid(path, name string) {
+	f.t.Helper()
+	f.writeScript(path, "set -eu\nprintf '%s\\n' "+name+" >>\"$HERDR_TEST_DIR/"+attemptsFile+"\"\n")
+}
+
+func (f *buildFixture) writeScript(path, body string) {
+	f.t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// fakeGo puts the stand-in toolchain on the fixture PATH. exit is the status it
+// reports; 0 emulates a successful build.
+func (f *buildFixture) fakeGo(exit string) {
+	f.t.Helper()
+	f.writeScript(filepath.Join(f.bin, "go"), fakeGoScript)
+	f.goExit, f.hasGo = exit, true
+}
+
+// run executes the real build script the way the manifest does (`sh
+// scripts/build.sh` from the plugin root) and returns its streams and exit
+// status. A nonzero status is a result to assert on, not a test failure.
+func (f *buildFixture) run() (stdout, stderr string, code int) {
+	f.t.Helper()
+	cmd := exec.Command(f.sh, "scripts/build.sh")
+	cmd.Dir = f.dir
+	cmd.Env = []string{
+		"PATH=" + f.bin,
+		"HOME=" + f.dir,
+		"HERDR_TEST_DIR=" + f.dir,
+	}
+	if f.hasGo {
+		cmd.Env = append(cmd.Env, "FAKE_GO_EXIT="+f.goExit)
+	}
+	var out, errOut bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errOut
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case errors.As(err, &exitErr):
+		code = exitErr.ExitCode()
+	default:
+		f.t.Fatalf("run scripts/build.sh: %v", err)
+	}
+	return out.String(), errOut.String(), code
+}
+
+// goArgv returns the arguments the fake toolchain was called with, or nil when
+// it was never invoked.
+func (f *buildFixture) goArgv() []string {
+	f.t.Helper()
+	raw, err := os.ReadFile(filepath.Join(f.dir, "go-argv"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	argv := strings.Split(string(raw), "\x00")
+	return argv[:len(argv)-1] // trailing separator, not an empty argument
+}
+
+// requireNoFetch fails when the build ran the standalone installer or any
+// downloader. This is the guard the exact-source requirement turns on: the
+// plugin must be the checked-out code, never an upstream release binary.
+func (f *buildFixture) requireNoFetch() {
+	f.t.Helper()
+	raw, err := os.ReadFile(filepath.Join(f.dir, attemptsFile))
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.t.Errorf("build tried to fetch a prebuilt binary; ran: %s", strings.Join(strings.Fields(string(raw)), ", "))
+}
+
+// output returns the built binary's contents, or "" when it was not produced.
+func (f *buildFixture) output() string {
+	f.t.Helper()
+	raw, err := os.ReadFile(filepath.Join(f.dir, "bin", "herdr-plus"))
+	if errors.Is(err, os.ErrNotExist) {
+		return ""
+	}
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// TestBuildScriptBuildsCheckedOutSource is the success path herdr takes at
+// install time: with a toolchain present the script builds this directory into
+// bin/herdr-plus, passes exactly the expected arguments, keeps its progress
+// chatter on stderr, and downloads nothing.
+func TestBuildScriptBuildsCheckedOutSource(t *testing.T) {
+	f := newBuildFixture(t)
+	f.fakeGo("0")
+
+	stdout, stderr, code := f.run()
+
+	if code != 0 {
+		t.Fatalf("exit status = %d, want 0\nstderr: %s", code, stderr)
+	}
+	if argv := f.goArgv(); !slices.Equal(argv, wantBuildArgv) {
+		t.Errorf("go argv = %q, want %q", argv, wantBuildArgv)
+	}
+	if got := f.output(); got != "fake herdr-plus binary\n" {
+		t.Errorf("bin/herdr-plus = %q, want the toolchain's output", got)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want it empty so herdr's captured output stays clean", stdout)
+	}
+	if !strings.Contains(stderr, "building from source") {
+		t.Errorf("stderr = %q, want it to report the source build", stderr)
+	}
+	f.requireNoFetch()
+}
+
+// TestBuildScriptPropagatesGoBuildFailure covers a checkout that does not
+// compile: the failure must stop the install with the toolchain's own status
+// and message, never fall back to a release binary that would compile.
+func TestBuildScriptPropagatesGoBuildFailure(t *testing.T) {
+	f := newBuildFixture(t)
+	f.fakeGo("3")
+
+	_, stderr, code := f.run()
+
+	if code != 3 {
+		t.Errorf("exit status = %d, want the toolchain's 3\nstderr: %s", code, stderr)
+	}
+	if argv := f.goArgv(); !slices.Equal(argv, wantBuildArgv) {
+		t.Errorf("go argv = %q, want %q", argv, wantBuildArgv)
+	}
+	if !strings.Contains(stderr, "fake go: deliberate build failure") {
+		t.Errorf("stderr = %q, want the toolchain's diagnostic preserved", stderr)
+	}
+	if got := f.output(); got != "" {
+		t.Errorf("bin/herdr-plus = %q, want no binary from a failed build", got)
+	}
+	f.requireNoFetch()
+}
+
+// TestBuildScriptRequiresGoToolchain covers the machine the fallback used to
+// serve: no Go on PATH. The install must fail with an actionable diagnostic
+// rather than silently installing an upstream binary that lacks this
+// checkout's code, and must leave no half-built bin directory behind.
+func TestBuildScriptRequiresGoToolchain(t *testing.T) {
+	f := newBuildFixture(t) // deliberately no fakeGo
+
+	stdout, stderr, code := f.run()
+
+	if code == 0 {
+		t.Fatalf("exit status = 0, want a failure when no Go toolchain is present\nstderr: %s", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want the diagnostic on stderr only", stdout)
+	}
+	for _, want := range []string{"no Go toolchain", "https://go.dev", "PATH"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr = %q, want it to mention %q", stderr, want)
+		}
+	}
+	if got := f.output(); got != "" {
+		t.Errorf("bin/herdr-plus = %q, want no binary without a toolchain", got)
+	}
+	if _, err := os.Stat(filepath.Join(f.dir, "bin")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("bin/ exists after a failed build (stat err %v), want the tree left untouched", err)
+	}
+	f.requireNoFetch()
+}

--- a/config.go
+++ b/config.go
@@ -54,6 +54,20 @@ type PluginConfig struct {
 		// `plugin pane open --placement`). Empty keeps the built-in default,
 		// zoomed.
 		Placement string `toml:"placement"`
+
+		// CrewTab is the label of the tab the Projects action returns to when it
+		// fires inside a linked-worktree workspace — the task tab you were already
+		// working in. Empty (the default) turns the behavior off entirely and keeps
+		// the upstream picker-only action, so no Crew name is baked into the
+		// plugin: a machine that wants this policy names its own tab here.
+		CrewTab string `toml:"crew_tab"`
+
+		// ReuseCheckout makes opening a project focus the workspace that already
+		// has that exact checkout open instead of creating a second one. Default
+		// false keeps the upstream always-create behavior; identity is the
+		// canonical checkout path herdr records for a workspace, never a label or
+		// a shared repository key (see reuseOpenCheckout).
+		ReuseCheckout bool `toml:"reuse_checkout"`
 	} `toml:"projects"`
 
 	QuickActions struct {

--- a/config.go
+++ b/config.go
@@ -36,6 +36,31 @@ var validPanePlacements = map[string]bool{
 	"zoomed":  true,
 }
 
+// placementAcceptsTargetPane reports whether herdr allows an explicit
+// --target-pane with this placement.
+//
+// Verified against installed herdr 0.9.0: an overlay or popup plugin pane is
+// placed over whichever pane is active, and naming one explicitly is refused
+// outright — `invalid_params: overlay and popup plugin panes target the active
+// pane`, with no pane created. The API schema carries target_pane_id as a
+// top-level field, which reads as placement-independent; the server disagrees,
+// and the server decides. So the flag goes only where it is honored.
+//
+// Losing it costs less than it looks. The launch path proves the invoking pane
+// before opening anything (verifyInvokingPane), so a pane that moved, changed
+// workspace or changed directory still refuses instead of opening somewhere
+// wrong; what remains is that native, not this plugin, chooses which pane an
+// overlay covers. For a full-screen overlay or a centered popup that is the
+// documented native behavior rather than a placement this plugin could pin.
+func placementAcceptsTargetPane(placement string) bool {
+	switch placement {
+	case "overlay", "popup":
+		return false
+	default:
+		return true
+	}
+}
+
 // PluginConfig holds herdr-plus's optional global settings, read from config.toml
 // at the config root (alongside projects/ and quick-actions/). Every field is
 // optional; an absent file yields the zero value.

--- a/config.go
+++ b/config.go
@@ -45,7 +45,8 @@ type PluginConfig struct {
 		// projects browser (ctrl+g). It is used verbatim, so include any trailing
 		// "/" yourself. Empty disables prefixing; a name that already contains "/"
 		// is left untouched (see resolveWorktreeBranch).
-		BranchPrefix string `toml:"branch_prefix"`
+		BranchPrefix string           `toml:"branch_prefix"`
+		Projects     []WorktreePolicy `toml:"projects"`
 	} `toml:"worktree"`
 
 	Projects struct {

--- a/config_test.go
+++ b/config_test.go
@@ -141,3 +141,46 @@ func TestResolvePlacement(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadPluginConfigParsesCrewPolicy covers the two opt-in [projects] keys the
+// contextual-Projects behavior reads: crew_tab (the task tab label P returns to)
+// and reuse_checkout (reuse an already-open checkout instead of creating a second
+// workspace). Both are optional, so an absent file must leave the upstream
+// picker-only, always-create behavior in place — no baked-in Crew name.
+func TestLoadPluginConfigParsesCrewPolicy(t *testing.T) {
+	t.Run("absent config leaves both off", func(t *testing.T) {
+		t.Setenv("HERDR_PLUGIN_CONFIG_DIR", t.TempDir())
+		cfg, err := loadPluginConfig()
+		if err != nil {
+			t.Fatalf("loadPluginConfig: %v", err)
+		}
+		if cfg.Projects.CrewTab != "" {
+			t.Fatalf("Projects.CrewTab = %q, want empty", cfg.Projects.CrewTab)
+		}
+		if cfg.Projects.ReuseCheckout {
+			t.Fatal("Projects.ReuseCheckout = true, want false by default")
+		}
+	})
+
+	t.Run("configured values are read", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+		toml := "[projects]\nplacement = \"popup\"\ncrew_tab = \"Crew\"\nreuse_checkout = true\n"
+		if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(toml), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := loadPluginConfig()
+		if err != nil {
+			t.Fatalf("loadPluginConfig: %v", err)
+		}
+		if cfg.Projects.CrewTab != "Crew" {
+			t.Fatalf("Projects.CrewTab = %q, want Crew", cfg.Projects.CrewTab)
+		}
+		if !cfg.Projects.ReuseCheckout {
+			t.Fatal("Projects.ReuseCheckout = false, want true")
+		}
+		if cfg.Projects.Placement != "popup" {
+			t.Fatalf("Projects.Placement = %q, want popup (existing keys must keep working)", cfg.Projects.Placement)
+		}
+	})
+}

--- a/context.go
+++ b/context.go
@@ -9,7 +9,9 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 )
 
 // RunContext is the bag of variables herdr-plus exposes to an action's command.
@@ -109,6 +111,30 @@ type pluginContext struct {
 	FocusedPaneID    string `json:"focused_pane_id"`
 	FocusedPaneCwd   string `json:"focused_pane_cwd"`
 	FocusedPaneAgent string `json:"focused_pane_agent"`
+
+	// Worktree is the checkout herdr says the invoking workspace holds, nil when
+	// it holds none. It is a claim made when the action fired, so the Projects
+	// action re-reads the same provenance live before acting on it.
+	Worktree *worktreeProvenance `json:"worktree"`
+}
+
+// pluginContextFromEnv decodes HERDR_PLUGIN_CONTEXT_JSON, the explicit
+// per-invocation context herdr injects describing the pane the action fired
+// from. Unlike contextFromPluginEnv it is strict: an unset variable yields an
+// empty context (the action simply has no identity to work from), but a
+// malformed one is an error. That distinction matters for the Projects action —
+// silently reading a broken context as "no workspace" would look exactly like
+// "not a task workspace" and open a picker that goes on to create a duplicate.
+func pluginContextFromEnv() (pluginContext, error) {
+	var pc pluginContext
+	raw := strings.TrimSpace(os.Getenv("HERDR_PLUGIN_CONTEXT_JSON"))
+	if raw == "" {
+		return pc, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &pc); err != nil {
+		return pluginContext{}, fmt.Errorf("malformed HERDR_PLUGIN_CONTEXT_JSON: %w", err)
+	}
+	return pc, nil
 }
 
 // contextFromPluginEnv builds a RunContext from HERDR_PLUGIN_CONTEXT_JSON, which
@@ -117,10 +143,10 @@ type pluginContext struct {
 // cwd. Any field herdr does not supply is left empty — a partial context is far
 // better than refusing to launch.
 func contextFromPluginEnv() RunContext {
-	var pc pluginContext
-	if raw := os.Getenv("HERDR_PLUGIN_CONTEXT_JSON"); raw != "" {
-		_ = json.Unmarshal([]byte(raw), &pc)
-	}
+	// A malformed context is deliberately ignored here: a quick action would
+	// rather launch with no metadata than refuse to open. The Projects action
+	// calls pluginContextFromEnv directly, where the same input is an error.
+	pc, _ := pluginContextFromEnv()
 	return RunContext{
 		WorkDir:        firstNonEmpty(pc.FocusedPaneCwd, pc.WorkspaceCwd),
 		PaneId:         pc.FocusedPaneID,

--- a/context.go
+++ b/context.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -137,11 +138,66 @@ func pluginContextFromEnv() (pluginContext, error) {
 	return pc, nil
 }
 
+// verifyInvokingPane proves that the pane herdr named as the action's invoker is
+// still that pane, in that workspace, in that directory.
+//
+// A plugin action runs server-side with no terminal of its own, and global focus
+// belongs to whichever client moved it last. So the pane named in the action
+// context is the only safe thing to place an overlay over and the only
+// trustworthy working directory: anything read from live focus could belong to
+// another client's window by the time the picker opens. An incomplete context,
+// or a pane that has since moved, is reported rather than guessed around.
+//
+// action names the caller for the diagnostic; the checks are identical for
+// every action that uses it.
+func verifyInvokingPane(client *herdrClient, pc pluginContext, action string) (paneInfo, error) {
+	if pc.WorkspaceID == "" || pc.FocusedPaneID == "" || !filepath.IsAbs(pc.FocusedPaneCwd) {
+		return paneInfo{}, fmt.Errorf("%s action needs an explicit invoking workspace, pane and directory", action)
+	}
+	pane, err := client.paneGet(pc.FocusedPaneID)
+	if err != nil {
+		return paneInfo{}, err
+	}
+	if pane.PaneID != pc.FocusedPaneID || pane.WorkspaceID != pc.WorkspaceID || !samePath(firstNonEmpty(pane.ForegroundCwd, pane.Cwd), pc.FocusedPaneCwd) {
+		return paneInfo{}, fmt.Errorf("invoking pane changed; invoke the %s action again", action)
+	}
+	return pane, nil
+}
+
+// quickActionsInvocation is contextFromPluginEnv with the invoking pane proven
+// first. Quick Actions places its picker over that pane and runs the chosen
+// command in its directory, so an unverified context is both a placement and a
+// working directory this plugin cannot stand behind.
+//
+// Every field herdr supplied is still carried through: the picker and the
+// actions it runs see the same tab and workspace labels, agent, and — because
+// the guard requires the focused pane's own absolute cwd — the same working
+// directory contextFromPluginEnv would have produced for any launch that this
+// guard admits.
+func quickActionsInvocation(client *herdrClient, pc pluginContext) (RunContext, error) {
+	if _, err := verifyInvokingPane(client, pc, "quick actions"); err != nil {
+		return RunContext{}, err
+	}
+	return RunContext{
+		WorkDir:        pc.FocusedPaneCwd,
+		PaneId:         pc.FocusedPaneID,
+		TabId:          pc.TabID,
+		TabLabel:       pc.TabLabel,
+		WorkspaceId:    pc.WorkspaceID,
+		WorkspaceLabel: pc.WorkspaceLabel,
+		Agent:          pc.FocusedPaneAgent,
+	}, nil
+}
+
 // contextFromPluginEnv builds a RunContext from HERDR_PLUGIN_CONTEXT_JSON, which
-// herdr sets when it runs the quick-actions action. The working directory is the
-// focused pane's cwd (the user's real directory), falling back to the workspace
-// cwd. Any field herdr does not supply is left empty — a partial context is far
-// better than refusing to launch.
+// herdr sets when it runs a plugin action. The working directory is the focused
+// pane's cwd (the user's real directory), falling back to the workspace cwd. Any
+// field herdr does not supply is left empty — a partial context is far better
+// than refusing to launch.
+//
+// It is the unverified reading, used where no pane is placed over and nothing is
+// run in that directory. Quick Actions does both, and uses
+// quickActionsInvocation instead.
 func contextFromPluginEnv() RunContext {
 	// A malformed context is deliberately ignored here: a quick action would
 	// rather launch with no metadata than refuse to open. The Projects action

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -147,6 +147,16 @@ func (s *worktreeSelection) verifyBase(root, ref string) (string, error) {
 //
 // commonDir is this repository's canonical Git common directory.
 func verifyNativeParent(parent workspaceInfo, workspace, primary, commonDir string) error {
+	// No provenance at all is a different situation from provenance that
+	// disagrees, and it has a different remedy: herdr records checkout
+	// membership when it opens a workspace as a worktree, not when one is made
+	// with workspace.create, so a workspace opened outside Plus can hold this
+	// very checkout and still carry nothing. Saying it "no longer holds the
+	// primary checkout" would describe a state that is not the case and hide
+	// the fix.
+	if parent.WorkspaceID == workspace && parent.Worktree == nil {
+		return fmt.Errorf("source workspace %s has no recorded checkout provenance; open the project through Herdr Plus so herdr records it, then retry. No worktree was created", workspace)
+	}
 	if parent.WorkspaceID != workspace || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, primary) {
 		return errors.New("source workspace no longer holds the primary checkout; no worktree was created")
 	}

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -129,7 +129,9 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 			params["path"], expectedPath = path, path
 		}
 		if absent {
-			if _, err := ensureGit(canonical, 2*time.Minute, "fetch", "origin", base); err != nil {
+			// Map the destination explicitly: remote.origin.fetch may exclude BASE
+			// and leave a previously fetched origin/BASE stale.
+			if _, err := ensureGit(canonical, 2*time.Minute, "fetch", "origin", "refs/heads/"+base+":refs/remotes/origin/"+base); err != nil {
 				return nil, err
 			}
 			params["base"] = "origin/" + base
@@ -152,8 +154,9 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 
 func ensureBranchName(cwd, flagName, value string) error {
 	// Use a full ref so Git cannot expand @{-1}; branch shorthand must never
-	// silently select another branch. Leading '-' is unsafe for fetch/native CLI.
-	if value == "" || strings.HasPrefix(value, "-") || value == "HEAD" {
+	// silently select another branch. Leading '-' is unsafe for fetch/native CLI;
+	// a base beginning with '+' is force-refspec syntax, not an accepted base.
+	if value == "" || strings.HasPrefix(value, "-") || value == "HEAD" || (flagName == "base" && strings.HasPrefix(value, "+")) {
 		return fmt.Errorf("invalid --%s branch name %q", flagName, value)
 	}
 	if _, err := ensureGit(cwd, 10*time.Second, "check-ref-format", "refs/heads/"+value); err != nil {
@@ -167,6 +170,22 @@ func ensureGit(cwd string, timeout time.Duration, args ...string) ([]byte, error
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = cwd
+	// Explicit cwd owns repository discovery and its per-repository state.
+	// Preserve transport, authentication and config variables (including
+	// GIT_CONFIG_*); only inherited repository/object selection is excluded.
+	cmd.Env = make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+			"GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+			"GIT_GRAFT_FILE", "GIT_SHALLOW_FILE", "GIT_REPLACE_REF_BASE",
+			"GIT_NO_REPLACE_OBJECTS", "GIT_IMPLICIT_WORK_TREE", "GIT_PREFIX",
+			"GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM":
+			continue
+		}
+		cmd.Env = append(cmd.Env, entry)
+	}
 	// Bound pipe draining too, e.g. when a Git transport leaves a child holding it.
 	cmd.WaitDelay = time.Second
 	var stderr bytes.Buffer

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ensure-worktree resolves Git state only. Native Herdr owns the worktree and
+// workspace mutation; this command never creates a checkout or resets a branch.
+func runEnsureWorktree(args []string) {
+	result, err := ensureWorktree(args)
+	if err != nil {
+		errExit(err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(struct {
+		Result json.RawMessage `json:"result"`
+	}{result}); err != nil {
+		errExit("write result:", err)
+	}
+}
+
+func ensureWorktree(args []string) (json.RawMessage, error) {
+	flags := flag.NewFlagSet("ensure-worktree", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	var cwd, branch, base, path string
+	var focus bool
+	// Reject duplicates rather than letting a later flag hide an invalid value.
+	seen := make(map[string]bool)
+	for _, entry := range []struct {
+		name  string
+		value *string
+	}{
+		{"cwd", &cwd}, {"branch", &branch}, {"base", &base}, {"path", &path},
+	} {
+		flags.Func(entry.name, "explicit "+entry.name, func(value string) error {
+			if seen[entry.name] {
+				return fmt.Errorf("duplicate --%s", entry.name)
+			}
+			seen[entry.name] = true
+			*entry.value = value
+			return nil
+		})
+	}
+	flags.BoolVar(&focus, "focus", false, "focus the native workspace")
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+	if flags.NArg() != 0 {
+		return nil, errors.New("ensure-worktree accepts flags only")
+	}
+	if !filepath.IsAbs(cwd) || strings.ContainsRune(cwd, 0) {
+		return nil, errors.New("--cwd must be an explicit absolute directory")
+	}
+	if branch == "" {
+		return nil, errors.New("--branch is required")
+	}
+	if seen["path"] && (!filepath.IsAbs(path) || strings.ContainsRune(path, 0)) {
+		return nil, errors.New("--path must be an absolute path")
+	}
+	canonical, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("resolve --cwd: %w", err)
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("stat --cwd: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, errors.New("--cwd must be a directory")
+	}
+	if err := ensureBranchName(canonical, "branch", branch); err != nil {
+		return nil, err
+	}
+	if seen["base"] {
+		if err := ensureBranchName(canonical, "base", base); err != nil {
+			return nil, err
+		}
+	}
+	root, err := ensureGit(canonical, 10*time.Second, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, err
+	}
+	canonical, err = filepath.EvalSymlinks(strings.TrimSuffix(string(root), "\n"))
+	if err != nil || !filepath.IsAbs(canonical) {
+		return nil, fmt.Errorf("invalid git repository root %q", root)
+	}
+	listing, err := ensureGit(canonical, 10*time.Second, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return nil, err
+	}
+	registered, err := ensureRegisteredPath(canonical, listing, branch)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{"cwd": canonical, "branch": branch, "focus": focus}
+	method, expectedPath := "worktree.open", registered
+	if registered == "" {
+		method = "worktree.create"
+		_, err := ensureGit(canonical, 10*time.Second, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+		var exitErr *exec.ExitError
+		absent := errors.As(err, &exitErr) && exitErr.ExitCode() == 1
+		if err != nil && !absent {
+			return nil, err
+		}
+		if absent && (base == "" || path == "") {
+			return nil, errors.New("a new branch requires explicit --base and --path")
+		}
+		if path != "" {
+			// Check both spellings: trailing separators or '/.' can otherwise
+			// make Lstat follow a dangling symlink and report it as absent.
+			for _, candidate := range []string{path, filepath.Clean(path)} {
+				if _, err := os.Lstat(candidate); err == nil {
+					return nil, fmt.Errorf("target path already exists: %s", path)
+				} else if !os.IsNotExist(err) {
+					return nil, fmt.Errorf("inspect target path: %w", err)
+				}
+			}
+			params["path"], expectedPath = path, path
+		}
+		if absent {
+			if _, err := ensureGit(canonical, 2*time.Minute, "fetch", "origin", base); err != nil {
+				return nil, err
+			}
+			params["base"] = "origin/" + base
+		}
+	}
+	client, err := newHerdrClient()
+	if err != nil {
+		return nil, err
+	}
+	client.timeout = 30 * time.Second
+	var result json.RawMessage
+	if err := client.call(method, params, &result); err != nil {
+		return nil, err
+	}
+	if err := validateEnsureResult(result, branch, expectedPath); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func ensureBranchName(cwd, flagName, value string) error {
+	// Use a full ref so Git cannot expand @{-1}; branch shorthand must never
+	// silently select another branch. Leading '-' is unsafe for fetch/native CLI.
+	if value == "" || strings.HasPrefix(value, "-") || value == "HEAD" {
+		return fmt.Errorf("invalid --%s branch name %q", flagName, value)
+	}
+	if _, err := ensureGit(cwd, 10*time.Second, "check-ref-format", "refs/heads/"+value); err != nil {
+		return fmt.Errorf("invalid --%s: %w", flagName, err)
+	}
+	return nil
+}
+
+func ensureGit(cwd string, timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = cwd
+	// Bound pipe draining too, e.g. when a Git transport leaves a child holding it.
+	cmd.WaitDelay = time.Second
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("git %s: %w", args[0], ctx.Err())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", args[0], err, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
+}
+
+// Porcelain -z uses NUL fields and an empty field between records, preserving
+// spaces, newlines and quotes in paths. A broken query is never branch absence.
+func ensureRegisteredPath(cwd string, data []byte, branch string) (string, error) {
+	bad := errors.New("malformed git worktree list output")
+	if len(data) == 0 || !bytes.HasSuffix(data, []byte{0, 0}) {
+		return "", bad
+	}
+	var selected string
+	for _, record := range strings.Split(string(data[:len(data)-2]), "\x00\x00") {
+		fields := strings.Split(record, "\x00")
+		if !strings.HasPrefix(fields[0], "worktree ") {
+			return "", bad
+		}
+		path := strings.TrimPrefix(fields[0], "worktree ")
+		if !filepath.IsAbs(path) {
+			return "", bad
+		}
+		var head, ref string
+		var detached, bare bool
+		seen := make(map[string]bool)
+		for _, field := range fields[1:] {
+			key, value, hasValue := strings.Cut(field, " ")
+			if seen[key] {
+				return "", bad
+			}
+			seen[key] = true
+			switch key {
+			case "HEAD":
+				if !hasValue || (len(value) != 40 && len(value) != 64) {
+					return "", bad
+				}
+				if _, err := hex.DecodeString(value); err != nil {
+					return "", bad
+				}
+				head = value
+			case "branch":
+				if !strings.HasPrefix(value, "refs/heads/") || len(value) == len("refs/heads/") {
+					return "", bad
+				}
+				if _, err := ensureGit(cwd, 10*time.Second, "check-ref-format", value); err != nil {
+					return "", fmt.Errorf("malformed git worktree branch: %w", err)
+				}
+				ref = value
+			case "detached":
+				if hasValue {
+					return "", bad
+				}
+				detached = true
+			case "bare":
+				if hasValue {
+					return "", bad
+				}
+				bare = true
+			case "locked", "prunable": // Optional reason is an opaque NUL-delimited field.
+			default:
+				return "", bad
+			}
+		}
+		if bare {
+			if head != "" || ref != "" || detached {
+				return "", bad
+			}
+		} else if head == "" || (ref == "" && !detached) || (ref != "" && detached) {
+			return "", bad
+		}
+		if ref == "refs/heads/"+branch {
+			if selected != "" {
+				return "", errors.New("ambiguous git worktree registration for branch")
+			}
+			selected = path
+		}
+	}
+	return selected, nil
+}
+
+func validateEnsureResult(raw json.RawMessage, branch, expectedPath string) error {
+	var result struct {
+		Workspace struct {
+			ID string `json:"workspace_id"`
+		} `json:"workspace"`
+		RootPane struct {
+			ID string `json:"pane_id"`
+		} `json:"root_pane"`
+		Worktree struct {
+			Path   string `json:"path"`
+			Branch string `json:"branch"`
+		} `json:"worktree"`
+		AlreadyOpen *bool `json:"already_open"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return fmt.Errorf("malformed native worktree result: %w", err)
+	}
+	if strings.TrimSpace(result.Workspace.ID) == "" || strings.TrimSpace(result.RootPane.ID) == "" || !filepath.IsAbs(result.Worktree.Path) || strings.ContainsRune(result.Worktree.Path, 0) || result.Worktree.Branch != branch {
+		return errors.New("native worktree result lacks valid workspace/pane IDs or matching worktree path/branch")
+	}
+	if expectedPath != "" && filepath.Clean(result.Worktree.Path) != filepath.Clean(expectedPath) {
+		// Native may canonicalize a supplied path through a symlinked parent.
+		a, errA := filepath.EvalSymlinks(result.Worktree.Path)
+		b, errB := filepath.EvalSymlinks(expectedPath)
+		if errA != nil || errB != nil || a != b {
+			return errors.New("native worktree result path does not match requested checkout")
+		}
+	}
+	return nil
+}

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -117,7 +117,8 @@ func (s *worktreeSelection) verifyBranchPresence(branch string, absent bool) err
 // `run_worktree_add_command` into the start-point argument of
 // `git worktree add -b <branch> <path> <base>` with no branch-only validation
 // (pinned `src/app/api/worktrees/deferred.rs` and `src/worktree.rs`), so an
-// object id is accepted there and nothing can move underneath it.
+// object id is accepted there. Native uses this start point only if the branch
+// is still absent when its asynchronous Git operation runs.
 func (s *worktreeSelection) verifyBase(root, ref string) (string, error) {
 	if !isObjectID(s.BaseOID) {
 		return "", fmt.Errorf("the accepted plan carries no verified base commit for %s; %w", s.Branch, errWorktreeSelectionChanged)
@@ -324,6 +325,31 @@ func ensureWorktreeSelected(args []string, want *worktreeSelection) (json.RawMes
 		}
 		delete(params, "cwd")
 		params["workspace_id"] = workspace
+	}
+	// Fetch and native parent lookup can be slow. Refuse a selection whose
+	// Git meaning changed during those preparations, just before submission.
+	// Native execution is asynchronous; this is not an atomic Git lock.
+	if want != nil {
+		listing, err := ensureGit(canonical, 10*time.Second, "worktree", "list", "--porcelain", "-z")
+		if err != nil {
+			return nil, err
+		}
+		registered, err := ensureRegisteredPath(canonical, listing, branch)
+		if err != nil {
+			return nil, err
+		}
+		if err := want.verifyGitState(canonical, branch, path, registered); err != nil {
+			return nil, err
+		}
+		_, err = ensureGit(canonical, 10*time.Second, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+		var exitErr *exec.ExitError
+		absent := errors.As(err, &exitErr) && exitErr.ExitCode() == 1
+		if err != nil && !absent {
+			return nil, err
+		}
+		if err := want.verifyBranchPresence(branch, absent); err != nil {
+			return nil, err
+		}
 	}
 	var result json.RawMessage
 	if err := client.call(method, params, &result); err != nil {

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -54,6 +54,18 @@ type worktreeSelection struct {
 	BaseOID string
 }
 
+// isObjectID reports whether value is a full Git object id — SHA-1 or SHA-256.
+// A base that reaches native becomes the start-point argument of
+// `git worktree add`, so it must be an object id and nothing that Git could
+// interpret as an option or a revision expression.
+func isObjectID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
 // errWorktreeSelectionChanged closes every selection refusal with the only safe
 // remedy. Applying the new state instead would create or open something the
 // user never chose.
@@ -95,43 +107,61 @@ func (s *worktreeSelection) verifyBranchPresence(branch string, absent bool) err
 	return fmt.Errorf("branch %s %s, contradicting the accepted plan; %w", branch, state, errWorktreeSelectionChanged)
 }
 
-// verifyBase refuses when the fetch resolved the base ref to a commit other
-// than the one the plan showed. origin/BASE is a mutable ref: the remote can
-// advance between planning and applying, and another local fetch can move it
-// again. Reading it back is what makes the accepted base commit, rather than
-// whatever the ref happens to name, the one this branch is created from.
-func (s *worktreeSelection) verifyBase(root, ref string) error {
-	if s.BaseOID == "" {
-		return fmt.Errorf("the accepted plan carries no verified base commit for %s; %w", s.Branch, errWorktreeSelectionChanged)
+// verifyBase confirms the fetch brought back exactly the commit the plan showed,
+// and returns that commit for native creation.
+//
+// origin/BASE is a mutable ref: the remote can advance between planning and
+// applying, and another local fetch can move it again. So the ref is checked
+// once, here, against the accepted commit — and it is the commit, never the
+// ref, that is handed to native afterwards. Herdr 0.9 passes base through
+// `run_worktree_add_command` into the start-point argument of
+// `git worktree add -b <branch> <path> <base>` with no branch-only validation
+// (pinned `src/app/api/worktrees/deferred.rs` and `src/worktree.rs`), so an
+// object id is accepted there and nothing can move underneath it.
+func (s *worktreeSelection) verifyBase(root, ref string) (string, error) {
+	if !isObjectID(s.BaseOID) {
+		return "", fmt.Errorf("the accepted plan carries no verified base commit for %s; %w", s.Branch, errWorktreeSelectionChanged)
 	}
 	out, err := ensureGit(root, 10*time.Second, "rev-parse", "--verify", ref)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if got := strings.TrimSpace(string(out)); got != s.BaseOID {
-		return fmt.Errorf("base %s resolves to %s, not the accepted %s; %w", ref, got, s.BaseOID, errWorktreeSelectionChanged)
+		return "", fmt.Errorf("base %s resolves to %s, not the accepted %s; %w", ref, got, s.BaseOID, errWorktreeSelectionChanged)
 	}
-	return nil
+	return s.BaseOID, nil
 }
 
 // verifyNativeParent refuses a native parent record that does not agree with the
-// Git repository just planned. Herdr 0.9's worktree_source_from_workspace routes
-// a workspace-addressed operation through that workspace's stored
-// membership.repo_root, so a record whose repo_root is missing or names another
-// repository would run the mutation somewhere other than the checkout this plan
-// was built from — even when its checkout_path matches.
-func verifyNativeParent(parent workspaceInfo, workspace, primary string) error {
+// Git repository just planned.
+//
+// Herdr 0.9 routes a workspace-addressed operation through that workspace's
+// stored membership.repo_root (`worktree_source_from_workspace`), so a record
+// whose repo_root is missing or names another repository would run the mutation
+// somewhere other than the checkout this plan was built from — even when its
+// checkout_path matches. repo_key is the identity herdr groups and finds parent
+// workspaces by (`find_parent_workspace_by_key`), and pinned
+// `src/workspace/git_discovery.rs` derives it as the canonical Git common
+// directory, so Git can be asked for it directly rather than trusted.
+//
+// commonDir is this repository's canonical Git common directory.
+func verifyNativeParent(parent workspaceInfo, workspace, primary, commonDir string) error {
 	if parent.WorkspaceID != workspace || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, primary) {
 		return errors.New("source workspace no longer holds the primary checkout; no worktree was created")
 	}
 	if !samePath(parent.Worktree.RepoRoot, primary) {
 		return fmt.Errorf("source workspace %s reports repository root %q, not the primary checkout %s it is being used for; no worktree was created", workspace, parent.Worktree.RepoRoot, primary)
 	}
-	// repo_key and repo_name are what herdr groups and labels the repository by.
-	// They cannot be derived from Git here, but a record missing them is not a
-	// usable identity for the workspace the mutation would be attached to.
-	if strings.TrimSpace(parent.Worktree.RepoKey) == "" || strings.TrimSpace(parent.Worktree.RepoName) == "" {
-		return fmt.Errorf("source workspace %s reports incomplete repository provenance; no worktree was created", workspace)
+	// samePath refuses an empty value, so a record with no key is refused here
+	// rather than needing a separate presence check.
+	if !samePath(parent.Worktree.RepoKey, commonDir) {
+		return fmt.Errorf("source workspace %s reports repository key %q, not this repository's Git directory %s; no worktree was created", workspace, parent.Worktree.RepoKey, commonDir)
+	}
+	// repo_name is herdr's display label for the repository, derived from the
+	// common directory's own name; it selects nothing, so it is required to be
+	// present and not re-derived here.
+	if strings.TrimSpace(parent.Worktree.RepoName) == "" {
+		return fmt.Errorf("source workspace %s reports no repository name; no worktree was created", workspace)
 	}
 	return nil
 }
@@ -226,10 +256,6 @@ func ensureWorktreeSelected(args []string, want *worktreeSelection) (json.RawMes
 		}
 	}
 	params := map[string]any{"cwd": canonical, "branch": branch, "focus": focus}
-	// The ref the accepted base commit was verified against, re-read just before
-	// the mutation is submitted so the native call cannot inherit a base another
-	// local fetch moved while this command was talking to herdr.
-	var verifiedBase string
 	method, expectedPath := "worktree.open", registered
 	if registered == "" {
 		method = "worktree.create"
@@ -265,13 +291,16 @@ func ensureWorktreeSelected(args []string, want *worktreeSelection) (json.RawMes
 			if _, err := ensureGit(canonical, 2*time.Minute, "fetch", "origin", "refs/heads/"+base+":refs/remotes/origin/"+base); err != nil {
 				return nil, err
 			}
+			// Legacy callers name a branch and get the remote-tracking ref they
+			// asked for. An accepted plan gets the commit it showed the user.
+			params["base"] = "origin/" + base
 			if want != nil {
-				verifiedBase = "refs/remotes/origin/" + base
-				if err := want.verifyBase(canonical, verifiedBase); err != nil {
+				verified, err := want.verifyBase(canonical, "refs/remotes/origin/"+base)
+				if err != nil {
 					return nil, err
 				}
+				params["base"] = verified
 			}
-			params["base"] = "origin/" + base
 		}
 	}
 	client, err := newHerdrClient()
@@ -284,16 +313,17 @@ func ensureWorktreeSelected(args []string, want *worktreeSelection) (json.RawMes
 		if err != nil {
 			return nil, err
 		}
-		if err := verifyNativeParent(parent, workspace, canonical); err != nil {
+		// Ask Git for the same value herdr derives repo_key from, rather than
+		// accepting the key the record carries.
+		commonDir, err := ensureGit(canonical, 10*time.Second, "rev-parse", "--path-format=absolute", "--git-common-dir")
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyNativeParent(parent, workspace, canonical, strings.TrimSpace(string(commonDir))); err != nil {
 			return nil, err
 		}
 		delete(params, "cwd")
 		params["workspace_id"] = workspace
-	}
-	if verifiedBase != "" {
-		if err := want.verifyBase(canonical, verifiedBase); err != nil {
-			return nil, err
-		}
 	}
 	var result json.RawMessage
 	if err := client.call(method, params, &result); err != nil {

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -33,7 +33,7 @@ func runEnsureWorktree(args []string) {
 func ensureWorktree(args []string) (json.RawMessage, error) {
 	flags := flag.NewFlagSet("ensure-worktree", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	var cwd, branch, base, path string
+	var cwd, branch, base, path, workspace string
 	var focus bool
 	// Reject duplicates rather than letting a later flag hide an invalid value.
 	seen := make(map[string]bool)
@@ -41,7 +41,7 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 		name  string
 		value *string
 	}{
-		{"cwd", &cwd}, {"branch", &branch}, {"base", &base}, {"path", &path},
+		{"cwd", &cwd}, {"branch", &branch}, {"base", &base}, {"path", &path}, {"workspace", &workspace},
 	} {
 		flags.Func(entry.name, "explicit "+entry.name, func(value string) error {
 			if seen[entry.name] {
@@ -64,6 +64,9 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 	}
 	if branch == "" {
 		return nil, errors.New("--branch is required")
+	}
+	if seen["workspace"] && !workspaceIDPattern.MatchString(workspace) {
+		return nil, errors.New("--workspace must be an explicit native workspace id")
 	}
 	if seen["path"] && (!filepath.IsAbs(path) || strings.ContainsRune(path, 0)) {
 		return nil, errors.New("--path must be an absolute path")
@@ -142,6 +145,17 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 		return nil, err
 	}
 	client.timeout = 30 * time.Second
+	if workspace != "" {
+		parent, err := client.workspaceGet(workspace)
+		if err != nil {
+			return nil, err
+		}
+		if parent.WorkspaceID != workspace || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, canonical) {
+			return nil, errors.New("source workspace no longer holds the primary checkout")
+		}
+		delete(params, "cwd")
+		params["workspace_id"] = workspace
+	}
 	var result json.RawMessage
 	if err := client.call(method, params, &result); err != nil {
 		return nil, err

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -30,7 +31,120 @@ func runEnsureWorktree(args []string) {
 	}
 }
 
+// worktreeSelection is the plan snapshot a caller already showed the user and
+// the user accepted. ensure-worktree reads Git for itself, so without the
+// snapshot its fresh answer would quietly replace the accepted one; carrying it
+// through makes a changed selection a visible refusal instead.
+//
+// The legacy explicit-cwd command passes nil. It has no accepted plan to
+// preserve — its caller supplies the branch, path and base directly — and its
+// semantics are unchanged by these additional constraints.
+type worktreeSelection struct {
+	// Repository is the canonical primary checkout the plan was built against.
+	Repository string
+	// Branch and Path are the accepted candidate.
+	Branch, Path string
+	// Checkout is true when the candidate was a checkout Git had already
+	// registered for Branch, so Path must still be that registration.
+	Checkout bool
+	// Existing is true when Branch already existed locally at plan time.
+	Existing bool
+	// BaseOID is the commit the plan resolved the base ref to. It is empty for
+	// a candidate that needs no base.
+	BaseOID string
+}
+
+// errWorktreeSelectionChanged closes every selection refusal with the only safe
+// remedy. Applying the new state instead would create or open something the
+// user never chose.
+var errWorktreeSelectionChanged = errors.New("refresh and choose again; no worktree was created")
+
+// verifyGitState compares the fresh Git read against the accepted candidate.
+func (s *worktreeSelection) verifyGitState(root, branch, path, registered string) error {
+	if !samePath(root, s.Repository) {
+		return fmt.Errorf("the repository resolved to %s, not the planned %s; %w", root, s.Repository, errWorktreeSelectionChanged)
+	}
+	if branch != s.Branch {
+		return fmt.Errorf("the branch resolved to %q, not the selected %q; %w", branch, s.Branch, errWorktreeSelectionChanged)
+	}
+	if s.Checkout {
+		if registered == "" || !samePath(registered, s.Path) {
+			return fmt.Errorf("branch %s is no longer checked out at the selected %s (git now registers %q); %w", branch, s.Path, registered, errWorktreeSelectionChanged)
+		}
+		return nil
+	}
+	if registered != "" {
+		return fmt.Errorf("branch %s acquired a checkout at %s after the plan was made; %w", branch, registered, errWorktreeSelectionChanged)
+	}
+	if filepath.Clean(path) != filepath.Clean(s.Path) {
+		return fmt.Errorf("the destination resolved to %s, not the selected %s; %w", path, s.Path, errWorktreeSelectionChanged)
+	}
+	return nil
+}
+
+// verifyBranchPresence refuses when the local branch appeared or disappeared
+// after the plan: either way the selection now means something else.
+func (s *worktreeSelection) verifyBranchPresence(branch string, absent bool) error {
+	if absent != s.Existing {
+		return nil
+	}
+	state := "now exists locally"
+	if absent {
+		state = "no longer exists locally"
+	}
+	return fmt.Errorf("branch %s %s, contradicting the accepted plan; %w", branch, state, errWorktreeSelectionChanged)
+}
+
+// verifyBase refuses when the fetch resolved the base ref to a commit other
+// than the one the plan showed. origin/BASE is a mutable ref: the remote can
+// advance between planning and applying, and another local fetch can move it
+// again. Reading it back is what makes the accepted base commit, rather than
+// whatever the ref happens to name, the one this branch is created from.
+func (s *worktreeSelection) verifyBase(root, ref string) error {
+	if s.BaseOID == "" {
+		return fmt.Errorf("the accepted plan carries no verified base commit for %s; %w", s.Branch, errWorktreeSelectionChanged)
+	}
+	out, err := ensureGit(root, 10*time.Second, "rev-parse", "--verify", ref)
+	if err != nil {
+		return err
+	}
+	if got := strings.TrimSpace(string(out)); got != s.BaseOID {
+		return fmt.Errorf("base %s resolves to %s, not the accepted %s; %w", ref, got, s.BaseOID, errWorktreeSelectionChanged)
+	}
+	return nil
+}
+
+// verifyNativeParent refuses a native parent record that does not agree with the
+// Git repository just planned. Herdr 0.9's worktree_source_from_workspace routes
+// a workspace-addressed operation through that workspace's stored
+// membership.repo_root, so a record whose repo_root is missing or names another
+// repository would run the mutation somewhere other than the checkout this plan
+// was built from — even when its checkout_path matches.
+func verifyNativeParent(parent workspaceInfo, workspace, primary string) error {
+	if parent.WorkspaceID != workspace || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, primary) {
+		return errors.New("source workspace no longer holds the primary checkout; no worktree was created")
+	}
+	if !samePath(parent.Worktree.RepoRoot, primary) {
+		return fmt.Errorf("source workspace %s reports repository root %q, not the primary checkout %s it is being used for; no worktree was created", workspace, parent.Worktree.RepoRoot, primary)
+	}
+	// repo_key and repo_name are what herdr groups and labels the repository by.
+	// They cannot be derived from Git here, but a record missing them is not a
+	// usable identity for the workspace the mutation would be attached to.
+	if strings.TrimSpace(parent.Worktree.RepoKey) == "" || strings.TrimSpace(parent.Worktree.RepoName) == "" {
+		return fmt.Errorf("source workspace %s reports incomplete repository provenance; no worktree was created", workspace)
+	}
+	return nil
+}
+
+// ensureWorktree is the legacy explicit-cwd entry point: every constraint comes
+// from its flags, with no accepted plan behind them.
 func ensureWorktree(args []string) (json.RawMessage, error) {
+	return ensureWorktreeSelected(args, nil)
+}
+
+// ensureWorktreeSelected is the sole ensure implementation. want is the plan
+// snapshot to preserve, or nil for the legacy API.
+func ensureWorktreeSelected(args []string, want *worktreeSelection) (json.RawMessage, error) {
 	flags := flag.NewFlagSet("ensure-worktree", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	var cwd, branch, base, path, workspace string
@@ -106,7 +220,16 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	if want != nil {
+		if err := want.verifyGitState(canonical, branch, path, registered); err != nil {
+			return nil, err
+		}
+	}
 	params := map[string]any{"cwd": canonical, "branch": branch, "focus": focus}
+	// The ref the accepted base commit was verified against, re-read just before
+	// the mutation is submitted so the native call cannot inherit a base another
+	// local fetch moved while this command was talking to herdr.
+	var verifiedBase string
 	method, expectedPath := "worktree.open", registered
 	if registered == "" {
 		method = "worktree.create"
@@ -115,6 +238,11 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 		absent := errors.As(err, &exitErr) && exitErr.ExitCode() == 1
 		if err != nil && !absent {
 			return nil, err
+		}
+		if want != nil {
+			if err := want.verifyBranchPresence(branch, absent); err != nil {
+				return nil, err
+			}
 		}
 		if absent && (base == "" || path == "") {
 			return nil, errors.New("a new branch requires explicit --base and --path")
@@ -137,6 +265,12 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 			if _, err := ensureGit(canonical, 2*time.Minute, "fetch", "origin", "refs/heads/"+base+":refs/remotes/origin/"+base); err != nil {
 				return nil, err
 			}
+			if want != nil {
+				verifiedBase = "refs/remotes/origin/" + base
+				if err := want.verifyBase(canonical, verifiedBase); err != nil {
+					return nil, err
+				}
+			}
 			params["base"] = "origin/" + base
 		}
 	}
@@ -150,11 +284,16 @@ func ensureWorktree(args []string) (json.RawMessage, error) {
 		if err != nil {
 			return nil, err
 		}
-		if parent.WorkspaceID != workspace || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, canonical) {
-			return nil, errors.New("source workspace no longer holds the primary checkout")
+		if err := verifyNativeParent(parent, workspace, canonical); err != nil {
+			return nil, err
 		}
 		delete(params, "cwd")
 		params["workspace_id"] = workspace
+	}
+	if verifiedBase != "" {
+		if err := want.verifyBase(canonical, verifiedBase); err != nil {
+			return nil, err
+		}
 	}
 	var result json.RawMessage
 	if err := client.call(method, params, &result); err != nil {
@@ -316,13 +455,21 @@ func ensureRegisteredPath(cwd string, data []byte, branch string) (string, error
 	return selected, nil
 }
 
+// panePartPattern is the suffix Herdr appends to the owning workspace id to
+// spell a pane id: ":p" plus the pane's public number
+// (public_pane_id_for_number in the pinned 0.9.0 source). Checking it, and the
+// workspace id it is built on, is what makes "this pane belongs to this
+// workspace" a fact rather than an assumption the adapter would inherit.
+var panePartPattern = regexp.MustCompile(`^p[0-9A-Za-z]+$`)
+
 func validateEnsureResult(raw json.RawMessage, branch, expectedPath string) error {
 	var result struct {
 		Workspace struct {
 			ID string `json:"workspace_id"`
 		} `json:"workspace"`
 		RootPane struct {
-			ID string `json:"pane_id"`
+			ID          string `json:"pane_id"`
+			WorkspaceID string `json:"workspace_id"`
 		} `json:"root_pane"`
 		Worktree struct {
 			Path   string `json:"path"`
@@ -333,8 +480,17 @@ func validateEnsureResult(raw json.RawMessage, branch, expectedPath string) erro
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("malformed native worktree result: %w", err)
 	}
-	if strings.TrimSpace(result.Workspace.ID) == "" || strings.TrimSpace(result.RootPane.ID) == "" || !filepath.IsAbs(result.Worktree.Path) || strings.ContainsRune(result.Worktree.Path, 0) || result.Worktree.Branch != branch {
+	workspaceID := strings.TrimSpace(result.Workspace.ID)
+	paneID := strings.TrimSpace(result.RootPane.ID)
+	if !workspaceIDPattern.MatchString(workspaceID) || !workspaceIDPattern.MatchString(paneID) || !filepath.IsAbs(result.Worktree.Path) || strings.ContainsRune(result.Worktree.Path, 0) || result.Worktree.Branch != branch {
 		return errors.New("native worktree result lacks valid workspace/pane IDs or matching worktree path/branch")
+	}
+	// A workspace and a root pane that name different workspaces are not one
+	// result. Passing the pair on intact would hand the caller two native
+	// objects it has no basis for treating as related.
+	suffix, ok := strings.CutPrefix(paneID, workspaceID+":")
+	if !ok || !panePartPattern.MatchString(suffix) || strings.TrimSpace(result.RootPane.WorkspaceID) != workspaceID {
+		return fmt.Errorf("native worktree result reports root pane %q for workspace %q; they are not one workspace", result.RootPane.ID, result.Workspace.ID)
 	}
 	if expectedPath != "" && filepath.Clean(result.Worktree.Path) != filepath.Clean(expectedPath) {
 		// Native may canonicalize a supplied path through a symlinked parent.

--- a/ensureworktree.go
+++ b/ensureworktree.go
@@ -200,22 +200,35 @@ func ensureGit(cwd string, timeout time.Duration, args ...string) ([]byte, error
 	return out, nil
 }
 
+// gitWorktreeRecord is one entry of `git worktree list --porcelain -z`: the
+// checkout's path plus the state Git registers for it. It is shared by the
+// ensure-worktree command and the Projects checkout binding so both read Git's
+// registry through one strict parser rather than two.
+type gitWorktreeRecord struct {
+	Path string
+	// Ref is the full "refs/heads/<name>" a checkout has on a branch, empty when
+	// it is detached or bare.
+	Ref      string
+	Detached bool
+	Bare     bool
+}
+
 // Porcelain -z uses NUL fields and an empty field between records, preserving
 // spaces, newlines and quotes in paths. A broken query is never branch absence.
-func ensureRegisteredPath(cwd string, data []byte, branch string) (string, error) {
+func parseGitWorktreeList(cwd string, data []byte) ([]gitWorktreeRecord, error) {
 	bad := errors.New("malformed git worktree list output")
 	if len(data) == 0 || !bytes.HasSuffix(data, []byte{0, 0}) {
-		return "", bad
+		return nil, bad
 	}
-	var selected string
+	var records []gitWorktreeRecord
 	for _, record := range strings.Split(string(data[:len(data)-2]), "\x00\x00") {
 		fields := strings.Split(record, "\x00")
 		if !strings.HasPrefix(fields[0], "worktree ") {
-			return "", bad
+			return nil, bad
 		}
 		path := strings.TrimPrefix(fields[0], "worktree ")
 		if !filepath.IsAbs(path) {
-			return "", bad
+			return nil, bad
 		}
 		var head, ref string
 		var detached, bare bool
@@ -223,53 +236,67 @@ func ensureRegisteredPath(cwd string, data []byte, branch string) (string, error
 		for _, field := range fields[1:] {
 			key, value, hasValue := strings.Cut(field, " ")
 			if seen[key] {
-				return "", bad
+				return nil, bad
 			}
 			seen[key] = true
 			switch key {
 			case "HEAD":
 				if !hasValue || (len(value) != 40 && len(value) != 64) {
-					return "", bad
+					return nil, bad
 				}
 				if _, err := hex.DecodeString(value); err != nil {
-					return "", bad
+					return nil, bad
 				}
 				head = value
 			case "branch":
 				if !strings.HasPrefix(value, "refs/heads/") || len(value) == len("refs/heads/") {
-					return "", bad
+					return nil, bad
 				}
 				if _, err := ensureGit(cwd, 10*time.Second, "check-ref-format", value); err != nil {
-					return "", fmt.Errorf("malformed git worktree branch: %w", err)
+					return nil, fmt.Errorf("malformed git worktree branch: %w", err)
 				}
 				ref = value
 			case "detached":
 				if hasValue {
-					return "", bad
+					return nil, bad
 				}
 				detached = true
 			case "bare":
 				if hasValue {
-					return "", bad
+					return nil, bad
 				}
 				bare = true
 			case "locked", "prunable": // Optional reason is an opaque NUL-delimited field.
 			default:
-				return "", bad
+				return nil, bad
 			}
 		}
 		if bare {
 			if head != "" || ref != "" || detached {
-				return "", bad
+				return nil, bad
 			}
 		} else if head == "" || (ref == "" && !detached) || (ref != "" && detached) {
-			return "", bad
+			return nil, bad
 		}
-		if ref == "refs/heads/"+branch {
+		records = append(records, gitWorktreeRecord{Path: path, Ref: ref, Detached: detached, Bare: bare})
+	}
+	return records, nil
+}
+
+// ensureRegisteredPath returns the checkout path Git has registered for branch,
+// or "" when the branch has no worktree. A broken query is never branch absence.
+func ensureRegisteredPath(cwd string, data []byte, branch string) (string, error) {
+	records, err := parseGitWorktreeList(cwd, data)
+	if err != nil {
+		return "", err
+	}
+	var selected string
+	for _, record := range records {
+		if record.Ref == "refs/heads/"+branch {
 			if selected != "" {
 				return "", errors.New("ambiguous git worktree registration for branch")
 			}
-			selected = path
+			selected = record.Path
 		}
 	}
 	return selected, nil

--- a/ensureworktree_test.go
+++ b/ensureworktree_test.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// This suite runs the built CLI with real disposable Git repositories. Only
+// fetch and deliberately broken Git queries are replaced; IPC is a local fake.
+// Neither the user's Git configuration nor a live Herdr endpoint is inherited.
+func TestEnsureWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic Unix socket and sh Git boundary; Windows native gate is separate")
+	}
+	bin := filepath.Join(t.TempDir(), "herdr-plus")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build CLI: %v\n%s", err, out)
+	}
+
+	t.Run("selection", func(t *testing.T) {
+		for _, tc := range []struct {
+			name, state                string
+			path, base, focus, symlink bool
+		}{
+			{name: "registered preserves old path", state: "registered", path: true, base: true},
+			{name: "registered needs no defaults", state: "registered"},
+			{name: "locked checkout with newline path", state: "locked"},
+			{name: "local branch without checkout", state: "local"},
+			{name: "local branch explicit path ignores base", state: "local", path: true, base: true},
+			{name: "new branch fetches explicit base", state: "new", path: true, base: true},
+			{name: "exact match a is not ab", state: "prefix", path: true, base: true},
+			{name: "canonical cwd and explicit focus", state: "local", symlink: true, focus: true},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				oldPath := filepath.Join(f.dir, "old checkout with spaces")
+				switch tc.state {
+				case "registered":
+					f.git("worktree", "add", "-b", "feature/a", oldPath)
+				case "locked":
+					oldPath += "\nwith a quote \""
+					f.git("worktree", "add", "-b", "feature/a", oldPath)
+					f.git("worktree", "lock", "--reason", "locked\nreason", oldPath)
+					f.git("worktree", "add", "--detach", filepath.Join(f.dir, "detached"))
+				case "local":
+					f.git("branch", "feature/a")
+				case "prefix":
+					f.git("worktree", "add", "-b", "feature/ab", oldPath)
+				}
+				before := f.git("show-ref", "--heads")
+				cwd := f.repo
+				if tc.symlink {
+					cwd = filepath.Join(f.dir, "repo alias")
+					if err := os.Symlink(f.repo, cwd); err != nil {
+						t.Fatal(err)
+					}
+				}
+				args := []string{"--cwd", cwd, "--branch", "feature/a"}
+				want := map[string]any{"cwd": f.repo, "branch": "feature/a", "focus": tc.focus}
+				method := "worktree.create"
+				resultPath := f.target
+				if tc.path {
+					args = append(args, "--path", f.target)
+				}
+				if tc.base {
+					args = append(args, "--base", "main")
+				}
+				if tc.focus {
+					args = append(args, "--focus")
+				}
+				if tc.state == "registered" || tc.state == "locked" {
+					method, resultPath = "worktree.open", oldPath
+				} else if tc.path {
+					want["path"] = f.target
+				}
+				fetch := tc.state == "new" || tc.state == "prefix"
+				if fetch {
+					want["base"] = "origin/main"
+				}
+				result := ensureResult(resultPath)
+				if method == "worktree.open" {
+					result["already_open"] = true
+				}
+				f.reply = map[string]any{"id": "herdr-plus", "result": result}
+				stdout, stderr, err := f.run(args...)
+				if err != nil {
+					t.Fatalf("CLI: %v; stderr=%s; stdout=%s", err, stderr, stdout)
+				}
+				if stderr != "" {
+					t.Fatalf("unexpected stderr: %s", stderr)
+				}
+				var got map[string]any
+				if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+					t.Fatalf("stdout must be one JSON object: %q: %v", stdout, err)
+				}
+				if !reflect.DeepEqual(got, map[string]any{"result": result}) {
+					t.Fatalf("result changed: %#v", got)
+				}
+				f.assertCalls(method, want)
+				log := f.log()
+				if strings.Contains(log, "fetch origin main\n") != fetch {
+					t.Fatalf("fetch selection: %q", log)
+				}
+				if fetch && !strings.Contains(log, "fetch origin main\nNATIVE worktree.create\n") {
+					t.Fatalf("fetch must precede native call: %q", log)
+				}
+				if after := f.git("show-ref", "--heads"); after != before {
+					t.Fatalf("local branch refs changed: before=%s after=%s", before, after)
+				}
+				if _, err := os.Lstat(f.target); !os.IsNotExist(err) {
+					t.Fatalf("Plus created target directly: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid inputs fail before mutation", func(t *testing.T) {
+		for _, tc := range []struct{ name, flag, value, diagnostic string }{
+			{"missing cwd", "--cwd", "OMIT", "cwd"},
+			{"relative cwd", "--cwd", ".", "cwd"},
+			{"empty cwd", "--cwd", "", "cwd"},
+			{"not a repo", "--cwd", "DIR", "git"},
+			{"missing branch", "--branch", "OMIT", "branch"},
+			{"empty branch", "--branch", "", "branch"},
+			{"invalid branch", "--branch", "a..b", "branch"},
+			{"leading option branch", "--branch", "--help", "branch"},
+			{"branch expression", "--branch", "@{-1}", "branch"},
+			{"missing base", "--base", "OMIT", "base"},
+			{"empty base", "--base", "", "base"},
+			{"invalid base", "--base", "main:other", "base"},
+			{"leading option base", "--base", "--upload-pack=evil", "base"},
+			{"missing path", "--path", "OMIT", "path"},
+			{"empty path", "--path", "", "path"},
+			{"relative path", "--path", "relative", "path"},
+			{"existing directory", "--path", "DIR", "path"},
+			{"dangling symlink", "--path", "DANGLING", "path"},
+			{"dangling symlink trailing separator", "--path", "DANGLING-SLASH", "path"},
+			{"existing file", "--path", "FILE", "path"},
+			{"unknown flag", "--unknown", "yes", "flag"},
+			{"invalid focus", "--focus=maybe", "OMIT", "focus"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				value := tc.value
+				switch value {
+				case "DIR":
+					value = f.dir
+				case "DANGLING", "DANGLING-SLASH":
+					value = f.target
+					if err := os.Symlink(filepath.Join(f.dir, "missing"), value); err != nil {
+						t.Fatal(err)
+					}
+					if tc.value == "DANGLING-SLASH" {
+						value += string(filepath.Separator)
+					}
+				case "FILE":
+					value = f.target
+					if err := os.WriteFile(value, nil, 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				flags := []string{"--cwd", "--branch", "--base", "--path"}
+				values := []string{f.repo, "feature/a", "main", f.target}
+				var args []string
+				for i, flag := range flags {
+					if flag == tc.flag {
+						if value != "OMIT" {
+							args = append(args, flag, value)
+						}
+						continue
+					}
+					args = append(args, flag, values[i])
+				}
+				if strings.HasPrefix(tc.flag, "--unknown") {
+					args = append(args, tc.flag, value)
+				}
+				if strings.HasPrefix(tc.flag, "--focus") {
+					args = append(args, tc.flag)
+				}
+				f.assertFailure(tc.diagnostic, 0, args...)
+				if strings.Contains(f.log(), "fetch ") {
+					t.Fatalf("invalid input fetched: %s", f.log())
+				}
+			})
+		}
+	})
+
+	t.Run("validate unused and repeated arguments", func(t *testing.T) {
+		for _, extra := range [][]string{
+			{"--base", "bad..base"}, {"--path", "relative"}, {"--branch", "--evil", "--branch", "feature/a"},
+			{"--base", "", "--base", "main"}, {"--focus", "unexpected"},
+		} {
+			t.Run(strings.Join(extra, " "), func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				f.git("worktree", "add", "-b", "feature/a", filepath.Join(f.dir, "old"))
+				f.assertFailure("", 0, append([]string{"--cwd", f.repo, "--branch", "feature/a"}, extra...)...)
+				if strings.Contains(f.log(), "fetch ") {
+					t.Fatal("invalid unused argument fetched")
+				}
+			})
+		}
+	})
+
+	t.Run("failed Git queries never become absence", func(t *testing.T) {
+		for _, mode := range []string{"list-fail", "list-empty", "list-malformed", "list-truncated", "list-invalid-head", "list-missing-branch", "list-invalid-branch", "list-duplicate", "show-ref-fail", "fetch-fail"} {
+			t.Run(mode, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				f.mode = mode
+				f.assertFailure("git", 0, "--cwd", f.repo, "--branch", "feature/a", "--base", "main", "--path", f.target)
+				if mode != "fetch-fail" && strings.Contains(f.log(), "fetch ") {
+					t.Fatalf("query failure fetched: %s", f.log())
+				}
+			})
+		}
+	})
+
+	t.Run("native failures never emit success or retry", func(t *testing.T) {
+		for _, mode := range []string{"error", "malformed-json", "wrong-id", "missing-id", "null", "missing-workspace", "missing-pane", "missing-path", "relative-path", "missing-branch", "wrong-branch", "wrong-path", "bad-already-open"} {
+			t.Run(mode, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				f.git("branch", "feature/a")
+				result := ensureResult(f.target)
+				f.reply = map[string]any{"id": "herdr-plus", "result": result}
+				switch mode {
+				case "error":
+					f.reply = map[string]any{"error": map[string]any{"code": "path_exists", "message": "race-time native refusal"}}
+				case "malformed-json":
+					f.rawReply = "not json\n"
+				case "wrong-id":
+					f.reply["id"] = "unrelated-request"
+				case "missing-id":
+					delete(f.reply, "id")
+				case "null":
+					f.reply["result"] = nil
+				case "missing-workspace":
+					delete(result, "workspace")
+				case "missing-pane":
+					delete(result, "root_pane")
+				case "missing-path":
+					delete(result["worktree"].(map[string]any), "path")
+				case "relative-path":
+					result["worktree"].(map[string]any)["path"] = "relative"
+				case "missing-branch":
+					delete(result["worktree"].(map[string]any), "branch")
+				case "wrong-branch":
+					result["worktree"].(map[string]any)["branch"] = "feature/ab"
+				case "wrong-path":
+					result["worktree"].(map[string]any)["path"] = filepath.Join(f.dir, "other")
+				case "bad-already-open":
+					result["already_open"] = "yes"
+				}
+				message := ""
+				if mode == "error" {
+					message = "path_exists: race-time native refusal"
+				}
+				f.assertFailure(message, 1, "--cwd", f.repo, "--branch", "feature/a", "--path", f.target)
+				if strings.Contains(f.log(), "fetch ") {
+					t.Fatal("native error fetched existing branch")
+				}
+			})
+		}
+	})
+
+	t.Run("bounded waits", func(t *testing.T) {
+		for _, mode := range []string{"list-stall", "native-stall"} {
+			t.Run(mode, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				f.git("branch", "feature/a")
+				f.mode = mode
+				calls := 0
+				if mode == "native-stall" {
+					calls = 1
+				}
+				f.assertFailure("deadline exceeded", calls, "--cwd", f.repo, "--branch", "feature/a")
+				if strings.Contains(f.log(), "fetch ") {
+					t.Fatal("timeout fetched existing branch")
+				}
+			})
+		}
+	})
+}
+
+type ensureFixture struct {
+	t                                                          *testing.T
+	bin, dir, repo, target, realGit, wrapperDir, logPath, mode string
+	reply                                                      map[string]any
+	rawReply                                                   string
+	mu                                                         sync.Mutex
+	calls                                                      []request
+}
+
+func newEnsureFixture(t *testing.T, bin string) *ensureFixture {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &ensureFixture{t: t, bin: bin, dir: dir, realGit: git, repo: filepath.Join(dir, "repo with spaces"), target: filepath.Join(dir, "new checkout with spaces"), wrapperDir: filepath.Join(dir, "bin"), logPath: filepath.Join(dir, "git.log")}
+	for _, path := range []string{f.repo, f.wrapperDir} {
+		if err := os.Mkdir(path, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.git("init", "-b", "main")
+	f.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "fixture")
+	// Never pass fetch through, even if production supplies unexpected arguments.
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$ENSURE_LOG"
+case "$1" in
+fetch)
+  if [ "$ENSURE_MODE" = fetch-fail ]; then echo 'synthetic fetch failure' >&2; exit 1; fi
+  [ "$#" = 3 ] && [ "$2" = origin ] && [ "$3" = main ] || exit 91
+  exit 0;;
+worktree)
+  [ "$2" = list ] || exit 92
+  case "$ENSURE_MODE" in
+    list-fail) echo 'synthetic listing failure' >&2; exit 1;;
+    list-empty) exit 0;;
+    list-malformed) printf 'garbage\000\000'; exit 0;;
+    list-truncated) printf 'worktree /tmp/example\000HEAD 123'; exit 0;;
+    list-invalid-head) printf 'worktree /tmp/example\000HEAD nope\000branch refs/heads/main\000\000'; exit 0;;
+    list-missing-branch) printf 'worktree /tmp/example\000HEAD 1111111111111111111111111111111111111111\000\000'; exit 0;;
+    list-invalid-branch) printf 'worktree /tmp/example\000HEAD 1111111111111111111111111111111111111111\000branch refs/heads/bad..branch\000\000'; exit 0;;
+    list-duplicate) for n in 1 2; do printf 'worktree /tmp/example\000HEAD 1111111111111111111111111111111111111111\000branch refs/heads/feature/a\000\000'; done; exit 0;;
+    list-stall) exec sleep 60;;
+  esac;;
+show-ref)
+  if [ "$ENSURE_MODE" = show-ref-fail ]; then echo 'synthetic ref failure' >&2; exit 128; fi;;
+rev-parse|check-ref-format) ;;
+*) echo 'unexpected git mutation' >&2; exit 93;;
+esac
+exec "$ENSURE_REAL_GIT" "$@"
+`
+	if err := os.WriteFile(filepath.Join(f.wrapperDir, "git"), []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	f.reply = map[string]any{"id": "herdr-plus", "result": ensureResult(f.target)}
+	return f
+}
+
+func (f *ensureFixture) env() []string {
+	return []string{"PATH=" + f.wrapperDir + string(os.PathListSeparator) + os.Getenv("PATH"), "HOME=" + f.dir, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull, "GIT_TERMINAL_PROMPT=0", "ENSURE_REAL_GIT=" + f.realGit, "ENSURE_LOG=" + f.logPath, "ENSURE_MODE=" + f.mode}
+}
+
+func (f *ensureFixture) git(args ...string) string {
+	f.t.Helper()
+	cmd := exec.Command(f.realGit, args...)
+	cmd.Dir, cmd.Env = f.repo, f.env()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		f.t.Fatalf("fixture git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+func ensureResult(path string) map[string]any {
+	return map[string]any{"workspace": map[string]any{"workspace_id": "w1"}, "root_pane": map[string]any{"pane_id": "w1:p1"}, "worktree": map[string]any{"path": path, "branch": "feature/a"}, "native_extra": "preserved"}
+}
+
+func (f *ensureFixture) run(args ...string) (string, string, error) {
+	f.t.Helper()
+	// Keep socket paths under the Unix length limit on macOS.
+	dir, err := os.MkdirTemp("", "ew-")
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	socket := filepath.Join(dir, "s")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.SetDeadline(time.Now().Add(40 * time.Second))
+			var req request
+			if err := json.NewDecoder(conn).Decode(&req); err == nil {
+				f.mu.Lock()
+				f.calls = append(f.calls, req)
+				f.mu.Unlock()
+				file, err := os.OpenFile(f.logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+				if err == nil {
+					fmt.Fprintln(file, "NATIVE", req.Method)
+					file.Close()
+				}
+				if f.mode == "native-stall" {
+					_, _ = io.Copy(io.Discard, conn)
+				} else if f.rawReply != "" {
+					fmt.Fprint(conn, f.rawReply)
+				} else {
+					_ = json.NewEncoder(conn).Encode(f.reply)
+				}
+			}
+			conn.Close()
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.bin, append([]string{"ensure-worktree"}, args...)...)
+	cmd.Env = append(f.env(), "HERDR_SOCKET_PATH="+socket)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err = cmd.Run()
+	listener.Close()
+	<-done
+	if ctx.Err() != nil {
+		f.t.Fatalf("CLI exceeded test deadline: %v", ctx.Err())
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func (f *ensureFixture) assertFailure(diagnostic string, calls int, args ...string) {
+	f.t.Helper()
+	stdout, stderr, err := f.run(args...)
+	if err == nil || stdout != "" || stderr == "" || !strings.Contains(strings.ToLower(stderr), strings.ToLower(diagnostic)) {
+		f.t.Fatalf("want failure containing %q with no stdout: err=%v stdout=%q stderr=%q", diagnostic, err, stdout, stderr)
+	}
+	if len(f.calls) != calls {
+		f.t.Fatalf("native calls=%v; want count %d", f.calls, calls)
+	}
+}
+
+func (f *ensureFixture) assertCalls(method string, params map[string]any) {
+	f.t.Helper()
+	if len(f.calls) != 1 || f.calls[0].Method != method || !reflect.DeepEqual(f.calls[0].Params, params) {
+		f.t.Fatalf("native calls=%#v; want %s %#v", f.calls, method, params)
+	}
+}
+
+func (f *ensureFixture) log() string {
+	f.t.Helper()
+	b, err := os.ReadFile(f.logPath)
+	if err != nil && !os.IsNotExist(err) {
+		f.t.Fatal(err)
+	}
+	return string(b)
+}

--- a/ensureworktree_test.go
+++ b/ensureworktree_test.go
@@ -542,7 +542,9 @@ func (f *ensureFixture) git(args ...string) string {
 }
 
 func ensureResult(path string) map[string]any {
-	return map[string]any{"workspace": map[string]any{"workspace_id": "w1"}, "root_pane": map[string]any{"pane_id": "w1:p1"}, "worktree": map[string]any{"path": path, "branch": "feature/a"}, "native_extra": "preserved"}
+	// root_pane carries its own workspace_id, as PaneInfo does in the 0.9.0 API
+	// schema, so the fixture proves the workspace and pane are one result.
+	return map[string]any{"workspace": map[string]any{"workspace_id": "w1"}, "root_pane": map[string]any{"pane_id": "w1:p1", "workspace_id": "w1"}, "worktree": map[string]any{"path": path, "branch": "feature/a"}, "native_extra": "preserved"}
 }
 
 func (f *ensureFixture) run(args ...string) (string, string, error) {

--- a/ensureworktree_test.go
+++ b/ensureworktree_test.go
@@ -19,7 +19,8 @@ import (
 )
 
 // This suite runs the built CLI with real disposable Git repositories. Only
-// fetch and deliberately broken Git queries are replaced; IPC is a local fake.
+// deliberately broken Git queries and most fetches are replaced; one bounded
+// fixture fetches a temporary file origin. IPC is always a local fake.
 // Neither the user's Git configuration nor a live Herdr endpoint is inherited.
 func TestEnsureWorktree(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -112,10 +113,10 @@ func TestEnsureWorktree(t *testing.T) {
 				}
 				f.assertCalls(method, want)
 				log := f.log()
-				if strings.Contains(log, "fetch origin main\n") != fetch {
+				if strings.Contains(log, "fetch origin refs/heads/main:refs/remotes/origin/main\n") != fetch {
 					t.Fatalf("fetch selection: %q", log)
 				}
-				if fetch && !strings.Contains(log, "fetch origin main\nNATIVE worktree.create\n") {
+				if fetch && !strings.Contains(log, "fetch origin refs/heads/main:refs/remotes/origin/main\nNATIVE worktree.create\n") {
 					t.Fatalf("fetch must precede native call: %q", log)
 				}
 				if after := f.git("show-ref", "--heads"); after != before {
@@ -125,6 +126,162 @@ func TestEnsureWorktree(t *testing.T) {
 					t.Fatalf("Plus created target directly: %v", err)
 				}
 			})
+		}
+	})
+
+	t.Run("cwd overrides inherited repository selectors", func(t *testing.T) {
+		for _, selectors := range []string{"directory and worktree", "common directory", "config count", "config parameters"} {
+			t.Run(selectors, func(t *testing.T) {
+				a, b := newEnsureFixture(t, bin), newEnsureFixture(t, bin)
+				oldPath := filepath.Join(a.dir, "registered in A")
+				a.git("worktree", "add", "-b", "feature/a", oldPath)
+				b.git("worktree", "add", "-b", "feature/a", filepath.Join(b.dir, "registered in B"))
+				a.cliEnv = []string{"GIT_DIR=" + filepath.Join(b.repo, ".git"), "GIT_WORK_TREE=" + b.repo}
+				if selectors == "common directory" {
+					a.cliEnv = []string{"GIT_COMMON_DIR=" + filepath.Join(b.repo, ".git")}
+				}
+				if selectors == "config count" {
+					a.cliEnv = []string{"GIT_CONFIG_COUNT=1", "GIT_CONFIG_KEY_0=core.worktree", "GIT_CONFIG_VALUE_0=" + b.repo}
+				}
+				if selectors == "config parameters" {
+					a.cliEnv = []string{"GIT_CONFIG_PARAMETERS='core.worktree=" + b.repo + "'"}
+				}
+				if strings.HasPrefix(selectors, "config ") {
+					// Verify that Git actually received the override; a benign or
+					// ineffective test environment would leave the doubt unresolved.
+					cmd := exec.Command(a.realGit, "config", "--get", "core.worktree")
+					cmd.Dir, cmd.Env = a.repo, append(a.env(), a.cliEnv...)
+					out, err := cmd.CombinedOutput()
+					if err != nil || strings.TrimSpace(string(out)) != b.repo {
+						t.Fatalf("injected config missing: out=%q err=%v", out, err)
+					}
+					cmd = exec.Command(a.realGit, "rev-parse", "--show-toplevel")
+					cmd.Dir, cmd.Env = a.repo, append(a.env(), a.cliEnv...)
+					out, err = cmd.CombinedOutput()
+					t.Logf("unfiltered Git root=%q err=%v; explicit A=%q", out, err, a.repo)
+				}
+				a.reply = map[string]any{"id": "herdr-plus", "result": ensureResult(oldPath)}
+				stdout, stderr, err := a.run("--cwd", a.repo, "--branch", "feature/a")
+				if err != nil {
+					t.Fatalf("explicit A must succeed: %v stdout=%q stderr=%q", err, stdout, stderr)
+				}
+				a.assertCalls("worktree.open", map[string]any{"cwd": a.repo, "branch": "feature/a", "focus": false})
+				if strings.Contains(a.log(), "fetch ") {
+					t.Fatal("registered branch fetched")
+				}
+			})
+		}
+	})
+
+	t.Run("Git paths ignore inherited selectors", func(t *testing.T) {
+		for _, tc := range []struct{ variable, path string }{
+			{"GIT_INDEX_FILE", "index"},
+			{"GIT_OBJECT_DIRECTORY", "objects"},
+			{"GIT_GRAFT_FILE", "info/grafts"},
+		} {
+			t.Run(tc.variable, func(t *testing.T) {
+				f := newEnsureFixture(t, bin)
+				t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+				t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+				t.Setenv(tc.variable, filepath.Join(f.dir, "foreign"))
+				out, err := ensureGit(f.repo, 10*time.Second, "rev-parse", "--path-format=absolute", "--git-path", tc.path)
+				want := filepath.Join(f.repo, ".git", tc.path)
+				if err != nil || strings.TrimSpace(string(out)) != want {
+					t.Fatalf("Git must use cwd's %s: got=%q err=%v want=%q", tc.path, out, err, want)
+				}
+			})
+		}
+	})
+
+	t.Run("Git object lookup ignores inherited alternates", func(t *testing.T) {
+		a, b := newEnsureFixture(t, bin), newEnsureFixture(t, bin)
+		b.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "only B")
+		oid := strings.TrimSpace(b.git("rev-parse", "HEAD"))
+		t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+		t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+		t.Setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", filepath.Join(b.repo, ".git", "objects"))
+		if _, err := ensureGit(a.repo, 10*time.Second, "cat-file", "-e", oid); err == nil {
+			t.Fatal("cwd A unexpectedly sees an object present only in B")
+		}
+	})
+
+	t.Run("Git retains supplied configuration", func(t *testing.T) {
+		f := newEnsureFixture(t, bin)
+		t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+		t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+		t.Setenv("GIT_CONFIG_COUNT", "1")
+		t.Setenv("GIT_CONFIG_KEY_0", "ensure.fixture")
+		t.Setenv("GIT_CONFIG_VALUE_0", "retained")
+		out, err := ensureGit(f.repo, 10*time.Second, "config", "--get", "ensure.fixture")
+		if err != nil || string(out) != "retained\n" {
+			t.Fatalf("inherited configuration lost: out=%q err=%v", out, err)
+		}
+	})
+
+	t.Run("Git ignores inherited replacement namespace", func(t *testing.T) {
+		f := newEnsureFixture(t, bin)
+		original := strings.TrimSpace(f.git("rev-parse", "HEAD"))
+		f.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "replacement")
+		f.git("update-ref", "refs/foreign-replacements/"+original, "HEAD")
+		t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+		t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+		t.Setenv("GIT_REPLACE_REF_BASE", "refs/foreign-replacements/")
+		out, err := ensureGit(f.repo, 10*time.Second, "log", "-1", "--format=%s", original)
+		if err != nil || string(out) != "fixture\n" {
+			t.Fatalf("foreign replacement changed object: got=%q err=%v", out, err)
+		}
+	})
+
+	t.Run("local origin refreshes stale base with narrowed mapping", func(t *testing.T) {
+		f, origin := newEnsureFixture(t, bin), newEnsureFixture(t, bin)
+		f.git("remote", "add", "origin", origin.repo)
+		// Establish actual shared history before advancing origin. Independently
+		// created fixture commits need not have the same timestamp or object ID.
+		f.git("fetch", "origin", "refs/heads/main:refs/remotes/origin/main")
+		stale := strings.TrimSpace(f.git("rev-parse", "refs/remotes/origin/main"))
+		f.git("config", "remote.origin.fetch", "+refs/heads/other:refs/remotes/origin/other")
+		origin.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "new origin base")
+		fresh := strings.TrimSpace(origin.git("rev-parse", "HEAD"))
+		if stale == fresh {
+			t.Fatal("fixture base must start stale")
+		}
+		origin.git("merge-base", "--is-ancestor", stale, fresh)
+		before := f.git("show-ref", "--heads")
+		f.localOrigin, f.wantBase = origin.repo, fresh
+		stdout, stderr, err := f.run("--cwd", f.repo, "--branch", "feature/a", "--base", "main", "--path", f.target)
+		if err != nil {
+			t.Fatalf("local fetch: %v stdout=%q stderr=%q", err, stdout, stderr)
+		}
+		if got := strings.TrimSpace(f.git("rev-parse", "refs/remotes/origin/main")); got != fresh {
+			t.Fatalf("origin/main stayed stale: got=%s want=%s", got, fresh)
+		}
+		f.assertCalls("worktree.create", map[string]any{"cwd": f.repo, "branch": "feature/a", "base": "origin/main", "path": f.target, "focus": false})
+		if got := f.git("show-ref", "--heads"); got != before {
+			t.Fatalf("local branches changed: before=%s after=%s", before, got)
+		}
+		if strings.Count(f.log(), "fetch ") != 1 {
+			t.Fatalf("want one fetch: %s", f.log())
+		}
+	})
+
+	t.Run("local origin missing base stops before native without retry", func(t *testing.T) {
+		f, origin := newEnsureFixture(t, bin), newEnsureFixture(t, bin)
+		f.git("remote", "add", "origin", origin.repo)
+		f.git("fetch", "origin", "refs/heads/main:refs/remotes/origin/main")
+		stale := strings.TrimSpace(f.git("rev-parse", "refs/remotes/origin/main"))
+		f.git("config", "remote.origin.fetch", "+refs/heads/other:refs/remotes/origin/other")
+		origin.git("branch", "-m", "other")
+		f.localOrigin = origin.repo
+		before := f.git("show-ref", "--heads")
+		f.assertFailure("git fetch", 0, "--cwd", f.repo, "--branch", "feature/a", "--base", "main", "--path", f.target)
+		if strings.Count(f.log(), "fetch ") != 1 {
+			t.Fatalf("failed fetch must not retry: %s", f.log())
+		}
+		if got := strings.TrimSpace(f.git("rev-parse", "refs/remotes/origin/main")); got != stale {
+			t.Fatalf("failed fetch changed stale ref: got=%s want=%s", got, stale)
+		}
+		if got := f.git("show-ref", "--heads"); got != before {
+			t.Fatalf("local branches changed: before=%s after=%s", before, got)
 		}
 	})
 
@@ -143,6 +300,7 @@ func TestEnsureWorktree(t *testing.T) {
 			{"empty base", "--base", "", "base"},
 			{"invalid base", "--base", "main:other", "base"},
 			{"leading option base", "--base", "--upload-pack=evil", "base"},
+			{"leading plus base", "--base", "+main", "base"},
 			{"missing path", "--path", "OMIT", "path"},
 			{"empty path", "--path", "", "path"},
 			{"relative path", "--path", "relative", "path"},
@@ -201,7 +359,7 @@ func TestEnsureWorktree(t *testing.T) {
 
 	t.Run("validate unused and repeated arguments", func(t *testing.T) {
 		for _, extra := range [][]string{
-			{"--base", "bad..base"}, {"--path", "relative"}, {"--branch", "--evil", "--branch", "feature/a"},
+			{"--base", "bad..base"}, {"--base", "+main"}, {"--path", "relative"}, {"--branch", "--evil", "--branch", "feature/a"},
 			{"--base", "", "--base", "main"}, {"--focus", "unexpected"},
 		} {
 			t.Run(strings.Join(extra, " "), func(t *testing.T) {
@@ -299,6 +457,8 @@ type ensureFixture struct {
 	bin, dir, repo, target, realGit, wrapperDir, logPath, mode string
 	reply                                                      map[string]any
 	rawReply                                                   string
+	cliEnv                                                     []string
+	localOrigin, wantBase                                      string
 	mu                                                         sync.Mutex
 	calls                                                      []request
 }
@@ -321,13 +481,20 @@ func newEnsureFixture(t *testing.T, bin string) *ensureFixture {
 	}
 	f.git("init", "-b", "main")
 	f.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-m", "fixture")
-	// Never pass fetch through, even if production supplies unexpected arguments.
+	// Fetch is synthetic unless this fixture explicitly permits a temporary file
+	// origin. Even then, deny all other protocols and unexpected arguments.
 	script := `#!/bin/sh
 printf '%s\n' "$*" >> "$ENSURE_LOG"
 case "$1" in
 fetch)
   if [ "$ENSURE_MODE" = fetch-fail ]; then echo 'synthetic fetch failure' >&2; exit 1; fi
-  [ "$#" = 3 ] && [ "$2" = origin ] && [ "$3" = main ] || exit 91
+  [ "$#" = 3 ] && [ "$2" = origin ] || exit 91
+  case "$3" in main|+main|refs/heads/main:refs/remotes/origin/main) ;; *) exit 91;; esac
+  if [ -n "$ENSURE_LOCAL_ORIGIN" ]; then
+    [ "$("$ENSURE_REAL_GIT" remote get-url origin)" = "$ENSURE_LOCAL_ORIGIN" ] || exit 94
+    export GIT_ALLOW_PROTOCOL=file
+    exec "$ENSURE_REAL_GIT" "$@"
+  fi
   exit 0;;
 worktree)
   [ "$2" = list ] || exit 92
@@ -357,12 +524,15 @@ exec "$ENSURE_REAL_GIT" "$@"
 }
 
 func (f *ensureFixture) env() []string {
-	return []string{"PATH=" + f.wrapperDir + string(os.PathListSeparator) + os.Getenv("PATH"), "HOME=" + f.dir, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull, "GIT_TERMINAL_PROMPT=0", "ENSURE_REAL_GIT=" + f.realGit, "ENSURE_LOG=" + f.logPath, "ENSURE_MODE=" + f.mode}
+	return []string{"PATH=" + f.wrapperDir + string(os.PathListSeparator) + os.Getenv("PATH"), "HOME=" + f.dir, "GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=" + os.DevNull, "GIT_TERMINAL_PROMPT=0", "GIT_ALLOW_PROTOCOL=file", "ENSURE_REAL_GIT=" + f.realGit, "ENSURE_LOG=" + f.logPath, "ENSURE_MODE=" + f.mode, "ENSURE_LOCAL_ORIGIN=" + f.localOrigin}
 }
 
 func (f *ensureFixture) git(args ...string) string {
 	f.t.Helper()
-	cmd := exec.Command(f.realGit, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.realGit, args...)
+	cmd.WaitDelay = time.Second
 	cmd.Dir, cmd.Env = f.repo, f.env()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -412,6 +582,14 @@ func (f *ensureFixture) run(args ...string) (string, string, error) {
 				} else if f.rawReply != "" {
 					fmt.Fprint(conn, f.rawReply)
 				} else {
+					if f.wantBase != "" {
+						cmd := exec.Command(f.realGit, "rev-parse", "refs/remotes/origin/main")
+						cmd.Dir, cmd.Env = f.repo, f.env()
+						out, err := cmd.Output()
+						if err != nil || strings.TrimSpace(string(out)) != f.wantBase {
+							f.t.Errorf("base must be fresh before native call: got=%q err=%v want=%s", out, err, f.wantBase)
+						}
+					}
 					_ = json.NewEncoder(conn).Encode(f.reply)
 				}
 			}
@@ -421,7 +599,7 @@ func (f *ensureFixture) run(args ...string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, f.bin, append([]string{"ensure-worktree"}, args...)...)
-	cmd.Env = append(f.env(), "HERDR_SOCKET_PATH="+socket)
+	cmd.Env = append(append(f.env(), f.cliEnv...), "HERDR_SOCKET_PATH="+socket)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
 	err = cmd.Run()

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -16,7 +16,7 @@ id = "cloudmanic.herdr-plus"
 name = "Herdr Plus"
 # Kept in sync with internal/version/version.go by .github/workflows/release.yml.
 version = "0.1.24"
-min_herdr_version = "0.7.0"
+min_herdr_version = "0.9.0"
 description = "An extension for herdr — a collection of tools that make it better. Projects: fuzzy-pick a declarative template to spin up a whole workspace — every tab, pane, and startup command. Quick Actions: a fuzzy launcher for one-off scripts, run in the directory you launched from."
 # Windows is supported under herdr's Windows beta (a manifest platform in
 # preview). Per-command `platforms` below override this list so each OS runs the

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -72,6 +72,19 @@ platforms = ["linux", "macos"]
 command = ["./bin/herdr-plus", "projects"]
 
 [[actions]]
+id = "worktree"
+title = "Herdr Plus: Worktree"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "worktree"]
+
+[[panes]]
+id = "worktree-picker"
+title = "Herdr Plus: Worktree"
+placement = "overlay"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "worktree-ui"]
+
+[[actions]]
 id = "projects-windows"
 title = "Herdr Plus: Projects"
 platforms = ["windows"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -26,9 +26,10 @@ platforms = ["linux", "macos", "windows"]
 # Produce the binary at install time. herdr runs this once, after you confirm a
 # GitHub install and before registering the plugin.
 #
-# Unix: the sh script prefers a local Go toolchain (an exact build of the cloned
-# source) and falls back to downloading the latest prebuilt release binary, so
-# installing works with or without Go. The result is ./bin/herdr-plus.
+# Unix: the sh script builds the cloned source with a local Go toolchain, which is
+# required — there is no fallback to a prebuilt release binary, since a published
+# release would not contain the code herdr just checked out. A missing toolchain
+# fails the install with instructions. The result is ./bin/herdr-plus.
 [[build]]
 platforms = ["linux", "macos"]
 command = ["sh", "scripts/build.sh"]
@@ -75,6 +76,24 @@ id = "projects-windows"
 title = "Herdr Plus: Projects"
 platforms = ["windows"]
 command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe projects"]
+
+# projects-pick — the explicit "choose another project" entry. The plain
+# projects action above returns to the current task tab when [projects].crew_tab
+# is configured and it fires inside a linked worktree workspace; this one always
+# opens the browser, whatever it was invoked from. Bind a second key to it, or
+# run it from herdr's action menu, when you want a different project from inside
+# one you are already working in.
+[[actions]]
+id = "projects-pick"
+title = "Herdr Plus: Projects (pick another)"
+platforms = ["linux", "macos"]
+command = ["./bin/herdr-plus", "projects", "--pick"]
+
+[[actions]]
+id = "projects-pick-windows"
+title = "Herdr Plus: Projects (pick another)"
+platforms = ["windows"]
+command = ["powershell", "-NoProfile", "-NonInteractive", "-Command", "& .\\bin\\herdr-plus.exe projects --pick"]
 
 # picker — the projects browser as a herdr-managed pane (no throwaway workspace).
 # Opened by the projects action via `herdr plugin pane open`; herdr gives it a

--- a/herdr.go
+++ b/herdr.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +26,9 @@ import (
 // herdr runs us.
 type herdrClient struct {
 	socketPath string
+	// Opt-in bound for headless ensure-worktree; existing callers retain their
+	// transport behavior. Includes dial, write and response read time.
+	timeout time.Duration
 }
 
 // newHerdrClient builds a client from the HERDR_SOCKET_PATH environment
@@ -61,11 +65,53 @@ type response struct {
 // call sends a single request over a fresh connection and decodes the result
 // into out (which may be nil when the caller does not care about the payload).
 func (c *herdrClient) call(method string, params map[string]any, out any) error {
+	if c.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+		defer cancel()
+		type reply struct {
+			result json.RawMessage
+			err    error
+		}
+		done := make(chan reply, 1)
+		go func() {
+			// Keep decoding private: a timeout must not leave a goroutine writing
+			// into the caller's output after call returns.
+			var result json.RawMessage
+			err := c.callContext(ctx, method, params, &result)
+			done <- reply{result, err}
+		}()
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("herdr IPC %s: %w (native outcome unknown; no retry)", method, ctx.Err())
+		case r := <-done:
+			if ctx.Err() != nil {
+				return fmt.Errorf("herdr IPC %s: %w (native outcome unknown; no retry)", method, ctx.Err())
+			}
+			if r.err != nil {
+				return r.err
+			}
+			if out != nil {
+				if err := json.Unmarshal(r.result, out); err != nil {
+					return fmt.Errorf("decode result: %w", err)
+				}
+			}
+			return nil
+		}
+	}
+	return c.callContext(context.Background(), method, params, out)
+}
+
+func (c *herdrClient) callContext(ctx context.Context, method string, params map[string]any, out any) error {
 	conn, err := dialHerdr(c.socketPath)
 	if err != nil {
 		return fmt.Errorf("connect herdr IPC endpoint: %w", err)
 	}
 	defer conn.Close()
+	stop := context.AfterFunc(ctx, func() { conn.Close() })
+	defer stop()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// json.Encoder.Encode appends a trailing newline, which is exactly the
 	// framing herdr expects for each request.
@@ -79,6 +125,9 @@ func (c *herdrClient) call(method string, params map[string]any, out any) error 
 	}
 	if resp.Error != nil {
 		return fmt.Errorf("herdr error %s: %s", resp.Error.Code, resp.Error.Message)
+	}
+	if c.timeout > 0 && resp.ID != "herdr-plus" {
+		return errors.New("malformed herdr response: request ID mismatch")
 	}
 	if out != nil {
 		if err := json.Unmarshal(resp.Result, out); err != nil {

--- a/herdr.go
+++ b/herdr.go
@@ -49,10 +49,29 @@ type request struct {
 	Params map[string]any `json:"params"`
 }
 
-// herdrError carries the code and human message herdr returns on failure.
+// herdrError carries the code and human message herdr returns on failure. It is
+// returned as the error itself (wrapped) so a caller can tell one refusal from
+// another with errors.As — "this directory is not a Git work tree" is a normal
+// answer to some questions, while every other code is a real failure. The text
+// is unchanged from when this was a formatted string.
 type herdrError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+// Error renders the failure the way herdr-plus has always reported it.
+func (e *herdrError) Error() string {
+	return fmt.Sprintf("herdr error %s: %s", e.Code, e.Message)
+}
+
+// herdrErrorCode returns the native error code inside err, or "" when err did
+// not come from herdr.
+func herdrErrorCode(err error) string {
+	var he *herdrError
+	if errors.As(err, &he) {
+		return he.Code
+	}
+	return ""
 }
 
 // response is one JSON line returned by herdr. Exactly one of Result or Error
@@ -125,7 +144,7 @@ func (c *herdrClient) callContext(ctx context.Context, method string, params map
 		return fmt.Errorf("read response: %w", err)
 	}
 	if resp.Error != nil {
-		return fmt.Errorf("herdr error %s: %s", resp.Error.Code, resp.Error.Message)
+		return resp.Error
 	}
 	if c.timeout > 0 && resp.ID != "herdr-plus" {
 		return errors.New("malformed herdr response: request ID mismatch")
@@ -581,6 +600,96 @@ func (c *herdrClient) workspaceCreate(cwd, label string, focus bool) (workspaceI
 		return "", "", "", err
 	}
 	return out.Workspace.WorkspaceID, out.Tab.TabID, out.RootPane.PaneID, nil
+}
+
+// worktreeEntry is one checkout Git has registered for a repository, as herdr
+// reports it. OpenWorkspaceID is the workspace herdr considers that checkout
+// open in, if any — herdr's own binding, including workspaces it has no stored
+// checkout provenance for, which is exactly the case herdr-plus cannot see
+// through workspace.list.
+type worktreeEntry struct {
+	Path             string  `json:"path"`
+	Branch           *string `json:"branch"`
+	IsBare           bool    `json:"is_bare"`
+	IsDetached       bool    `json:"is_detached"`
+	IsPrunable       bool    `json:"is_prunable"`
+	IsLinkedWorktree bool    `json:"is_linked_worktree"`
+	OpenWorkspaceID  *string `json:"open_workspace_id"`
+	Label            string  `json:"label"`
+}
+
+// worktreeList asks herdr which checkouts of cwd's repository exist and which
+// are already open. It is read-only: it registers nothing and opens nothing.
+//
+// cwd may be any checkout of the repository, linked or primary. A directory
+// that is not inside a Git work tree comes back as the native "not_git_worktree"
+// refusal, which callers treat as "this project is not a Git checkout" rather
+// than as a failure.
+//
+// As with workspaceList, a missing or null array is an error, not an empty
+// inventory: the caller uses emptiness to decide that nothing is open.
+func (c *herdrClient) worktreeList(cwd string) ([]worktreeEntry, error) {
+	var out struct {
+		Worktrees *[]worktreeEntry `json:"worktrees"`
+	}
+	if err := c.call("worktree.list", map[string]any{"cwd": cwd}, &out); err != nil {
+		return nil, err
+	}
+	if out.Worktrees == nil {
+		return nil, errors.New("malformed worktree.list result: no worktrees array")
+	}
+	for i, entry := range *out.Worktrees {
+		if !filepath.IsAbs(strings.TrimSpace(entry.Path)) {
+			return nil, fmt.Errorf("malformed worktree.list result: worktree %d reports path %q, which is not an absolute path", i+1, entry.Path)
+		}
+	}
+	return *out.Worktrees, nil
+}
+
+// worktreeOpenResult is the part of worktree.open herdr-plus checks.
+type worktreeOpenResult struct {
+	WorkspaceID string
+	Path        string
+	AlreadyOpen bool
+}
+
+// worktreeOpenPath asks herdr to open an already-registered checkout by its
+// path. herdr binds the checkout to the workspace it is already open in when
+// there is one — reporting already_open — and creates a workspace only when
+// there is not. Panes in an already-open workspace are left untouched.
+//
+// It is addressed by path, never by branch: a path names exactly one registered
+// checkout, works for a detached HEAD, and cannot be ambiguous the way a branch
+// with several checkouts can. sourceCwd must be the repository's primary
+// checkout — herdr refuses a linked worktree as the source of a worktree action.
+//
+// This does not create checkouts or branches. The one caller uses it to attach
+// native checkout provenance to a workspace it just created.
+func (c *herdrClient) worktreeOpenPath(sourceCwd, path string, focus bool) (worktreeOpenResult, error) {
+	var out struct {
+		Workspace struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"workspace"`
+		Worktree struct {
+			Path string `json:"path"`
+		} `json:"worktree"`
+		AlreadyOpen *bool `json:"already_open"`
+	}
+	if err := c.call("worktree.open", map[string]any{
+		"cwd":   sourceCwd,
+		"path":  path,
+		"focus": focus,
+	}, &out); err != nil {
+		return worktreeOpenResult{}, err
+	}
+	if out.AlreadyOpen == nil {
+		return worktreeOpenResult{}, errors.New("malformed worktree.open result: no already_open flag")
+	}
+	return worktreeOpenResult{
+		WorkspaceID: out.Workspace.WorkspaceID,
+		Path:        out.Worktree.Path,
+		AlreadyOpen: *out.AlreadyOpen,
+	}, nil
 }
 
 // tabCreateParams builds the tab.create payload. An empty cwd is omitted so the

--- a/herdr.go
+++ b/herdr.go
@@ -658,12 +658,13 @@ type worktreeOpenResult struct {
 //
 // It is addressed by path, never by branch: a path names exactly one registered
 // checkout, works for a detached HEAD, and cannot be ambiguous the way a branch
-// with several checkouts can. sourceCwd must be the repository's primary
-// checkout — herdr refuses a linked worktree as the source of a worktree action.
+// with several checkouts can. sourceWorkspace must hold the primary checkout.
+// An explicit workspace prevents Herdr from silently creating an empty parent;
+// if that workspace was closed, the native call fails instead.
 //
 // This does not create checkouts or branches. The one caller uses it to attach
 // native checkout provenance to a workspace it just created.
-func (c *herdrClient) worktreeOpenPath(sourceCwd, path string, focus bool) (worktreeOpenResult, error) {
+func (c *herdrClient) worktreeOpenPath(sourceWorkspace, path string, focus bool) (worktreeOpenResult, error) {
 	var out struct {
 		Workspace struct {
 			WorkspaceID string `json:"workspace_id"`
@@ -674,9 +675,9 @@ func (c *herdrClient) worktreeOpenPath(sourceCwd, path string, focus bool) (work
 		AlreadyOpen *bool `json:"already_open"`
 	}
 	if err := c.call("worktree.open", map[string]any{
-		"cwd":   sourceCwd,
-		"path":  path,
-		"focus": focus,
+		"workspace_id": sourceWorkspace,
+		"path":         path,
+		"focus":        focus,
 	}, &out); err != nil {
 		return worktreeOpenResult{}, err
 	}

--- a/herdr.go
+++ b/herdr.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -394,8 +395,10 @@ func (c *herdrClient) focusedPaneID() (string, error) {
 // workspace. The worktree handler uses it as an idempotency guard: a freshly
 // created or opened worktree workspace has exactly one (root) pane, so a count
 // above one means the layout was already applied — and we should not apply it
-// again. On any socket error it returns 0 so the caller fails open (proceeds) and
-// degrades to the old, unguarded behavior rather than skipping wrongly.
+// again. A socket failure returns the error (with a zero count), and the handler
+// refuses to lay out on either an error or a zero count: neither can establish
+// that the workspace is fresh, and laying tabs into work that is already there
+// would be worse than doing nothing visibly.
 func (c *herdrClient) workspacePaneCount(workspaceID string) (int, error) {
 	var out struct {
 		Panes []struct {
@@ -426,8 +429,10 @@ func (c *herdrClient) paneGet(paneID string) (paneInfo, error) {
 
 // tabInfo is the subset of herdr's tab metadata herdr-plus uses.
 type tabInfo struct {
-	TabID string `json:"tab_id"`
-	Label string `json:"label"`
+	TabID       string `json:"tab_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Label       string `json:"label"`
+	Focused     bool   `json:"focused"`
 }
 
 // tabGet fetches metadata for a single tab, notably its human label.
@@ -439,10 +444,60 @@ func (c *herdrClient) tabGet(tabID string) (tabInfo, error) {
 	return out.Tab, err
 }
 
+// tabList returns the tabs of one workspace, in herdr's own order. It is how the
+// Projects action finds the task tab to return to: labels are read from live
+// native metadata rather than remembered, so a tab the user renamed or closed is
+// seen as it is now.
+// A missing or null tabs array is an error for the same reason workspaceList
+// rejects one: the caller reads an empty list as "that tab is not there", which
+// reports a renamed or closed tab to the user. A present, empty array is a
+// legitimate answer.
+func (c *herdrClient) tabList(workspaceID string) ([]tabInfo, error) {
+	var out struct {
+		Tabs *[]tabInfo `json:"tabs"`
+	}
+	if err := c.call("tab.list", map[string]any{"workspace_id": workspaceID}, &out); err != nil {
+		return nil, err
+	}
+	if out.Tabs == nil {
+		return nil, errors.New("malformed tab.list result: no tabs array")
+	}
+	for i, t := range *out.Tabs {
+		if strings.TrimSpace(t.TabID) == "" {
+			return nil, fmt.Errorf("malformed tab.list result: tab %d has no tab_id", i+1)
+		}
+	}
+	return *out.Tabs, nil
+}
+
+// tabFocus brings an existing tab to the front. It changes focus only: no pane
+// is created, resized, relaid or written to, so returning to a tab leaves
+// whatever is running in it exactly as it was.
+func (c *herdrClient) tabFocus(tabID string) error {
+	return c.call("tab.focus", map[string]any{"tab_id": tabID}, nil)
+}
+
+// worktreeProvenance is the checkout herdr records for a workspace: which
+// repository it belongs to and, crucially, which checkout of it. CheckoutPath is
+// the only identity herdr-plus matches on — RepoKey is shared by every worktree
+// of a repository, so two sibling worktrees would collide under it, and a Label
+// is a display string the user can change.
+type worktreeProvenance struct {
+	RepoKey          string `json:"repo_key"`
+	RepoName         string `json:"repo_name"`
+	RepoRoot         string `json:"repo_root"`
+	CheckoutPath     string `json:"checkout_path"`
+	IsLinkedWorktree bool   `json:"is_linked_worktree"`
+}
+
 // workspaceInfo is the subset of herdr's workspace metadata herdr-plus uses.
+// Worktree is nil for a workspace herdr has no checkout provenance for (a plain
+// folder), which is never treated as a match for anything.
 type workspaceInfo struct {
-	WorkspaceID string `json:"workspace_id"`
-	Label       string `json:"label"`
+	WorkspaceID string              `json:"workspace_id"`
+	Label       string              `json:"label"`
+	Focused     bool                `json:"focused"`
+	Worktree    *worktreeProvenance `json:"worktree"`
 }
 
 // workspaceGet fetches metadata for a single workspace, notably its label —
@@ -453,6 +508,52 @@ func (c *herdrClient) workspaceGet(workspaceID string) (workspaceInfo, error) {
 	}
 	err := c.call("workspace.get", map[string]any{"workspace_id": workspaceID}, &out)
 	return out.Workspace, err
+}
+
+// workspaceList returns every open workspace with the checkout provenance herdr
+// holds for it. It is the inventory the "is this project already open?" question
+// is answered from — herdr's own record of what each workspace checks out, not a
+// registry herdr-plus keeps for itself.
+//
+// A successful but malformed reply is an error, never an empty inventory. The
+// difference matters: the caller reads "no workspaces" as "nothing is open yet"
+// and creates one, so a missing or null array — which plain decoding would hand
+// back as an empty slice — would quietly produce the duplicate workspace the
+// whole feature exists to prevent. An array that is present and genuinely empty
+// is fine, and means what it says.
+func (c *herdrClient) workspaceList() ([]workspaceInfo, error) {
+	var out struct {
+		// A pointer distinguishes "herdr sent an empty list" from "herdr sent no
+		// list at all"; both decode to a nil slice otherwise.
+		Workspaces *[]workspaceInfo `json:"workspaces"`
+	}
+	if err := c.call("workspace.list", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	if out.Workspaces == nil {
+		return nil, errors.New("malformed workspace.list result: no workspaces array")
+	}
+	for i, ws := range *out.Workspaces {
+		if strings.TrimSpace(ws.WorkspaceID) == "" {
+			return nil, fmt.Errorf("malformed workspace.list result: workspace %d has no workspace_id", i+1)
+		}
+		// Provenance is optional (a plain folder has none), but a provenance block
+		// that is present has to be usable as identity — an absolute checkout path.
+		// Anything else cannot be compared, and must not be silently skipped over.
+		if ws.Worktree == nil {
+			continue
+		}
+		if path := strings.TrimSpace(ws.Worktree.CheckoutPath); path == "" || !filepath.IsAbs(path) {
+			return nil, fmt.Errorf("malformed workspace.list result: workspace %s reports checkout path %q, which is not an absolute path", ws.WorkspaceID, ws.Worktree.CheckoutPath)
+		}
+	}
+	return *out.Workspaces, nil
+}
+
+// workspaceFocus switches to an existing workspace. Like tabFocus it only moves
+// focus: the workspace's tabs, panes and running processes are untouched.
+func (c *herdrClient) workspaceFocus(workspaceID string) error {
+	return c.call("workspace.focus", map[string]any{"workspace_id": workspaceID}, nil)
 }
 
 // workspaceCreate makes a brand-new workspace rooted at cwd with the given

--- a/herdr.go
+++ b/herdr.go
@@ -410,30 +410,28 @@ func (c *herdrClient) focusedPaneID() (string, error) {
 	return "", errors.New("no focused pane")
 }
 
-// workspacePaneCount returns how many panes currently live in the given
-// workspace. The worktree handler uses it as an idempotency guard: a freshly
-// created or opened worktree workspace has exactly one (root) pane, so a count
-// above one means the layout was already applied — and we should not apply it
-// again. A socket failure returns the error (with a zero count), and the handler
-// refuses to lay out on either an error or a zero count: neither can establish
-// that the workspace is fresh, and laying tabs into work that is already there
-// would be worse than doing nothing visibly.
-func (c *herdrClient) workspacePaneCount(workspaceID string) (int, error) {
+// workspacePanes returns a validated inventory for one explicit workspace.
+// Incomplete or duplicate identities cannot authorize applying a fresh layout.
+func (c *herdrClient) workspacePanes(workspaceID string) ([]paneInfo, error) {
 	var out struct {
-		Panes []struct {
-			WorkspaceID string `json:"workspace_id"`
-		} `json:"panes"`
+		Panes *[]paneInfo `json:"panes"`
 	}
-	if err := c.call("pane.list", map[string]any{}, &out); err != nil {
-		return 0, err
+	if err := c.call("pane.list", map[string]any{"workspace_id": workspaceID}, &out); err != nil {
+		return nil, err
 	}
-	n := 0
-	for _, p := range out.Panes {
-		if p.WorkspaceID == workspaceID {
-			n++
+	if out.Panes == nil {
+		return nil, errors.New("malformed pane.list result: no panes array")
+	}
+	seen := make(map[string]bool)
+	for _, pane := range *out.Panes {
+		if pane.WorkspaceID != workspaceID ||
+			!workspaceIDPattern.MatchString(pane.PaneID) ||
+			!workspaceIDPattern.MatchString(pane.TabID) || seen[pane.PaneID] {
+			return nil, errors.New("malformed pane.list result: incomplete, unrelated or duplicate pane identity")
 		}
+		seen[pane.PaneID] = true
 	}
-	return n, nil
+	return *out.Panes, nil
 }
 
 // paneGet fetches metadata for a single pane, including its working directory

--- a/install.sh
+++ b/install.sh
@@ -22,9 +22,8 @@
 #   curl -fsSL .../install.sh | VERSION=v0.0.1 sh
 #
 # Designed to run under POSIX `sh` so it works on Alpine / BusyBox / minimal
-# SSH targets in addition to bash on a normal Linux box. herdr plugin install
-# also reuses it (via scripts/build.sh) to fetch a prebuilt binary when the
-# machine has no Go toolchain.
+# SSH targets in addition to bash on a normal Linux box. Plugin installation
+# builds the checked-out source through scripts/build.sh and requires Go.
 
 set -eu
 

--- a/main.go
+++ b/main.go
@@ -49,6 +49,9 @@ func main() {
 		case "open":
 			runOpen(os.Args[2:])
 			return
+		case "ensure-worktree":
+			runEnsureWorktree(os.Args[2:])
+			return
 		case "ping":
 			runPing()
 			return

--- a/main.go
+++ b/main.go
@@ -53,6 +53,21 @@ func main() {
 		case "ensure-worktree":
 			runEnsureWorktree(os.Args[2:])
 			return
+		case "plan-worktree", "apply-worktree":
+			runWorktreePolicy(os.Args[1], os.Args[2:])
+			return
+		case "worktree":
+			launchPolicyWorktree()
+			return
+		case "worktree-ui":
+			ctx, err := decodeRunContext(os.Getenv("HERDR_PLUS_CTX"))
+			if err != nil {
+				errExit(err)
+			}
+			if err := runPolicyPicker(worktreeRequest{Cwd: ctx.WorkDir}); err != nil {
+				errExit(err)
+			}
+			return
 		case "ping":
 			runPing()
 			return

--- a/main.go
+++ b/main.go
@@ -18,7 +18,8 @@ import (
 // manifest entry point.
 //
 //   - "projects" / "quick-actions" are the actions herdr runs from a keybinding:
-//     each asks herdr to open its UI as a plugin pane.
+//     each asks herdr to open its UI as a plugin pane. "projects --pick" always
+//     opens the picker, even where bare "projects" would return to a task tab.
 //   - "projects-ui" / "quick-actions-ui" are those UIs; herdr runs them inside the
 //     pane it opens (the `picker` / `quick-actions-picker` entrypoints), so end
 //     users never run them directly.
@@ -35,7 +36,7 @@ func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "projects":
-			launchProjects()
+			launchProjects(os.Args[2:])
 			return
 		case "projects-ui":
 			runProjectsUI()

--- a/open.go
+++ b/open.go
@@ -38,6 +38,11 @@ func runOpen(args []string) {
 		errExit(err)
 	}
 
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		errExit(err)
+	}
+
 	// Resolve the requested name to a single project (or a helpful error).
 	p, err := findProject(projects, name)
 	if err != nil {
@@ -50,8 +55,11 @@ func runOpen(args []string) {
 		errExit(err)
 	}
 
-	// Build the live workspace via the shared picker code path.
-	if err := openProject(client, p); err != nil {
+	// Build the live workspace via the shared picker code path. Reuse honors the
+	// same [projects].reuse_checkout policy, with no chooser: a headless caller
+	// has nobody to ask, so several matching workspaces is an error rather than a
+	// guess (openProject names them so the caller can pick one deliberately).
+	if err := openProject(client, p, reuseOptions{enabled: cfg.Projects.ReuseCheckout}); err != nil {
 		errExit("could not open project:", err)
 	}
 

--- a/project.go
+++ b/project.go
@@ -40,6 +40,21 @@ type ProjectPane struct {
 	Label      string  `toml:"label"`
 	Ratio      float64 `toml:"ratio"`
 	WorkingDir string  `toml:"working_dir"`
+
+	// SplitFrom names which earlier pane in the same tab this one is split off,
+	// as a 1-based index into the tab's panes. Omitting it (zero) keeps the
+	// original behavior: each pane splits the one created immediately before it.
+	//
+	// It exists because a chain of previous-pane splits cannot express a layout
+	// where one pane stays full height while others stack beside it: to keep an
+	// edge pane whole, the panes in the middle have to be split off each other,
+	// not off the edge. Naming the target directly makes creation order
+	// independent of the arrangement you want.
+	//
+	// The first pane of a tab is its root and splits nothing, so it must leave
+	// this zero; a value that is not an earlier pane is rejected at config load
+	// (see validateTabs), before any workspace exists.
+	SplitFrom int `toml:"split_from"`
 }
 
 // splitRatio translates the pane's authored ratio — the share of the split it
@@ -88,6 +103,7 @@ func (t ProjectTab) effectivePanes() []ProjectPane {
 		if i == 0 {
 			panes[i].Split = ""
 			panes[i].Ratio = 0
+			panes[i].SplitFrom = 0
 			continue
 		}
 		if panes[i].Split == "" {
@@ -227,6 +243,9 @@ func validateTabs(label, source string, tabs []ProjectTab) error {
 			return fmt.Errorf("%q (%s): tab %q has %d panes; at most %d are allowed", label, source, t.Name, len(t.Panes), maxPanesPerTab)
 		}
 		for j, pane := range t.Panes {
+			if _, err := splitTargetIndex(j, pane); err != nil {
+				return fmt.Errorf("%q (%s): tab %q %w", label, source, t.Name, err)
+			}
 			if j == 0 {
 				continue // the first pane is the tab's root; its split is ignored
 			}
@@ -245,6 +264,31 @@ func validateTabs(label, source string, tabs []ProjectTab) error {
 		}
 	}
 	return nil
+}
+
+// splitTargetIndex resolves which pane a pane is split off, returning the 0-based
+// index of that earlier pane. j is the pane's own 0-based index within its tab.
+// The tab's first pane splits nothing and returns -1.
+//
+// It is the single definition of the split_from rule, used both by validateTabs
+// (so a bad target is a config error, caught before anything is created) and by
+// layoutTabs (so the executor resolves targets the same way it validated them).
+func splitTargetIndex(j int, p ProjectPane) (int, error) {
+	if j == 0 {
+		if p.SplitFrom != 0 {
+			return -1, fmt.Errorf("pane 1 is the tab's root and splits nothing; remove its split_from = %d", p.SplitFrom)
+		}
+		return -1, nil
+	}
+	if p.SplitFrom == 0 {
+		// Nothing declared: split the pane created immediately before this one,
+		// exactly as every layout did before split_from existed.
+		return j - 1, nil
+	}
+	if p.SplitFrom < 0 || p.SplitFrom > j {
+		return -1, fmt.Errorf("pane %d has split_from = %d; it must name an earlier pane in the same tab (1 to %d)", j+1, p.SplitFrom, j)
+	}
+	return p.SplitFrom - 1, nil
 }
 
 // promptDirSentinel is the working_dir value that makes a project ask for its

--- a/project_test.go
+++ b/project_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -440,5 +441,119 @@ func TestResolvePaneDirs(t *testing.T) {
 	}
 	if _, err := resolvePaneDirs(root, []ProjectTab{{Name: "api", WorkingDir: "README"}}); err == nil {
 		t.Fatal("expected a file working_dir to be rejected")
+	}
+}
+
+// TestValidateSplitFrom covers the declarative split target: a pane may name an
+// earlier pane in its own tab to split off, and anything that is not an earlier
+// pane is rejected at config load — before any workspace, tab or pane exists.
+func TestValidateSplitFrom(t *testing.T) {
+	tab := func(splitFroms ...int) []ProjectTab {
+		panes := make([]ProjectPane, len(splitFroms))
+		for i, sf := range splitFroms {
+			panes[i] = ProjectPane{Split: SplitRight, SplitFrom: sf}
+		}
+		return []ProjectTab{{Name: "work", Panes: panes}}
+	}
+
+	cases := []struct {
+		name    string
+		tabs    []ProjectTab
+		wantErr string
+	}{
+		{name: "omitted keeps the previous-pane default", tabs: tab(0, 0, 0, 0)},
+		{name: "the full-height edge shape", tabs: tab(0, 1, 1, 3)},
+		{name: "an earlier pane is fine", tabs: tab(0, 1, 2, 2)},
+		{name: "first pane cannot split from anything", tabs: tab(1, 0), wantErr: "pane 1"},
+		{name: "negative is rejected", tabs: tab(0, -1), wantErr: "split_from"},
+		{name: "splitting from itself is rejected", tabs: tab(0, 2), wantErr: "split_from"},
+		{name: "a forward reference is rejected", tabs: tab(0, 3, 0), wantErr: "split_from"},
+		{name: "a pane that does not exist is rejected", tabs: tab(0, 9), wantErr: "split_from"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateTabs("proj", "proj.toml", c.tabs)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateTabs: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("want a validation error, got none")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadProjectsParsesSplitFrom confirms split_from survives the TOML round
+// trip and that a project declaring an impossible one fails to load at all,
+// naming the file — the same loud failure every other config mistake gets.
+func TestLoadProjectsParsesSplitFrom(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", dir)
+	projects := filepath.Join(dir, "projects")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	good := `
+name = "crew"
+working_dir = "~"
+
+[[tabs]]
+name = "Crew"
+
+  [[tabs.panes]]
+  label = "Orchestrator"
+
+  [[tabs.panes]]
+  label = "Issue"
+  split = "right"
+  split_from = 1
+  ratio = 0.25
+
+  [[tabs.panes]]
+  label = "Worker 1"
+  split = "right"
+  split_from = 1
+
+  [[tabs.panes]]
+  label = "Worker 2"
+  split = "down"
+  split_from = 3
+`
+	if err := os.WriteFile(filepath.Join(projects, "crew.toml"), []byte(good), 0o644); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+
+	loaded, err := loadProjects()
+	if err != nil {
+		t.Fatalf("loadProjects: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded %d projects, want 1", len(loaded))
+	}
+	panes := loaded[0].Tabs[0].effectivePanes()
+	if len(panes) != 4 {
+		t.Fatalf("panes = %d, want 4", len(panes))
+	}
+	if panes[0].SplitFrom != 0 {
+		t.Fatalf("root pane SplitFrom = %d, want 0", panes[0].SplitFrom)
+	}
+	if panes[1].SplitFrom != 1 || panes[2].SplitFrom != 1 || panes[3].SplitFrom != 3 {
+		t.Fatalf("split targets = %d/%d/%d, want 1/1/3", panes[1].SplitFrom, panes[2].SplitFrom, panes[3].SplitFrom)
+	}
+
+	bad := "name = \"bad\"\nworking_dir = \"~\"\n\n[[tabs]]\nname = \"t\"\n\n  [[tabs.panes]]\n\n  [[tabs.panes]]\n  split_from = 5\n"
+	if err := os.WriteFile(filepath.Join(projects, "bad.toml"), []byte(bad), 0o644); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+	if _, err := loadProjects(); err == nil || !strings.Contains(err.Error(), "bad.toml") {
+		t.Fatalf("want a load error naming bad.toml, got %v", err)
 	}
 }

--- a/projectreuse.go
+++ b/projectreuse.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -289,12 +290,15 @@ func samePath(a, b string) bool {
 //     (`already_open`), attaches provenance to it, and leaves its panes alone —
 //     it does not create or lay out anything. From then on the workspace is
 //     matchable by the same strict provenance rule as any other.
-//   - legacyOpenCheckout covers workspaces that never got that far: ones from an
-//     older build, or created some other way. herdr's own worktree.list reports
-//     which registered checkout is open in which workspace, so a checkout that
-//     is open but unprovenanced is detected — and refused visibly instead of
-//     duplicated. Adopting it would mean trusting an identity herdr-plus cannot
-//     verify, which is the decision deferred to the user.
+//   - resolveCheckoutForReuse decides whether that is even possible, and covers
+//     workspaces that never got provenance: ones from an older build, or created
+//     some other way. herdr's own worktree.list reports which registered checkout
+//     is open in which workspace, so a checkout that is open but unprovenanced is
+//     detected — and refused visibly instead of duplicated. Adopting it would mean
+//     trusting an identity herdr-plus cannot verify, which is the decision
+//     deferred to the user. Anything it cannot establish — a Git that will not
+//     answer, a listing that contradicts Git — is an error raised before a
+//     workspace exists, never a silent fall-through to creating one.
 
 // gitCheckout is a project directory that Git has registered as a checkout, and
 // the primary checkout of its repository — the only source herdr accepts for a
@@ -306,29 +310,25 @@ type gitCheckout struct {
 	Primary string
 }
 
-// resolveGitCheckout reports how a project's directory sits in Git, reading
-// Git's own registry (`git worktree list --porcelain`, through the same strict
-// parser ensure-worktree uses). It returns nil with no error when provenance
-// simply does not apply — the directory is not in a Git work tree, is a
-// subdirectory of a checkout rather than a checkout root, or Git cannot be run
-// at all — because those projects keep working exactly as they always have.
+// resolveGitCheckout reports how a project's directory sits in Git's own
+// registry (`git worktree list --porcelain`, through the same strict parser
+// ensure-worktree uses), for a directory herdr has already confirmed is inside a
+// Git work tree.
 //
-// It returns an error only when Git answers with something that cannot be
-// trusted: a malformed listing, or a repository whose main worktree is bare and
-// therefore has no checkout to act from. Guessing a primary path from a
-// directory name is exactly the kind of improvisation this must not do.
-func resolveGitCheckout(dir string) (*gitCheckout, error) {
-	canonical, err := canonicalPath(dir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve the project directory %s: %w", dir, err)
-	}
+// It returns nil with no error for the one benign case: the directory is inside
+// a work tree but is not itself a checkout root — a monorepo subdirectory, say —
+// so there is no checkout for herdr to record.
+//
+// Every other problem is an error, and the caller surfaces it before creating
+// anything. A Git that cannot be run, times out, or answers with a listing that
+// cannot be parsed leaves this plugin unable to tell whether the project is
+// already open; creating a workspace anyway is precisely the duplicate this is
+// meant to prevent. Guessing a primary path from a directory name is likewise
+// out: it is the kind of improvisation that puts panes in the wrong place.
+func resolveGitCheckout(canonical string) (*gitCheckout, error) {
 	listing, err := ensureGit(canonical, 10*time.Second, "worktree", "list", "--porcelain", "-z")
 	if err != nil {
-		// Git ran and refused (not a repository), or could not run at all. Either
-		// way there is no Git identity to establish here; the project opens as it
-		// always did. A checkout that is nevertheless already open is still caught
-		// by legacyOpenCheckout, which asks herdr rather than Git.
-		return nil, nil
+		return nil, fmt.Errorf("read the Git worktree registry for %s: %w\n  herdr reports this directory is inside a Git work tree, so this has to be readable before a second workspace could safely be created", canonical, err)
 	}
 	records, err := parseGitWorktreeList(canonical, listing)
 	if err != nil {
@@ -354,37 +354,82 @@ func resolveGitCheckout(dir string) (*gitCheckout, error) {
 			return &gitCheckout{Path: canonical, Primary: primaryPath}, nil
 		}
 	}
-	// Inside a work tree but not a checkout root — a monorepo subdirectory, say.
-	// herdr's provenance is per checkout, so there is nothing to bind.
+	// Inside a work tree but not a checkout root. herdr's provenance is per
+	// checkout, so there is nothing to bind and nothing to look up.
 	return nil, nil
 }
 
-// legacyOpenCheckout reports the workspace herdr already has this checkout open
-// in but holds no provenance for, or "" when there is none. It is asked only
-// after provenance matching found nothing, and its answer is herdr's own
-// (worktree.list's open_workspace_id) — never another client's focus and never a
-// directory comparison of our own.
+// workspaceIDPattern is the shape a herdr workspace id has ("w3A", "w1D:2").
+// An id from herdr is only ever shown back to the user inside a message, so it
+// is checked before it is displayed rather than pasted through unexamined.
+var workspaceIDPattern = regexp.MustCompile(`^[A-Za-z0-9_.:-]{1,64}$`)
+
+// resolveCheckoutForReuse decides what to do about a project directory after
+// provenance matching found no match. It returns the checkout to bind once the
+// workspace has been created, or nil when there is nothing to bind — and an
+// error whenever the answer cannot be established, so that every uncertainty is
+// resolved BEFORE a workspace is created rather than after.
 //
-// A directory herdr says is not in a Git work tree is not an error: that is a
-// non-Git project, which keeps its existing behavior.
-func legacyOpenCheckout(client *herdrClient, checkout gitCheckout) (string, error) {
-	entries, err := client.worktreeList(checkout.Path)
+// herdr, not this plugin, decides whether the directory is a Git checkout at
+// all: a native "not_git_worktree" refusal is the one positive identification of
+// a non-Git project. A local Git failure is never read that way, because "git
+// could not answer" and "this is not a repository" are completely different
+// facts with opposite consequences.
+//
+// When the directory is a registered checkout root, herdr's listing must contain
+// exactly one entry for it. A valid but empty listing, a listing missing this
+// checkout, or one naming it twice are all inconsistent or ambiguous answers —
+// never absence — and none of them may lead to a second workspace.
+func resolveCheckoutForReuse(client *herdrClient, dir string) (*gitCheckout, error) {
+	canonical, err := canonicalPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve the project directory %s: %w", dir, err)
+	}
+
+	entries, err := client.worktreeList(canonical)
 	if err != nil {
 		if herdrErrorCode(err) == "not_git_worktree" {
-			return "", nil
+			// The one benign refusal: herdr says this is not a Git work tree, so
+			// there is no checkout identity to establish and the project opens
+			// exactly as it always has.
+			return nil, nil
 		}
-		return "", fmt.Errorf("ask herdr which checkouts are open: %w", err)
+		return nil, fmt.Errorf("ask herdr which checkouts are open: %w", err)
 	}
+
+	checkout, err := resolveGitCheckout(canonical)
+	if err != nil {
+		return nil, err
+	}
+	if checkout == nil {
+		return nil, nil
+	}
+
+	var matches []worktreeEntry
 	for _, entry := range entries {
-		if !samePath(entry.Path, checkout.Path) {
-			continue
+		if samePath(entry.Path, checkout.Path) {
+			matches = append(matches, entry)
 		}
-		if entry.OpenWorkspaceID != nil && strings.TrimSpace(*entry.OpenWorkspaceID) != "" {
-			return strings.TrimSpace(*entry.OpenWorkspaceID), nil
-		}
-		return "", nil
 	}
-	return "", nil
+	switch len(matches) {
+	case 1:
+		// The consistent case, handled below.
+	case 0:
+		return nil, fmt.Errorf("git has %s registered as a checkout, but herdr's listing of this repository does not include it (%d other checkouts listed); nothing was created, because herdr and Git disagree about what this directory is", checkout.Path, len(entries))
+	default:
+		return nil, fmt.Errorf("herdr's listing names the checkout %s %d times; nothing was created, because there is no unambiguous entry to act on", checkout.Path, len(matches))
+	}
+
+	raw := matches[0].OpenWorkspaceID
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		// Registered, consistent, and not open anywhere: create it, then bind it.
+		return checkout, nil
+	}
+	open := strings.TrimSpace(*raw)
+	if !workspaceIDPattern.MatchString(open) {
+		return nil, fmt.Errorf("herdr reports %s is already open, but gave its workspace id in an unusable form (%q); nothing was created or changed", checkout.Path, *raw)
+	}
+	return nil, fmt.Errorf("workspace %s already has %s checked out, but herdr holds no checkout provenance for it — so it cannot be identified as this project. Nothing was created or changed. Close that workspace and open the project again, or open the checkout through herdr's own worktree open so it carries provenance", open, checkout.Path)
 }
 
 // bindCheckoutProvenance attaches herdr's native checkout provenance to a

--- a/projectreuse.go
+++ b/projectreuse.go
@@ -421,7 +421,7 @@ func resolveCheckoutForReuse(client *herdrClient, dir string) (*gitCheckout, err
 	}
 
 	raw := matches[0].OpenWorkspaceID
-	if raw == nil || strings.TrimSpace(*raw) == "" {
+	if raw == nil {
 		// Registered, consistent, and not open anywhere: create it, then bind it.
 		return checkout, nil
 	}

--- a/projectreuse.go
+++ b/projectreuse.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -267,6 +268,155 @@ func samePath(a, b string) bool {
 	ca, errA := canonicalPath(a)
 	cb, errB := canonicalPath(b)
 	return errA == nil && errB == nil && ca == cb
+}
+
+// Native checkout provenance and the workspaces herdr-plus creates itself
+// ---------------------------------------------------------------------------
+//
+// herdr records checkout provenance (workspace.worktree) for a workspace it
+// opened as a worktree, but NOT for one made with workspace.create — which is
+// how openProject builds a project's workspace. Verified against Herdr 0.9.0:
+// `handle_worktree_open` is what calls `mark_worktree_membership`; nothing on
+// the workspace.create path does. So a project workspace this plugin created is
+// invisible to the provenance matching above, and the second P would build a
+// duplicate of work that is already on screen.
+//
+// The two functions below close that gap without loosening the identity rule —
+// no shell-directory matching, no title matching, no local registry:
+//
+//   - bindCheckoutProvenance asks herdr to open the checkout it just created a
+//     workspace for. herdr finds that workspace already open on that checkout
+//     (`already_open`), attaches provenance to it, and leaves its panes alone —
+//     it does not create or lay out anything. From then on the workspace is
+//     matchable by the same strict provenance rule as any other.
+//   - legacyOpenCheckout covers workspaces that never got that far: ones from an
+//     older build, or created some other way. herdr's own worktree.list reports
+//     which registered checkout is open in which workspace, so a checkout that
+//     is open but unprovenanced is detected — and refused visibly instead of
+//     duplicated. Adopting it would mean trusting an identity herdr-plus cannot
+//     verify, which is the decision deferred to the user.
+
+// gitCheckout is a project directory that Git has registered as a checkout, and
+// the primary checkout of its repository — the only source herdr accepts for a
+// worktree action.
+type gitCheckout struct {
+	// Path is the canonical registered checkout path, as Git spells it.
+	Path string
+	// Primary is the canonical path of the repository's main worktree.
+	Primary string
+}
+
+// resolveGitCheckout reports how a project's directory sits in Git, reading
+// Git's own registry (`git worktree list --porcelain`, through the same strict
+// parser ensure-worktree uses). It returns nil with no error when provenance
+// simply does not apply — the directory is not in a Git work tree, is a
+// subdirectory of a checkout rather than a checkout root, or Git cannot be run
+// at all — because those projects keep working exactly as they always have.
+//
+// It returns an error only when Git answers with something that cannot be
+// trusted: a malformed listing, or a repository whose main worktree is bare and
+// therefore has no checkout to act from. Guessing a primary path from a
+// directory name is exactly the kind of improvisation this must not do.
+func resolveGitCheckout(dir string) (*gitCheckout, error) {
+	canonical, err := canonicalPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve the project directory %s: %w", dir, err)
+	}
+	listing, err := ensureGit(canonical, 10*time.Second, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		// Git ran and refused (not a repository), or could not run at all. Either
+		// way there is no Git identity to establish here; the project opens as it
+		// always did. A checkout that is nevertheless already open is still caught
+		// by legacyOpenCheckout, which asks herdr rather than Git.
+		return nil, nil
+	}
+	records, err := parseGitWorktreeList(canonical, listing)
+	if err != nil {
+		return nil, fmt.Errorf("read the Git worktree registry for %s: %w", canonical, err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("git registered no worktrees for %s", canonical)
+	}
+	// Git lists the main worktree first, then each linked worktree.
+	primary := records[0]
+	if primary.Bare {
+		return nil, fmt.Errorf("repository for %s has a bare main worktree, so herdr has no primary checkout to open it from", canonical)
+	}
+	primaryPath, err := canonicalPath(primary.Path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve the primary checkout %s: %w", primary.Path, err)
+	}
+	for _, record := range records {
+		if record.Bare {
+			continue
+		}
+		if samePath(record.Path, canonical) {
+			return &gitCheckout{Path: canonical, Primary: primaryPath}, nil
+		}
+	}
+	// Inside a work tree but not a checkout root — a monorepo subdirectory, say.
+	// herdr's provenance is per checkout, so there is nothing to bind.
+	return nil, nil
+}
+
+// legacyOpenCheckout reports the workspace herdr already has this checkout open
+// in but holds no provenance for, or "" when there is none. It is asked only
+// after provenance matching found nothing, and its answer is herdr's own
+// (worktree.list's open_workspace_id) — never another client's focus and never a
+// directory comparison of our own.
+//
+// A directory herdr says is not in a Git work tree is not an error: that is a
+// non-Git project, which keeps its existing behavior.
+func legacyOpenCheckout(client *herdrClient, checkout gitCheckout) (string, error) {
+	entries, err := client.worktreeList(checkout.Path)
+	if err != nil {
+		if herdrErrorCode(err) == "not_git_worktree" {
+			return "", nil
+		}
+		return "", fmt.Errorf("ask herdr which checkouts are open: %w", err)
+	}
+	for _, entry := range entries {
+		if !samePath(entry.Path, checkout.Path) {
+			continue
+		}
+		if entry.OpenWorkspaceID != nil && strings.TrimSpace(*entry.OpenWorkspaceID) != "" {
+			return strings.TrimSpace(*entry.OpenWorkspaceID), nil
+		}
+		return "", nil
+	}
+	return "", nil
+}
+
+// bindCheckoutProvenance attaches herdr's native checkout provenance to a
+// workspace herdr-plus just created, so opening the same project again finds it
+// instead of building a second one.
+//
+// It asks herdr to open the checkout the workspace was created for. herdr sees
+// that checkout is already open, binds it to that very workspace, and reports
+// already_open — no workspace, tab or pane is created, and the layout that was
+// just built is left exactly as it is. The worktree.opened event this emits
+// carries already_open, which the worktree layout handler skips on, so the
+// layout cannot be applied a second time.
+//
+// Every part of the answer is checked: it must be the workspace we created, on
+// the checkout we asked for, and already open. Anything else means herdr acted
+// on something other than what was intended, which is reported rather than
+// retried — one attempt, no competing lifecycle management.
+func bindCheckoutProvenance(client *herdrClient, workspaceID string, checkout gitCheckout) error {
+	result, err := client.worktreeOpenPath(checkout.Primary, checkout.Path, false)
+	if err != nil {
+		return fmt.Errorf("bind checkout %s to workspace %s: %w", checkout.Path, workspaceID, err)
+	}
+	if result.WorkspaceID != workspaceID {
+		return fmt.Errorf("herdr bound checkout %s to workspace %s, not the workspace %s just created for it", checkout.Path, result.WorkspaceID, workspaceID)
+	}
+	if !samePath(result.Path, checkout.Path) {
+		return fmt.Errorf("herdr bound workspace %s to checkout %s, not %s", workspaceID, result.Path, checkout.Path)
+	}
+	if !result.AlreadyOpen {
+		return fmt.Errorf("herdr did not recognize workspace %s as already holding checkout %s; provenance was not established", workspaceID, checkout.Path)
+	}
+	return nil
 }
 
 // chooseWorkspaceInteractively is the chooseWorkspaceFunc the projects browser

--- a/projectreuse.go
+++ b/projectreuse.go
@@ -308,6 +308,8 @@ type gitCheckout struct {
 	Path string
 	// Primary is the canonical path of the repository's main worktree.
 	Primary string
+	// For linked checkouts, the already-open, verified primary workspace.
+	PrimaryWorkspace string
 }
 
 // resolveGitCheckout reports how a project's directory sits in Git's own
@@ -422,6 +424,29 @@ func resolveCheckoutForReuse(client *herdrClient, dir string) (*gitCheckout, err
 
 	raw := matches[0].OpenWorkspaceID
 	if raw == nil {
+		if !samePath(checkout.Path, checkout.Primary) {
+			var parents []worktreeEntry
+			for _, entry := range entries {
+				if samePath(entry.Path, checkout.Primary) {
+					parents = append(parents, entry)
+				}
+			}
+			if len(parents) != 1 || parents[0].OpenWorkspaceID == nil {
+				return nil, fmt.Errorf("open the primary-checkout project at %s first, then open %s; nothing was created, because native grouping would otherwise create an empty parent workspace", checkout.Primary, checkout.Path)
+			}
+			id := *parents[0].OpenWorkspaceID
+			if !workspaceIDPattern.MatchString(id) {
+				return nil, fmt.Errorf("herdr returned an invalid primary workspace id; nothing was created")
+			}
+			parent, err := client.workspaceGet(id)
+			if err != nil {
+				return nil, fmt.Errorf("verify primary workspace %s: %w", id, err)
+			}
+			if parent.WorkspaceID != id || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, checkout.Primary) {
+				return nil, fmt.Errorf("primary workspace %s has no matching primary-checkout provenance; open the primary-checkout project at %s first", id, checkout.Primary)
+			}
+			checkout.PrimaryWorkspace = id
+		}
 		// Registered, consistent, and not open anywhere: create it, then bind it.
 		return checkout, nil
 	}
@@ -429,7 +454,7 @@ func resolveCheckoutForReuse(client *herdrClient, dir string) (*gitCheckout, err
 	if !workspaceIDPattern.MatchString(open) {
 		return nil, fmt.Errorf("herdr reports %s is already open, but gave its workspace id in an unusable form (%q); nothing was created or changed", checkout.Path, *raw)
 	}
-	return nil, fmt.Errorf("workspace %s already has %s checked out, but herdr holds no checkout provenance for it — so it cannot be identified as this project. Nothing was created or changed. Close that workspace and open the project again, or open the checkout through herdr's own worktree open so it carries provenance", open, checkout.Path)
+	return nil, fmt.Errorf("herdr reports workspace %s in checkout %s, but holds no checkout provenance for it — so it cannot be identified as this project. Nothing was created or changed. Inspect that workspace; close it when safe, or open the checkout through herdr's own worktree open so it carries provenance", open, checkout.Path)
 }
 
 // bindCheckoutProvenance attaches herdr's native checkout provenance to a
@@ -448,7 +473,21 @@ func resolveCheckoutForReuse(client *herdrClient, dir string) (*gitCheckout, err
 // on something other than what was intended, which is reported rather than
 // retried — one attempt, no competing lifecycle management.
 func bindCheckoutProvenance(client *herdrClient, workspaceID string, checkout gitCheckout) error {
-	result, err := client.worktreeOpenPath(checkout.Primary, checkout.Path, false)
+	source := workspaceID
+	if !samePath(checkout.Path, checkout.Primary) {
+		source = checkout.PrimaryWorkspace
+		if source == "" {
+			return fmt.Errorf("no verified primary workspace for checkout %s", checkout.Path)
+		}
+		parent, err := client.workspaceGet(source)
+		if err != nil {
+			return fmt.Errorf("revalidate primary workspace %s: %w", source, err)
+		}
+		if parent.WorkspaceID != source || parent.Worktree == nil || parent.Worktree.IsLinkedWorktree || !samePath(parent.Worktree.CheckoutPath, checkout.Primary) {
+			return fmt.Errorf("primary workspace %s changed checkout before binding", source)
+		}
+	}
+	result, err := client.worktreeOpenPath(source, checkout.Path, false)
 	if err != nil {
 		return fmt.Errorf("bind checkout %s to workspace %s: %w", checkout.Path, workspaceID, err)
 	}
@@ -530,6 +569,7 @@ func (m workspacePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.list.setViewport(max(1, m.height-6-listPromptLines), m.width)
 		return m, nil
 
 	case tea.KeyMsg:

--- a/projectreuse.go
+++ b/projectreuse.go
@@ -1,0 +1,404 @@
+//
+// Date: 2026-09-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// This file holds the two "go back to what is already open" behaviors the
+// Projects action grew, kept together because they answer the same question with
+// the same evidence: which native workspace, if any, is already the thing the
+// user is asking for?
+//
+//   - returnToCrew answers it for the action's own invocation context — the pane
+//     the keybinding fired from — so pressing the Projects key inside a task
+//     workspace returns to that task's tab instead of offering a picker.
+//   - reuseOpenCheckout answers it for a project the user picked, so choosing an
+//     already-open project focuses its workspace instead of building a second one.
+//
+// Three rules govern both, and every function here exists to keep them:
+//
+//  1. Identity comes from herdr's own metadata, read live — the workspace's
+//     recorded checkout path, and the tab labels as they are right now. Never a
+//     display title, never a remembered association, never another client's
+//     focus, and never a repository key (every worktree of a repo shares one).
+//  2. Reuse only ever moves focus. Nothing is created, closed, split, renamed,
+//     relaid, or typed into. Returning to busy work must not disturb it.
+//  3. When identity cannot be established, say so. A failed lookup is never
+//     downgraded to "nothing matched", because that reads as "make a new one".
+
+// returnToCrew focuses the task tab of the workspace the Projects action was
+// invoked from, reporting whether it did. A false return with no error means
+// this simply is not a task workspace — the caller should open the project
+// picker, exactly as it always has.
+//
+// crewTab is the label the machine's config gives its task tab; the caller only
+// gets here when one is configured, so no tab name is baked into the plugin.
+//
+// The injected context is a claim about a moment that has already passed, so
+// every part of it is checked against live native metadata before anything is
+// acted on: the workspace still exists and is the one named, the pane the action
+// fired from still belongs to it, and the checkout has not changed underneath.
+func returnToCrew(client *herdrClient, pc pluginContext, crewTab string) (bool, error) {
+	label := strings.TrimSpace(crewTab)
+	if label == "" || strings.TrimSpace(pc.WorkspaceID) == "" {
+		// No policy, or no explicit context to work from. Fall back to the picker
+		// rather than guessing at a workspace from anyone's focus.
+		return false, nil
+	}
+
+	ws, err := client.workspaceGet(pc.WorkspaceID)
+	if err != nil {
+		return false, fmt.Errorf("look up workspace %s: %w", pc.WorkspaceID, err)
+	}
+	if ws.WorkspaceID != pc.WorkspaceID {
+		return false, fmt.Errorf("cannot establish workspace identity: herdr answered for %q when asked about %q", ws.WorkspaceID, pc.WorkspaceID)
+	}
+
+	// The context names the pane the action fired from. Where herdr supplied one,
+	// confirm it really lives in this workspace — that is the check that makes the
+	// context explicit rather than ambient.
+	if paneID := strings.TrimSpace(pc.FocusedPaneID); paneID != "" {
+		pane, err := client.paneGet(paneID)
+		if err != nil {
+			return false, fmt.Errorf("look up pane %s from the action context: %w", paneID, err)
+		}
+		if pane.PaneID != paneID {
+			return false, fmt.Errorf("cannot establish pane identity: herdr answered for pane %q when asked about %q", pane.PaneID, paneID)
+		}
+		if pane.WorkspaceID != pc.WorkspaceID {
+			return false, fmt.Errorf("action context pane %s now belongs to workspace %q, not %q", paneID, pane.WorkspaceID, pc.WorkspaceID)
+		}
+	}
+
+	if ws.Worktree == nil || !ws.Worktree.IsLinkedWorktree {
+		// A plain folder or the repository's main checkout: not a task workspace,
+		// so the Projects action does what it has always done.
+		return false, nil
+	}
+
+	// A context describing a different checkout than the workspace now holds means
+	// the world moved between the keypress and this lookup. Refuse rather than act
+	// on the stale half.
+	if pc.Worktree != nil && pc.Worktree.CheckoutPath != "" && ws.Worktree.CheckoutPath != "" &&
+		!samePath(pc.Worktree.CheckoutPath, ws.Worktree.CheckoutPath) {
+		return false, fmt.Errorf("workspace %s now holds checkout %s, not the %s the action was invoked from", ws.WorkspaceID, ws.Worktree.CheckoutPath, pc.Worktree.CheckoutPath)
+	}
+
+	tabs, err := client.tabList(ws.WorkspaceID)
+	if err != nil {
+		return false, fmt.Errorf("list tabs of workspace %s: %w", ws.WorkspaceID, err)
+	}
+
+	var matches []tabInfo
+	for _, t := range tabs {
+		if t.WorkspaceID != "" && t.WorkspaceID != ws.WorkspaceID {
+			continue
+		}
+		if strings.TrimSpace(t.Label) == label {
+			matches = append(matches, t)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		if err := client.tabFocus(matches[0].TabID); err != nil {
+			return false, fmt.Errorf("focus tab %s: %w", matches[0].TabID, err)
+		}
+		return true, nil
+	case 0:
+		return false, fmt.Errorf("workspace %s (%s) has no tab labeled %q — it was renamed or closed; rename it back or open the project you want, since Projects will not create a second one", ws.WorkspaceID, ws.Label, label)
+	default:
+		ids := make([]string, len(matches))
+		for i, t := range matches {
+			ids[i] = t.TabID
+		}
+		return false, fmt.Errorf("workspace %s (%s) has %d tabs labeled %q (%s); rename all but one, since Projects will not guess which is the task tab", ws.WorkspaceID, ws.Label, len(matches), label, strings.Join(ids, ", "))
+	}
+}
+
+// workspaceCandidate is one open workspace whose checkout is exactly the
+// directory a project was about to be opened in. Everything shown to the user
+// comes from herdr: the native workspace id — which is unique and unambiguous
+// even when two workspaces carry the same label — the label, and the checkout.
+type workspaceCandidate struct {
+	WorkspaceID  string
+	Label        string
+	CheckoutPath string
+}
+
+// chooseWorkspaceFunc asks the user to pick between candidates. It reports the
+// choice and whether one was made; false means the user cancelled, which is a
+// no-op — not a licence to create a workspace they did not ask for. It is nil in
+// headless callers (`herdr-plus open <name>`), where ambiguity is an error
+// instead: there is no one at the keyboard to ask.
+type chooseWorkspaceFunc func([]workspaceCandidate) (workspaceCandidate, bool, error)
+
+// reuseOptions carries the reuse policy into openProject: whether reuse is
+// enabled at all ([projects].reuse_checkout), and how to resolve an ambiguous
+// match when it is.
+type reuseOptions struct {
+	enabled bool
+	choose  chooseWorkspaceFunc
+}
+
+// reuseOpenCheckout focuses the workspace that already has dir checked out,
+// reporting whether it did. A false return with no error means no open workspace
+// holds this exact checkout and the caller should create one as usual.
+//
+// dir is the project's resolved working directory. Matching is by canonical
+// filesystem path, so a symlinked alias of an open checkout is the same
+// checkout, while a sibling worktree of the same repository — same repo_key,
+// often the same label — is a different one and gets its own workspace.
+func reuseOpenCheckout(client *herdrClient, dir string, choose chooseWorkspaceFunc) (bool, error) {
+	want, err := canonicalPath(dir)
+	if err != nil {
+		// Canonicalization failing is not "nothing matched": we do not know what
+		// this directory is, so we must not conclude a duplicate is safe to make.
+		return false, fmt.Errorf("resolve the project directory %s: %w", dir, err)
+	}
+
+	workspaces, err := client.workspaceList()
+	if err != nil {
+		return false, fmt.Errorf("list workspaces to look for an open checkout: %w", err)
+	}
+
+	var matches []workspaceCandidate
+	for _, ws := range workspaces {
+		// A workspace herdr records no checkout for is never adopted: without
+		// provenance there is nothing to prove it is this project.
+		if ws.Worktree == nil || strings.TrimSpace(ws.Worktree.CheckoutPath) == "" || strings.TrimSpace(ws.WorkspaceID) == "" {
+			continue
+		}
+		if !samePath(ws.Worktree.CheckoutPath, want) {
+			continue
+		}
+		matches = append(matches, workspaceCandidate{
+			WorkspaceID:  ws.WorkspaceID,
+			Label:        ws.Label,
+			CheckoutPath: ws.Worktree.CheckoutPath,
+		})
+	}
+
+	switch len(matches) {
+	case 0:
+		return false, nil
+	case 1:
+		return true, focusExistingWorkspace(client, matches[0], want)
+	}
+
+	if choose == nil {
+		ids := make([]string, len(matches))
+		for i, m := range matches {
+			ids[i] = m.WorkspaceID
+		}
+		return false, fmt.Errorf("%d open workspaces already have %s checked out (%s); focus the one you want, or close the others", len(matches), want, strings.Join(ids, ", "))
+	}
+
+	choice, ok, err := choose(matches)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		// Cancelled. Doing nothing is the whole point — falling through to create a
+		// workspace would be the opposite of what the user just declined.
+		return true, nil
+	}
+	return true, focusExistingWorkspace(client, choice, want)
+}
+
+// focusExistingWorkspace revalidates a candidate against live native metadata
+// and then focuses it. The inventory it came from is a snapshot: between listing
+// and focusing, a workspace can be closed or have its checkout change. Checking
+// again means a stale choice fails visibly instead of focusing the wrong work.
+func focusExistingWorkspace(client *herdrClient, candidate workspaceCandidate, want string) error {
+	ws, err := client.workspaceGet(candidate.WorkspaceID)
+	if err != nil {
+		return fmt.Errorf("revalidate workspace %s before focusing it: %w", candidate.WorkspaceID, err)
+	}
+	if ws.WorkspaceID != candidate.WorkspaceID || ws.Worktree == nil || !samePath(ws.Worktree.CheckoutPath, want) {
+		return fmt.Errorf("workspace %s no longer has %s checked out; nothing was opened or created", candidate.WorkspaceID, want)
+	}
+	if err := client.workspaceFocus(ws.WorkspaceID); err != nil {
+		return fmt.Errorf("focus workspace %s: %w", ws.WorkspaceID, err)
+	}
+	return nil
+}
+
+// canonicalPath resolves a directory to the single spelling two paths can be
+// compared by: absolute, with every symlink along the way resolved. It is an
+// error when the directory cannot be resolved, because a guess here would decide
+// whether a workspace gets reused or duplicated.
+func canonicalPath(dir string) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+// samePath reports whether two paths name the same directory. It compares the
+// cleaned paths first, then their canonical forms, so a symlinked alias matches
+// the checkout it points at. A path that cannot be resolved (herdr knows of a
+// checkout that has since been deleted, say) falls back to the plain comparison
+// rather than matching loosely — this is never a fuzzy or prefix match.
+func samePath(a, b string) bool {
+	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
+		return false
+	}
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	ca, errA := canonicalPath(a)
+	cb, errB := canonicalPath(b)
+	return errA == nil && errB == nil && ca == cb
+}
+
+// chooseWorkspaceInteractively is the chooseWorkspaceFunc the projects browser
+// installs: a small fuzzyList of the matching workspaces, in the same idiom as
+// every other picker here. It runs after the browser's own program has exited,
+// in the same herdr-owned pane.
+func chooseWorkspaceInteractively(candidates []workspaceCandidate, dir string) (workspaceCandidate, bool, error) {
+	p := tea.NewProgram(newWorkspacePickerModel(candidates, dir), tea.WithAltScreen())
+	result, err := p.Run()
+	if err != nil {
+		return workspaceCandidate{}, false, err
+	}
+	m, ok := result.(workspacePickerModel)
+	if !ok || m.chosen == nil {
+		return workspaceCandidate{}, false, nil
+	}
+	return *m.chosen, true, nil
+}
+
+// workspacePickerTitle heads the ambiguity picker.
+const workspacePickerTitle = "Herdr Plus · Already open"
+
+// workspacePickerModel is the explicit choice between several open workspaces on
+// one checkout. There is deliberately no default: the first match is not more
+// likely to be the right one, and picking it silently is exactly the guess this
+// whole path exists to avoid. Esc cancels and nothing happens.
+type workspacePickerModel struct {
+	candidates []workspaceCandidate
+	list       fuzzyList
+	dir        string
+
+	// chosen is the workspace to focus, read back after the program exits; nil
+	// when the user cancelled.
+	chosen *workspaceCandidate
+
+	width  int
+	height int
+}
+
+// newWorkspacePickerModel builds the picker over the matching workspaces. Each
+// row leads with herdr's own workspace id, so two identically labeled
+// workspaces are still told apart by something unambiguous.
+func newWorkspacePickerModel(candidates []workspaceCandidate, dir string) workspacePickerModel {
+	items := make([]listItem, len(candidates))
+	for i, c := range candidates {
+		items[i] = listItem{
+			name:       fmt.Sprintf("%s · %s", c.WorkspaceID, c.Label),
+			desc:       c.CheckoutPath,
+			selectable: true,
+			ref:        i,
+		}
+	}
+	return workspacePickerModel{
+		candidates: candidates,
+		list:       newFuzzyList("Type to filter workspaces…", items),
+		dir:        dir,
+	}
+}
+
+// Init satisfies tea.Model; the picker has no startup command.
+func (m workspacePickerModel) Init() tea.Cmd { return nil }
+
+// Update handles navigation, an explicit enter, and cancellation.
+func (m workspacePickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc":
+			return m, tea.Quit
+		case "up", "ctrl+p":
+			m.list.moveUp()
+			return m, nil
+		case "down", "ctrl+n":
+			m.list.moveDown()
+			return m, nil
+		case "enter":
+			idx := m.list.selectedIndex()
+			if idx < 0 {
+				return m, nil
+			}
+			c := m.candidates[idx]
+			m.chosen = &c
+			return m, tea.Quit
+		}
+		cmd := m.list.editQuery(msg)
+		return m, cmd
+	}
+
+	cmd := m.list.editQuery(msg)
+	return m, cmd
+}
+
+// View renders the title, the directory in question, the list, and the keys.
+func (m workspacePickerModel) View() string {
+	var b strings.Builder
+	b.WriteString(headerBarStyle.Render(workspacePickerTitle))
+	b.WriteString("\n\n")
+	b.WriteString(descStyle.Render(fmt.Sprintf("%d workspaces already have %s checked out. Choose one to return to:", len(m.candidates), m.dir)))
+	b.WriteString("\n\n")
+	b.WriteString(m.list.view("no workspaces match"))
+	b.WriteString("\n")
+	b.WriteString(footerStyle.Render("enter focus · esc cancel (nothing is created either way)"))
+	return lipgloss.NewStyle().Render(b.String())
+}
+
+// projectsPickFlag is the explicit escape hatch: `projects --pick` always opens
+// the project picker, whatever context it was invoked from.
+const projectsPickFlag = "--pick"
+
+// parseProjectsArgs reads the Projects action's arguments, reporting whether the
+// picker was explicitly asked for. Anything else is an error rather than a
+// silently ignored argument — a typo in a keybinding or manifest entry should
+// say so, not quietly do something else.
+func parseProjectsArgs(args []string) (bool, error) {
+	pick := false
+	for _, a := range args {
+		if a == projectsPickFlag && !pick {
+			pick = true
+			continue
+		}
+		return false, fmt.Errorf("usage: herdr-plus projects [%s] (got %q)", projectsPickFlag, strings.Join(args, " "))
+	}
+	return pick, nil
+}
+
+// warnf reports a non-fatal problem on stderr, where herdr captures it in the
+// plugin log.
+func warnf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "herdr-plus: "+format+"\n", args...)
+}

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -1312,6 +1312,20 @@ func newNativeFixture(t *testing.T) *nativeFixture {
 	})
 	nf.worktreeListFromGit()
 	nf.handleFunc("worktree.open", func(req request) (any, *herdrError) {
+		if source, explicit := req.Params["workspace_id"]; explicit {
+			if _, exists := nf.labels[fmt.Sprint(source)]; !exists {
+				return nil, &herdrError{Code: "workspace_not_found", Message: "source was closed"}
+			}
+		} else {
+			primary := fmt.Sprint(req.Params["cwd"])
+			if _, exists := nf.openCheckouts[primary]; !exists {
+				nf.next++
+				id := fmt.Sprintf("w%d", nf.next)
+				nf.openCheckouts[primary] = id
+				nf.provenance[id] = primary
+				nf.labels[id] = "Native empty parent"
+			}
+		}
 		path := fmt.Sprint(req.Params["path"])
 		ws, open := nf.openCheckouts[path]
 		if !open {
@@ -1439,8 +1453,8 @@ func TestOpenProjectBindsThenReusesRealCheckout(t *testing.T) {
 	if bind["path"] != repo {
 		t.Fatalf("worktree.open path = %v, want the project checkout %s", bind["path"], repo)
 	}
-	if bind["cwd"] != repo {
-		t.Fatalf("worktree.open cwd = %v, want the primary checkout %s", bind["cwd"], repo)
+	if bind["workspace_id"] != "w1" || bind["cwd"] != nil {
+		t.Fatalf("binding must use the newly created primary workspace: %v", bind)
 	}
 	if bind["focus"] != false {
 		t.Fatalf("worktree.open focus = %v, want false", bind["focus"])
@@ -1486,6 +1500,9 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 		repo := newGitRepo(t)
 		linked := addWorktree(t, repo, "feature")
 		nf := newNativeFixture(t)
+		nf.openCheckouts[repo] = "wparent"
+		nf.provenance["wparent"] = repo
+		nf.labels["wparent"] = "Primary"
 
 		project := Project{Name: "feature", WorkingDir: linked, Tabs: crewTabs()}
 		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1495,8 +1512,8 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 		if bind["path"] != linked {
 			t.Fatalf("worktree.open path = %v, want the linked checkout %s", bind["path"], linked)
 		}
-		if bind["cwd"] != repo {
-			t.Fatalf("worktree.open cwd = %v, want the primary checkout %s (herdr refuses a linked source)", bind["cwd"], repo)
+		if bind["workspace_id"] != "wparent" || bind["cwd"] != nil {
+			t.Fatalf("binding must use the verified primary workspace: %v", bind)
 		}
 	})
 
@@ -1505,6 +1522,9 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 		linked := addWorktree(t, repo, "detachable")
 		runGit(t, linked, "checkout", "--detach")
 		nf := newNativeFixture(t)
+		nf.openCheckouts[repo] = "wparent"
+		nf.provenance["wparent"] = repo
+		nf.labels["wparent"] = "Primary"
 
 		project := Project{Name: "detached", WorkingDir: linked, Tabs: crewTabs()}
 		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1517,6 +1537,55 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 			t.Fatal("the binding must never name a branch; a detached checkout has none")
 		}
 	})
+}
+
+func TestLinkedFirstCannotShadowPrimaryProject(t *testing.T) {
+	repo := newGitRepo(t)
+	linked := addWorktree(t, repo, "feature")
+	nf := newNativeFixture(t)
+	child := Project{Name: "Feature", WorkingDir: linked, Tabs: crewTabs()}
+	err := openProject(nf.client(), child, reuseOptions{enabled: true})
+	if err == nil || !strings.Contains(err.Error(), "open the primary-checkout project") {
+		t.Fatalf("linked-first should explain the prerequisite, got %v", err)
+	}
+	if len(nf.labels) != 0 {
+		t.Fatalf("linked-first created a workspace: %v", nf.labels)
+	}
+	nf.assertNoMutations()
+	if err := openProject(nf.client(), Project{Name: "Primary", WorkingDir: repo, Tabs: crewTabs()}, reuseOptions{enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := nf.paramsFor("workspace.create")["label"]; got != "Primary" {
+		t.Fatalf("primary template was shadowed: %v", got)
+	}
+	if err := openProject(nf.client(), child, reuseOptions{enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(nf.labels) != 2 {
+		t.Fatalf("expected only the two requested projects: %v", nf.labels)
+	}
+	if got := nf.calls[len(nf.calls)-1]; got.Method != "worktree.open" || got.Params["workspace_id"] != "w1" {
+		t.Fatalf("linked binding omitted explicit primary: %v", got)
+	}
+}
+
+func TestBindingRefusesChangedOrClosedParent(t *testing.T) {
+	for _, state := range []string{"closed", "changed"} {
+		t.Run(state, func(t *testing.T) {
+			repo := newGitRepo(t)
+			linked := addWorktree(t, repo, "feature")
+			nf := newNativeFixture(t)
+			if state == "changed" {
+				nf.labels["wparent"] = "Changed"
+				nf.provenance["wparent"] = linked
+			}
+			err := bindCheckoutProvenance(nf.client(), "wchild", gitCheckout{Path: linked, Primary: repo, PrimaryWorkspace: "wparent"})
+			if err == nil {
+				t.Fatal("closed or changed parent was accepted")
+			}
+			nf.assertNoMutations()
+		})
+	}
 }
 
 // TestOpenProjectRefusesLegacyOpenCheckout is the deferred-decision path: herdr

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -208,7 +208,32 @@ func (f *fakeHerdr) refuseWorktreeList() {
 
 // wsInfo builds one workspace.list / workspace.get entry with checkout
 // provenance, the way herdr reports a workspace opened on a git checkout.
+//
+// repo_root follows the real 0.9.0 shape rather than a placeholder: herdr builds
+// a membership from the source's repo root, so a workspace on a primary checkout
+// reports repo_root == checkout_path, and only a linked one reports a different
+// root. A fixture that always said "/repo" modelled provenance no real herdr
+// sends, and made a contradictory record look like the normal case.
 func wsInfo(id, label, checkout string, linked bool) map[string]any {
+	repoRoot := checkout
+	if linked {
+		repoRoot = "/repo"
+	}
+	return wsInfoWithRoot(id, label, checkout, repoRoot, linked)
+}
+
+// wsInfoWithRoot is wsInfo with the repository root stated explicitly, for the
+// cases that need a record herdr would not send.
+func wsInfoWithRoot(id, label, checkout, repoRoot string, linked bool) map[string]any {
+	worktree := map[string]any{
+		"repo_key":           "repo-key",
+		"repo_name":          "repo",
+		"checkout_path":      checkout,
+		"is_linked_worktree": linked,
+	}
+	if repoRoot != "" {
+		worktree["repo_root"] = repoRoot
+	}
 	return map[string]any{
 		"workspace_id": id,
 		"number":       1,
@@ -216,13 +241,7 @@ func wsInfo(id, label, checkout string, linked bool) map[string]any {
 		"focused":      false,
 		"pane_count":   1,
 		"tab_count":    1,
-		"worktree": map[string]any{
-			"repo_key":           "repo-key",
-			"repo_name":          "repo",
-			"repo_root":          "/repo",
-			"checkout_path":      checkout,
-			"is_linked_worktree": linked,
-		},
+		"worktree":     worktree,
 	}
 }
 

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -209,30 +209,35 @@ func (f *fakeHerdr) refuseWorktreeList() {
 // wsInfo builds one workspace.list / workspace.get entry with checkout
 // provenance, the way herdr reports a workspace opened on a git checkout.
 //
-// repo_root follows the real 0.9.0 shape rather than a placeholder: herdr builds
-// a membership from the source's repo root, so a workspace on a primary checkout
-// reports repo_root == checkout_path, and only a linked one reports a different
-// root. A fixture that always said "/repo" modelled provenance no real herdr
-// sends, and made a contradictory record look like the normal case.
+// repo_root and repo_key follow the real 0.9.0 shapes rather than placeholders.
+// herdr builds a membership from the source's repo root, so a workspace on a
+// primary checkout reports repo_root == checkout_path and only a linked one
+// reports a different root; and git_space_metadata_from_info derives repo_key
+// as the canonical Git common directory, which for an ordinary checkout is its
+// own .git. Fixtures that said "/repo" and "repo-key" modelled provenance no
+// real herdr sends, and made a contradictory record look like the normal case.
 func wsInfo(id, label, checkout string, linked bool) map[string]any {
 	repoRoot := checkout
 	if linked {
 		repoRoot = "/repo"
 	}
-	return wsInfoWithRoot(id, label, checkout, repoRoot, linked)
+	return wsInfoWithProvenance(id, label, checkout, repoRoot, filepath.Join(repoRoot, ".git"), linked)
 }
 
-// wsInfoWithRoot is wsInfo with the repository root stated explicitly, for the
-// cases that need a record herdr would not send.
-func wsInfoWithRoot(id, label, checkout, repoRoot string, linked bool) map[string]any {
+// wsInfoWithProvenance is wsInfo with the repository root and key stated
+// explicitly, for the cases that need a record herdr would not send. An empty
+// repoRoot or repoKey omits that field entirely.
+func wsInfoWithProvenance(id, label, checkout, repoRoot, repoKey string, linked bool) map[string]any {
 	worktree := map[string]any{
-		"repo_key":           "repo-key",
 		"repo_name":          "repo",
 		"checkout_path":      checkout,
 		"is_linked_worktree": linked,
 	}
 	if repoRoot != "" {
 		worktree["repo_root"] = repoRoot
+	}
+	if repoKey != "" {
+		worktree["repo_key"] = repoKey
 	}
 	return map[string]any{
 		"workspace_id": id,

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -1,0 +1,1168 @@
+//
+// Date: 2026-09-09
+// Author: Spicer Matthews (spicer@cloudmanic.com)
+// Copyright: 2026 Cloudmanic Labs, LLC. All rights reserved.
+//
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fakeHerdr is an in-process stand-in for a running herdr: a real unix socket
+// speaking the same newline-delimited JSON protocol herdrClient writes, so these
+// tests exercise the actual client, the actual request payloads, and the actual
+// result decoding rather than a hand-mocked call layer. Every request is
+// recorded, so a test can assert not only what happened but — just as important
+// for reuse — that nothing was created, split, laid out or typed into.
+//
+// It is synthetic: no herdr instance, window, pane or workspace is touched. The
+// live behavior of the real methods is root's native canary, not this suite's.
+type fakeHerdr struct {
+	t        *testing.T
+	ln       net.Listener
+	mu       sync.Mutex
+	calls    []request
+	handlers map[string]func(request) (any, *herdrError)
+	done     chan struct{}
+}
+
+// startFakeHerdr listens on a short temporary socket path (the macOS sun_path
+// limit is unforgiving) and points HERDR_SOCKET_PATH at it, so newHerdrClient
+// connects to this fake exactly as it would to herdr.
+func startFakeHerdr(t *testing.T) *fakeHerdr {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic unix-socket IPC boundary; the Windows named-pipe path is a separate native gate")
+	}
+	dir, err := os.MkdirTemp("", "hp-")
+	if err != nil {
+		t.Fatalf("temp socket dir: %v", err)
+	}
+	socket := filepath.Join(dir, "s")
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	f := &fakeHerdr{t: t, ln: ln, handlers: map[string]func(request) (any, *herdrError){}, done: make(chan struct{})}
+	go f.serve()
+	t.Setenv("HERDR_SOCKET_PATH", socket)
+	t.Cleanup(func() {
+		ln.Close()
+		<-f.done
+		os.RemoveAll(dir)
+	})
+	return f
+}
+
+// serve accepts one request per connection, exactly as herdr does.
+func (f *fakeHerdr) serve() {
+	defer close(f.done)
+	for {
+		conn, err := f.ln.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+		var req request
+		if err := json.NewDecoder(conn).Decode(&req); err == nil {
+			f.mu.Lock()
+			f.calls = append(f.calls, req)
+			handler := f.handlers[req.Method]
+			f.mu.Unlock()
+			resp := response{ID: req.ID}
+			if handler == nil {
+				resp.Error = &herdrError{Code: "unknown_method", Message: "no handler for " + req.Method}
+			} else if result, herr := handler(req); herr != nil {
+				resp.Error = herr
+			} else {
+				raw, mErr := json.Marshal(result)
+				if mErr != nil {
+					f.t.Errorf("marshal %s result: %v", req.Method, mErr)
+				}
+				resp.Result = raw
+			}
+			_ = json.NewEncoder(conn).Encode(resp)
+		}
+		conn.Close()
+	}
+}
+
+// handle registers a canned result for a method.
+func (f *fakeHerdr) handle(method string, result any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers[method] = func(request) (any, *herdrError) { return result, nil }
+}
+
+// handleFunc registers a handler that can inspect the request or fail.
+func (f *fakeHerdr) handleFunc(method string, fn func(request) (any, *herdrError)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers[method] = fn
+}
+
+// fail makes a method return a herdr error, standing in for a native lookup
+// that cannot answer.
+func (f *fakeHerdr) fail(method, message string) {
+	f.handleFunc(method, func(request) (any, *herdrError) {
+		return nil, &herdrError{Code: "native_failure", Message: message}
+	})
+}
+
+// methods returns the methods called so far, in order.
+func (f *fakeHerdr) methods() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	for i, c := range f.calls {
+		out[i] = c.Method
+	}
+	return out
+}
+
+// paramsFor returns the params of the single call to method, failing the test
+// when it was not called exactly once.
+func (f *fakeHerdr) paramsFor(method string) map[string]any {
+	f.t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var found []map[string]any
+	for _, c := range f.calls {
+		if c.Method == method {
+			found = append(found, c.Params)
+		}
+	}
+	if len(found) != 1 {
+		f.t.Fatalf("want exactly one %s call, got %d (calls: %v)", method, len(found), f.calls)
+	}
+	return found[0]
+}
+
+// client builds a real herdrClient pointed at this fake.
+func (f *fakeHerdr) client() *herdrClient {
+	f.t.Helper()
+	c, err := newHerdrClient()
+	if err != nil {
+		f.t.Fatalf("newHerdrClient: %v", err)
+	}
+	return c
+}
+
+// mutatingMethods are every native call that creates, reflows, or types into
+// something. Reuse and failure paths must issue none of them: returning to work
+// that already exists must never rebuild or disturb it.
+var mutatingMethods = []string{
+	"workspace.create", "workspace.close", "worktree.create", "worktree.open",
+	"tab.create", "tab.close", "tab.rename", "pane.split", "pane.close",
+	"pane.rename", "pane.send_input", "pane.read", "layout.apply", "pane.zoom",
+}
+
+// assertNoMutations fails when any workspace/tab/pane was created, destroyed,
+// relaid, or sent input.
+func (f *fakeHerdr) assertNoMutations() {
+	f.t.Helper()
+	for _, m := range f.methods() {
+		for _, bad := range mutatingMethods {
+			if m == bad {
+				f.t.Fatalf("unexpected mutating native call %q; calls: %v", m, f.methods())
+			}
+		}
+	}
+}
+
+// assertNotCalled fails when method was called at all — used to prove the
+// action never falls back to another client's focused pane (pane.list).
+func (f *fakeHerdr) assertNotCalled(method string) {
+	f.t.Helper()
+	for _, m := range f.methods() {
+		if m == method {
+			f.t.Fatalf("native call %q must not happen; calls: %v", method, f.methods())
+		}
+	}
+}
+
+// wsInfo builds one workspace.list / workspace.get entry with checkout
+// provenance, the way herdr reports a workspace opened on a git checkout.
+func wsInfo(id, label, checkout string, linked bool) map[string]any {
+	return map[string]any{
+		"workspace_id": id,
+		"number":       1,
+		"label":        label,
+		"focused":      false,
+		"pane_count":   1,
+		"tab_count":    1,
+		"worktree": map[string]any{
+			"repo_key":           "repo-key",
+			"repo_name":          "repo",
+			"repo_root":          "/repo",
+			"checkout_path":      checkout,
+			"is_linked_worktree": linked,
+		},
+	}
+}
+
+// wsInfoNoProvenance builds a workspace herdr reports without any checkout
+// provenance — a plain folder workspace, which must never be adopted as a match.
+func wsInfoNoProvenance(id, label string) map[string]any {
+	return map[string]any{
+		"workspace_id": id,
+		"number":       1,
+		"label":        label,
+		"focused":      false,
+		"pane_count":   1,
+		"tab_count":    1,
+	}
+}
+
+// tabInfoJSON builds one tab.list entry.
+func tabInfoJSON(id, workspaceID, label string) map[string]any {
+	return map[string]any{
+		"tab_id":       id,
+		"workspace_id": workspaceID,
+		"number":       1,
+		"label":        label,
+		"focused":      false,
+		"pane_count":   1,
+	}
+}
+
+// setPluginContext installs a HERDR_PLUGIN_CONTEXT_JSON describing the pane the
+// action fired from — the explicit, per-invocation context herdr injects.
+func setPluginContext(t *testing.T, ctx map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(ctx)
+	if err != nil {
+		t.Fatalf("marshal plugin context: %v", err)
+	}
+	t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", string(raw))
+}
+
+// linkedContext is the common case: the action fired from a pane in a linked
+// worktree workspace.
+func linkedContext(t *testing.T, workspaceID, paneID, checkout string) {
+	t.Helper()
+	setPluginContext(t, map[string]any{
+		"workspace_id":    workspaceID,
+		"workspace_label": "repo · branch",
+		"workspace_cwd":   checkout,
+		"focused_pane_id": paneID,
+		"worktree": map[string]any{
+			"repo_key":           "repo-key",
+			"repo_name":          "repo",
+			"repo_root":          "/repo",
+			"checkout_path":      checkout,
+			"is_linked_worktree": true,
+		},
+	})
+}
+
+// paneInfoJSON builds a pane.get result for the pane the context names.
+func paneInfoJSON(paneID, tabID, workspaceID string) map[string]any {
+	return map[string]any{
+		"pane": map[string]any{
+			"pane_id":      paneID,
+			"tab_id":       tabID,
+			"workspace_id": workspaceID,
+			"terminal_id":  "t1",
+			"cwd":          "/checkout",
+		},
+	}
+}
+
+// crewFixture wires the fake native side for a linked worktree workspace whose
+// tabs are the given labels, and installs the matching injected context.
+func crewFixture(t *testing.T, labels ...string) *fakeHerdr {
+	t.Helper()
+	f := startFakeHerdr(t)
+	linkedContext(t, "w1", "w1:p1", "/checkout")
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo · branch", "/checkout", true)})
+	f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+	tabs := make([]any, len(labels))
+	for i, l := range labels {
+		tabs[i] = tabInfoJSON("w1:t"+string(rune('1'+i)), "w1", l)
+	}
+	f.handle("tab.list", map[string]any{"tabs": tabs})
+	f.handle("tab.focus", map[string]any{"type": "tab_focused"})
+	return f
+}
+
+// TestReturnToCrewFocusesTheExactTab is the core contextual-P behavior: fired
+// inside a linked worktree workspace whose Crew tab exists exactly once, the
+// action focuses that tab and does nothing else — no picker, no creation, no
+// layout, and no input into whatever is running there.
+func TestReturnToCrewFocusesTheExactTab(t *testing.T) {
+	f := crewFixture(t, "Editor", "Crew", "Logs")
+
+	pc, err := pluginContextFromEnv()
+	if err != nil {
+		t.Fatalf("pluginContextFromEnv: %v", err)
+	}
+	focused, err := returnToCrew(f.client(), pc, "Crew")
+	if err != nil {
+		t.Fatalf("returnToCrew: %v", err)
+	}
+	if !focused {
+		t.Fatal("returnToCrew reported not handled; want the Crew tab focused")
+	}
+	if got := f.paramsFor("tab.focus")["tab_id"]; got != "w1:t2" {
+		t.Fatalf("focused tab_id = %v, want w1:t2 (the one tab labeled Crew)", got)
+	}
+	if got := f.paramsFor("workspace.get")["workspace_id"]; got != "w1" {
+		t.Fatalf("workspace.get workspace_id = %v, want the injected w1", got)
+	}
+	if got := f.paramsFor("tab.list")["workspace_id"]; got != "w1" {
+		t.Fatalf("tab.list workspace_id = %v, want the injected w1", got)
+	}
+	f.assertNoMutations()
+	// Identity comes from the injected context, never from whatever pane another
+	// client happens to have focused.
+	f.assertNotCalled("pane.list")
+}
+
+// TestReturnToCrewIsIdempotent confirms pressing P again from the same context
+// simply focuses the same tab: no second Crew, no layout, no drift.
+func TestReturnToCrewIsIdempotent(t *testing.T) {
+	f := crewFixture(t, "Crew")
+	pc, err := pluginContextFromEnv()
+	if err != nil {
+		t.Fatalf("pluginContextFromEnv: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		focused, err := returnToCrew(f.client(), pc, "Crew")
+		if err != nil || !focused {
+			t.Fatalf("attempt %d: focused=%v err=%v", i+1, focused, err)
+		}
+	}
+	f.assertNoMutations()
+	focuses := 0
+	for _, m := range f.methods() {
+		if m == "tab.focus" {
+			focuses++
+		}
+	}
+	if focuses != 3 {
+		t.Fatalf("tab.focus calls = %d, want 3 (one per press, each a no-op re-focus)", focuses)
+	}
+}
+
+// TestReturnToCrewIgnoresOtherClientsFocus proves the workspace another client
+// is looking at — even one that also has a Crew tab — cannot capture P. The
+// injected context is the only identity source.
+func TestReturnToCrewIgnoresOtherClientsFocus(t *testing.T) {
+	f := startFakeHerdr(t)
+	linkedContext(t, "w1", "w1:p1", "/checkout")
+	f.handleFunc("workspace.get", func(req request) (any, *herdrError) {
+		if req.Params["workspace_id"] != "w1" {
+			return nil, &herdrError{Code: "not_found", Message: "wrong workspace"}
+		}
+		return map[string]any{"workspace": wsInfo("w1", "repo · branch", "/checkout", true)}, nil
+	})
+	f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+	f.handleFunc("tab.list", func(req request) (any, *herdrError) {
+		if req.Params["workspace_id"] != "w1" {
+			return nil, &herdrError{Code: "not_found", Message: "wrong workspace"}
+		}
+		return map[string]any{"tabs": []any{tabInfoJSON("w1:t9", "w1", "Crew")}}, nil
+	})
+	f.handle("tab.focus", map[string]any{})
+	// Another client is focused on a different workspace that also has a Crew tab.
+	f.handle("pane.list", map[string]any{"panes": []any{map[string]any{"pane_id": "w2:p1", "focused": true, "workspace_id": "w2"}}})
+
+	pc, _ := pluginContextFromEnv()
+	focused, err := returnToCrew(f.client(), pc, "Crew")
+	if err != nil || !focused {
+		t.Fatalf("focused=%v err=%v; want the injected workspace's Crew tab", focused, err)
+	}
+	if got := f.paramsFor("tab.focus")["tab_id"]; got != "w1:t9" {
+		t.Fatalf("focused tab_id = %v, want w1:t9", got)
+	}
+	f.assertNotCalled("pane.list")
+}
+
+// TestReturnToCrewDiagnostics covers every case where identity or the Crew tab
+// cannot be established: each must fail visibly, create nothing, and never be
+// silently downgraded to "not linked" (which would open a picker and, one
+// selection later, a duplicate workspace).
+func TestReturnToCrewDiagnostics(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T) *fakeHerdr
+		wantErr string
+	}{
+		{
+			name:    "renamed or missing Crew tab",
+			setup:   func(t *testing.T) *fakeHerdr { return crewFixture(t, "Editor", "crew-old") },
+			wantErr: "no tab labeled",
+		},
+		{
+			name:    "duplicate Crew tabs",
+			setup:   func(t *testing.T) *fakeHerdr { return crewFixture(t, "Crew", "Crew") },
+			wantErr: "2 tabs labeled",
+		},
+		{
+			name: "workspace lookup failure is not 'not linked'",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.fail("workspace.get", "socket exploded")
+				return f
+			},
+			wantErr: "look up workspace",
+		},
+		{
+			name: "tab lookup failure is not 'no Crew tab'",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/checkout", true)})
+				f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+				f.fail("tab.list", "socket exploded")
+				return f
+			},
+			wantErr: "list tabs",
+		},
+		{
+			name: "native answers about a different workspace",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w2", "other", "/other", true)})
+				return f
+			},
+			wantErr: "identity",
+		},
+		{
+			name: "context pane belongs to another workspace",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/checkout", true)})
+				f.handle("pane.get", paneInfoJSON("w1:p1", "w2:t1", "w2"))
+				return f
+			},
+			wantErr: "pane",
+		},
+		{
+			name: "context checkout no longer matches the live workspace",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/somewhere-else", true)})
+				f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+				return f
+			},
+			wantErr: "checkout",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := c.setup(t)
+			pc, err := pluginContextFromEnv()
+			if err != nil {
+				t.Fatalf("pluginContextFromEnv: %v", err)
+			}
+			focused, err := returnToCrew(f.client(), pc, "Crew")
+			if err == nil {
+				t.Fatalf("want a visible diagnostic, got focused=%v and no error", focused)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			if focused {
+				t.Fatal("a failed lookup must not report the action handled")
+			}
+			f.assertNoMutations()
+		})
+	}
+}
+
+// TestReturnToCrewFallsThroughToPicker covers the contexts that are simply not
+// task Crews: they hand the action back so the normal project picker opens.
+func TestReturnToCrewFallsThroughToPicker(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T) *fakeHerdr
+	}{
+		{
+			name: "workspace is not a linked worktree",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				linkedContext(t, "w1", "w1:p1", "/checkout")
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/checkout", false)})
+				f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+				return f
+			},
+		},
+		{
+			name: "workspace has no checkout provenance at all",
+			setup: func(t *testing.T) *fakeHerdr {
+				f := startFakeHerdr(t)
+				setPluginContext(t, map[string]any{"workspace_id": "w1", "focused_pane_id": "w1:p1"})
+				f.handle("workspace.get", map[string]any{"workspace": wsInfoNoProvenance("w1", "notes")})
+				f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+				return f
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := c.setup(t)
+			pc, _ := pluginContextFromEnv()
+			focused, err := returnToCrew(f.client(), pc, "Crew")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if focused {
+				t.Fatal("want the picker to open (handled=false)")
+			}
+			f.assertNoMutations()
+			f.assertNotCalled("tab.focus")
+		})
+	}
+}
+
+// TestPluginContextFromEnv covers the three shapes of the injected context: a
+// real one, an absent one (which is no identity at all, not an error), and a
+// malformed one — which must be a visible error rather than a zero context that
+// would look like "no workspace" and open a picker on a guess.
+func TestPluginContextFromEnv(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", "")
+		pc, err := pluginContextFromEnv()
+		if err != nil {
+			t.Fatalf("absent context must not be an error: %v", err)
+		}
+		if pc.WorkspaceID != "" {
+			t.Fatalf("WorkspaceID = %q, want empty", pc.WorkspaceID)
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", "{not json")
+		if _, err := pluginContextFromEnv(); err == nil {
+			t.Fatal("malformed context must be a visible error")
+		}
+	})
+
+	t.Run("linked worktree", func(t *testing.T) {
+		linkedContext(t, "w7", "w7:p2", "/checkout")
+		pc, err := pluginContextFromEnv()
+		if err != nil {
+			t.Fatalf("pluginContextFromEnv: %v", err)
+		}
+		if pc.WorkspaceID != "w7" || pc.FocusedPaneID != "w7:p2" {
+			t.Fatalf("context = %+v, want w7 / w7:p2", pc)
+		}
+		if pc.Worktree == nil || !pc.Worktree.IsLinkedWorktree || pc.Worktree.CheckoutPath != "/checkout" {
+			t.Fatalf("worktree provenance = %+v, want the linked /checkout", pc.Worktree)
+		}
+	})
+}
+
+// TestContextFromPluginEnvStillTolerantConfirms quick actions keep their
+// launch-anyway behavior: a malformed context there still yields a usable
+// (empty) RunContext rather than refusing to open the picker.
+func TestContextFromPluginEnvStillTolerant(t *testing.T) {
+	t.Setenv("HERDR_PLUGIN_CONTEXT_JSON", "{not json")
+	if ctx := contextFromPluginEnv(); ctx.WorkspaceId != "" {
+		t.Fatalf("RunContext = %+v, want the empty fallback", ctx)
+	}
+}
+
+// TestParseProjectsArgs covers the explicit escape hatch: bare `projects` keeps
+// the contextual behavior, `--pick` always opens the picker, and anything else
+// is rejected rather than silently ignored.
+func TestParseProjectsArgs(t *testing.T) {
+	cases := []struct {
+		args     []string
+		wantPick bool
+		wantErr  bool
+	}{
+		{args: nil, wantPick: false},
+		{args: []string{}, wantPick: false},
+		{args: []string{"--pick"}, wantPick: true},
+		{args: []string{"--pick", "--pick"}, wantErr: true},
+		{args: []string{"-pick"}, wantErr: true},
+		{args: []string{"--pickle"}, wantErr: true},
+		{args: []string{"pick"}, wantErr: true},
+		{args: []string{"--pick", "extra"}, wantErr: true},
+		{args: []string{""}, wantErr: true},
+	}
+	for _, c := range cases {
+		pick, err := parseProjectsArgs(c.args)
+		if c.wantErr {
+			if err == nil {
+				t.Fatalf("parseProjectsArgs(%q) = %v, want an error", c.args, pick)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseProjectsArgs(%q): %v", c.args, err)
+		}
+		if pick != c.wantPick {
+			t.Fatalf("parseProjectsArgs(%q) = %v, want %v", c.args, pick, c.wantPick)
+		}
+	}
+}
+
+// TestLaunchProjectsReturnsToCrew is the end-to-end action path: with crew_tab
+// configured and a linked context, launchProjects focuses the Crew tab and never
+// asks herdr to open a picker pane at all.
+func TestLaunchProjectsReturnsToCrew(t *testing.T) {
+	f := crewFixture(t, "Crew")
+	configDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[projects]\ncrew_tab = \"Crew\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	record := filepath.Join(t.TempDir(), "args.txt")
+	t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+	launchProjects(nil)
+
+	if _, err := os.Stat(record); err == nil {
+		got, _ := os.ReadFile(record)
+		t.Fatalf("herdr CLI was invoked (%q); returning to a Crew must not open a picker pane", got)
+	}
+	if got := f.paramsFor("tab.focus")["tab_id"]; got != "w1:t1" {
+		t.Fatalf("focused tab_id = %v, want w1:t1", got)
+	}
+	f.assertNoMutations()
+}
+
+// TestLaunchProjectsPickEscape confirms `projects --pick` always opens the
+// picker — even from a linked worktree context with a Crew tab present — and
+// makes no native identity calls at all on the way.
+func TestLaunchProjectsPickEscape(t *testing.T) {
+	f := crewFixture(t, "Crew")
+	configDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[projects]\ncrew_tab = \"Crew\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	record := filepath.Join(t.TempDir(), "args.txt")
+	t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+	launchProjects([]string{"--pick"})
+
+	got, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("--pick must open the picker pane: %v", err)
+	}
+	if !strings.Contains(string(got), "pane\nopen") {
+		t.Fatalf("recorded args %q do not open a plugin pane", got)
+	}
+	if len(f.methods()) != 0 {
+		t.Fatalf("native calls %v; --pick must not consult native identity", f.methods())
+	}
+}
+
+// TestLaunchProjectsForwardsCallerContext covers the non-linked path: the picker
+// opens as before, and the caller's context rides along in HERDR_PLUS_CTX the way
+// Quick Actions already forwards it — while the pane itself keeps running in the
+// plugin directory, so the manifest's relative ./bin/herdr-plus still resolves.
+func TestLaunchProjectsForwardsCallerContext(t *testing.T) {
+	f := startFakeHerdr(t)
+	setPluginContext(t, map[string]any{
+		"workspace_id":     "w1",
+		"workspace_label":  "notes",
+		"focused_pane_id":  "w1:p1",
+		"focused_pane_cwd": "/home/user/code",
+	})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfoNoProvenance("w1", "notes")})
+	f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+
+	configDir := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[projects]\ncrew_tab = \"Crew\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	record := filepath.Join(t.TempDir(), "args.txt")
+	t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+	launchProjects(nil)
+
+	raw, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("a non-linked context must still open the picker: %v", err)
+	}
+	args := strings.Split(string(raw), "\n")
+	var encoded string
+	for _, a := range args {
+		if strings.HasPrefix(a, "HERDR_PLUS_CTX=") {
+			encoded = strings.TrimPrefix(a, "HERDR_PLUS_CTX=")
+		}
+		if a == "--cwd" {
+			t.Fatal("--cwd must not be passed: the picker resolves ./bin/herdr-plus against the plugin directory")
+		}
+	}
+	if encoded == "" {
+		t.Fatalf("recorded args %q carry no HERDR_PLUS_CTX", raw)
+	}
+	if _, err := base64.StdEncoding.DecodeString(encoded); err != nil {
+		t.Fatalf("HERDR_PLUS_CTX is not the encoded context: %v", err)
+	}
+	ctx, err := decodeRunContext(encoded)
+	if err != nil {
+		t.Fatalf("decodeRunContext: %v", err)
+	}
+	if ctx.WorkDir != "/home/user/code" || ctx.WorkspaceId != "w1" {
+		t.Fatalf("forwarded context = %+v, want the caller's cwd and workspace", ctx)
+	}
+	f.assertNoMutations()
+}
+
+// TestLaunchProjectsWithoutCrewTabIsUnchanged confirms the upstream behavior is
+// exactly preserved when the policy is not configured: the picker opens and no
+// native identity lookup happens at all.
+func TestLaunchProjectsWithoutCrewTabIsUnchanged(t *testing.T) {
+	f := crewFixture(t, "Crew")
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", t.TempDir())
+	record := filepath.Join(t.TempDir(), "args.txt")
+	t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+	launchProjects(nil)
+
+	if _, err := os.Stat(record); err != nil {
+		t.Fatalf("the picker must open when no crew_tab is configured: %v", err)
+	}
+	if len(f.methods()) != 0 {
+		t.Fatalf("native calls %v; an unconfigured Crew policy must consult nothing", f.methods())
+	}
+}
+
+// --- Task 2: reuse the exact selected checkout -----------------------------
+
+// reuseProject is a minimal single-tab project rooted at dir.
+func reuseProject(name, dir string) Project {
+	return Project{Name: name, WorkingDir: dir, Tabs: []ProjectTab{{Name: "shell"}}}
+}
+
+// TestOpenProjectReusesExactCheckout covers the unique-match case: the selected
+// preset's directory is already open as a workspace, so that workspace is
+// focused and nothing is created, laid out, or started.
+func TestOpenProjectReusesExactCheckout(t *testing.T) {
+	dir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	f := startFakeHerdr(t)
+	f.handle("workspace.list", map[string]any{"workspaces": []any{
+		wsInfo("w1", "other", filepath.Join(canonical, "elsewhere"), true),
+		wsInfo("w2", "repo", canonical, false),
+	}})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("w2", "repo", canonical, false)})
+	f.handle("workspace.focus", map[string]any{})
+
+	// Repeat it: reuse must stay a focus, never a second workspace.
+	for i := 0; i < 2; i++ {
+		if err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true}); err != nil {
+			t.Fatalf("attempt %d: openProject: %v", i+1, err)
+		}
+	}
+	focuses := 0
+	for _, c := range f.calls {
+		if c.Method != "workspace.focus" {
+			continue
+		}
+		focuses++
+		if got := c.Params["workspace_id"]; got != "w2" {
+			t.Fatalf("focused workspace_id = %v, want w2 (the workspace holding this exact checkout)", got)
+		}
+	}
+	if focuses != 2 {
+		t.Fatalf("workspace.focus calls = %d, want 2 — one per open, each a plain focus", focuses)
+	}
+	f.assertNoMutations()
+}
+
+// TestOpenProjectReuseMatchesThroughSymlink confirms identity is the canonical
+// path: a preset pointing at a symlinked alias of an open checkout is the same
+// checkout, not a new one.
+func TestOpenProjectReuseMatchesThroughSymlink(t *testing.T) {
+	real := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(real, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	f := startFakeHerdr(t)
+	f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfo("w2", "repo", canonical, true)}})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("w2", "repo", canonical, true)})
+	f.handle("workspace.focus", map[string]any{})
+
+	if err := openProject(f.client(), reuseProject("repo", alias), reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	if got := f.paramsFor("workspace.focus")["workspace_id"]; got != "w2" {
+		t.Fatalf("focused workspace_id = %v, want w2 via the symlinked alias", got)
+	}
+	f.assertNoMutations()
+}
+
+// TestOpenProjectReuseIgnoresSiblingWorktrees is the identity rule that matters
+// most: two worktrees of one repository share a repo_key but are different
+// checkouts, so opening the second must build it rather than focus the first.
+func TestOpenProjectReuseIgnoresSiblingWorktrees(t *testing.T) {
+	parent := t.TempDir()
+	open := filepath.Join(parent, "worktree-a")
+	wanted := filepath.Join(parent, "worktree-b")
+	for _, d := range []string{open, wanted} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	canonicalOpen, err := filepath.EvalSymlinks(open)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	f := startFakeHerdr(t)
+	// Same repo_key, same label, different checkout — not a match.
+	f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfo("w1", "repo", canonicalOpen, true)}})
+	f.handle("workspace.create", map[string]any{
+		"workspace": map[string]any{"workspace_id": "w9"},
+		"tab":       map[string]any{"tab_id": "w9:t1"},
+		"root_pane": map[string]any{"pane_id": "w9:p1"},
+	})
+	f.handle("tab.rename", map[string]any{})
+
+	if err := openProject(f.client(), reuseProject("repo", wanted), reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	f.assertNotCalled("workspace.focus")
+	if got := f.paramsFor("workspace.create")["cwd"]; got != wanted {
+		t.Fatalf("created workspace cwd = %v, want %v", got, wanted)
+	}
+}
+
+// TestOpenProjectReuseFailuresNeverCreate covers the cases where the inventory
+// or the identity cannot be trusted: none of them may be read as "zero matches"
+// and quietly create a duplicate workspace.
+func TestOpenProjectReuseFailuresNeverCreate(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T, dir string) *fakeHerdr
+		wantErr string
+	}{
+		{
+			name: "failed native inventory",
+			setup: func(t *testing.T, dir string) *fakeHerdr {
+				f := startFakeHerdr(t)
+				f.fail("workspace.list", "socket exploded")
+				return f
+			},
+			wantErr: "list workspaces",
+		},
+		{
+			name: "the chosen workspace vanished before focus",
+			setup: func(t *testing.T, dir string) *fakeHerdr {
+				canonical, _ := filepath.EvalSymlinks(dir)
+				f := startFakeHerdr(t)
+				f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfo("w2", "repo", canonical, true)}})
+				f.fail("workspace.get", "no such workspace")
+				return f
+			},
+			wantErr: "revalidate",
+		},
+		{
+			name: "the chosen workspace changed checkout before focus",
+			setup: func(t *testing.T, dir string) *fakeHerdr {
+				canonical, _ := filepath.EvalSymlinks(dir)
+				f := startFakeHerdr(t)
+				f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfo("w2", "repo", canonical, true)}})
+				f.handle("workspace.get", map[string]any{"workspace": wsInfo("w2", "repo", "/somewhere-else", true)})
+				return f
+			},
+			wantErr: "no longer",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			f := c.setup(t, dir)
+			err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true})
+			if err == nil {
+				t.Fatal("want a visible error, got none")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			f.assertNoMutations()
+			f.assertNotCalled("workspace.focus")
+		})
+	}
+}
+
+// TestOpenProjectReuseDisabledKeepsCreating confirms the default: with the
+// policy off, a project opens a fresh workspace exactly as before and native
+// provenance is never even consulted.
+func TestOpenProjectReuseDisabledKeepsCreating(t *testing.T) {
+	dir := t.TempDir()
+	f := startFakeHerdr(t)
+	f.handle("workspace.create", map[string]any{
+		"workspace": map[string]any{"workspace_id": "w9"},
+		"tab":       map[string]any{"tab_id": "w9:t1"},
+		"root_pane": map[string]any{"pane_id": "w9:p1"},
+	})
+	f.handle("tab.rename", map[string]any{})
+
+	if err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	f.assertNotCalled("workspace.list")
+	f.assertNotCalled("workspace.focus")
+}
+
+// TestOpenProjectReuseIgnoresWorkspacesWithoutProvenance confirms a workspace
+// herdr reports no checkout for is never adopted, even when it is the only one
+// open and its label matches.
+func TestOpenProjectReuseIgnoresWorkspacesWithoutProvenance(t *testing.T) {
+	dir := t.TempDir()
+	f := startFakeHerdr(t)
+	f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfoNoProvenance("w1", "repo")}})
+	f.handle("workspace.create", map[string]any{
+		"workspace": map[string]any{"workspace_id": "w9"},
+		"tab":       map[string]any{"tab_id": "w9:t1"},
+		"root_pane": map[string]any{"pane_id": "w9:p1"},
+	})
+	f.handle("tab.rename", map[string]any{})
+
+	if err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	f.assertNotCalled("workspace.focus")
+}
+
+// TestOpenProjectAmbiguousMatchRequiresChoice covers two open workspaces on the
+// very same checkout: the user chooses explicitly, and the choice is revalidated
+// before it is focused. Nothing is created either way.
+func TestOpenProjectAmbiguousMatchRequiresChoice(t *testing.T) {
+	dir := t.TempDir()
+	canonical, _ := filepath.EvalSymlinks(dir)
+
+	t.Run("explicit choice is focused", func(t *testing.T) {
+		f := startFakeHerdr(t)
+		f.handle("workspace.list", map[string]any{"workspaces": []any{
+			wsInfo("w1", "repo", canonical, true),
+			wsInfo("w2", "repo", canonical, true),
+		}})
+		f.handle("workspace.get", map[string]any{"workspace": wsInfo("w2", "repo", canonical, true)})
+		f.handle("workspace.focus", map[string]any{})
+
+		var offered []workspaceCandidate
+		choose := func(c []workspaceCandidate) (workspaceCandidate, bool, error) {
+			offered = c
+			return c[1], true, nil
+		}
+		if err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true, choose: choose}); err != nil {
+			t.Fatalf("openProject: %v", err)
+		}
+		if len(offered) != 2 || offered[0].WorkspaceID != "w1" || offered[1].WorkspaceID != "w2" {
+			t.Fatalf("offered candidates = %+v, want both native workspace ids", offered)
+		}
+		if offered[0].Label != "repo" || offered[0].CheckoutPath == "" {
+			t.Fatalf("candidate %+v must carry the native label and checkout for display", offered[0])
+		}
+		if got := f.paramsFor("workspace.focus")["workspace_id"]; got != "w2" {
+			t.Fatalf("focused workspace_id = %v, want the chosen w2", got)
+		}
+		f.assertNoMutations()
+	})
+
+	t.Run("cancel is a no-op", func(t *testing.T) {
+		f := startFakeHerdr(t)
+		f.handle("workspace.list", map[string]any{"workspaces": []any{
+			wsInfo("w1", "repo", canonical, true),
+			wsInfo("w2", "repo", canonical, true),
+		}})
+		choose := func([]workspaceCandidate) (workspaceCandidate, bool, error) {
+			return workspaceCandidate{}, false, nil
+		}
+		if err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true, choose: choose}); err != nil {
+			t.Fatalf("cancel must be a silent no-op: %v", err)
+		}
+		f.assertNoMutations()
+		f.assertNotCalled("workspace.focus")
+	})
+
+	t.Run("no chooser fails visibly", func(t *testing.T) {
+		f := startFakeHerdr(t)
+		f.handle("workspace.list", map[string]any{"workspaces": []any{
+			wsInfo("w1", "repo", canonical, true),
+			wsInfo("w2", "repo", canonical, true),
+		}})
+		err := openProject(f.client(), reuseProject("repo", dir), reuseOptions{enabled: true})
+		if err == nil || !strings.Contains(err.Error(), "w1") || !strings.Contains(err.Error(), "w2") {
+			t.Fatalf("headless ambiguity must name both workspaces, got %v", err)
+		}
+		f.assertNoMutations()
+	})
+}
+
+// TestWorkspacePickerChoiceAndCancel drives the selection UI itself: enter picks
+// the highlighted workspace, esc cancels, and neither invents a default. The
+// list never pre-selects "the first match" on the user's behalf — cancelling
+// leaves nothing chosen at all.
+func TestWorkspacePickerChoiceAndCancel(t *testing.T) {
+	candidates := []workspaceCandidate{
+		{WorkspaceID: "w1", Label: "repo", CheckoutPath: "/checkout"},
+		{WorkspaceID: "w2", Label: "repo", CheckoutPath: "/checkout"},
+	}
+
+	m := newWorkspacePickerModel(candidates, "/checkout")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated, _ = updated.(workspacePickerModel).Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(workspacePickerModel)
+	if got.chosen == nil || got.chosen.WorkspaceID != "w2" {
+		t.Fatalf("chosen = %+v, want w2", got.chosen)
+	}
+	if !strings.Contains(got.View(), "w2") {
+		t.Fatalf("the picker must show native workspace ids; view:\n%s", got.View())
+	}
+
+	m = newWorkspacePickerModel(candidates, "/checkout")
+	cancelled, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if c := cancelled.(workspacePickerModel); c.chosen != nil {
+		t.Fatalf("esc must choose nothing, got %+v", c.chosen)
+	}
+}
+
+// TestMalformedInventoryIsNeverAbsence covers the difference between "herdr says
+// nothing is open" and "herdr's answer cannot be read". Only the first may lead
+// to creating a workspace; the second must be an error, or a broken reply would
+// quietly produce the duplicate this whole feature exists to prevent.
+func TestMalformedInventoryIsNeverAbsence(t *testing.T) {
+	cases := []struct {
+		name    string
+		result  any
+		wantErr string
+	}{
+		{
+			name:    "no workspaces key at all",
+			result:  map[string]any{"type": "workspace_list"},
+			wantErr: "no workspaces array",
+		},
+		{
+			name:    "a null workspaces array",
+			result:  map[string]any{"workspaces": nil},
+			wantErr: "no workspaces array",
+		},
+		{
+			name:    "a workspace with no id",
+			result:  map[string]any{"workspaces": []any{map[string]any{"label": "repo"}}},
+			wantErr: "no workspace_id",
+		},
+		{
+			name: "provenance with an unusable checkout path",
+			result: map[string]any{"workspaces": []any{map[string]any{
+				"workspace_id": "w1",
+				"label":        "repo",
+				"worktree":     map[string]any{"repo_key": "k", "checkout_path": "", "is_linked_worktree": true},
+			}}},
+			wantErr: "absolute path",
+		},
+		{
+			name: "provenance with a relative checkout path",
+			result: map[string]any{"workspaces": []any{map[string]any{
+				"workspace_id": "w1",
+				"label":        "repo",
+				"worktree":     map[string]any{"repo_key": "k", "checkout_path": "relative/checkout", "is_linked_worktree": true},
+			}}},
+			wantErr: "absolute path",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := startFakeHerdr(t)
+			f.handle("workspace.list", c.result)
+			err := openProject(f.client(), reuseProject("repo", t.TempDir()), reuseOptions{enabled: true})
+			if err == nil {
+				t.Fatal("want an error; a malformed inventory must never read as an empty one")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			f.assertNoMutations()
+		})
+	}
+
+	t.Run("a genuinely empty inventory still creates", func(t *testing.T) {
+		f := startFakeHerdr(t)
+		f.handle("workspace.list", map[string]any{"type": "workspace_list", "workspaces": []any{}})
+		f.handle("workspace.create", map[string]any{
+			"workspace": map[string]any{"workspace_id": "w9"},
+			"tab":       map[string]any{"tab_id": "w9:t1"},
+			"root_pane": map[string]any{"pane_id": "w9:p1"},
+		})
+		f.handle("tab.rename", map[string]any{})
+		if err := openProject(f.client(), reuseProject("repo", t.TempDir()), reuseOptions{enabled: true}); err != nil {
+			t.Fatalf("an empty list means nothing is open, which is not an error: %v", err)
+		}
+		if got := f.paramsFor("workspace.create")["label"]; got != "repo" {
+			t.Fatalf("workspace.create label = %v, want repo", got)
+		}
+	})
+}
+
+// TestMalformedTabListIsNeverAMissingTab is the same rule one level down: an
+// unreadable tab.list reply must not be reported to the user as a renamed or
+// closed Crew tab.
+func TestMalformedTabListIsNeverAMissingTab(t *testing.T) {
+	f := startFakeHerdr(t)
+	linkedContext(t, "w1", "w1:p1", "/checkout")
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/checkout", true)})
+	f.handle("pane.get", paneInfoJSON("w1:p1", "w1:t1", "w1"))
+	f.handle("tab.list", map[string]any{"type": "tab_list"})
+
+	pc, _ := pluginContextFromEnv()
+	focused, err := returnToCrew(f.client(), pc, "Crew")
+	if err == nil || !strings.Contains(err.Error(), "no tabs array") {
+		t.Fatalf("want a malformed-response error, got focused=%v err=%v", focused, err)
+	}
+	if strings.Contains(err.Error(), "no tab labeled") {
+		t.Fatalf("a broken reply must not be reported as a renamed tab: %v", err)
+	}
+	f.assertNoMutations()
+}
+
+// TestReturnToCrewChecksPaneIdentity confirms the pane lookup is an identity
+// check, not just a liveness one: an answer about some other pane cannot stand
+// in for the pane the action was actually invoked from.
+func TestReturnToCrewChecksPaneIdentity(t *testing.T) {
+	f := startFakeHerdr(t)
+	linkedContext(t, "w1", "w1:p1", "/checkout")
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("w1", "repo", "/checkout", true)})
+	// Right workspace, wrong pane.
+	f.handle("pane.get", paneInfoJSON("w1:p9", "w1:t1", "w1"))
+
+	pc, _ := pluginContextFromEnv()
+	focused, err := returnToCrew(f.client(), pc, "Crew")
+	if err == nil || !strings.Contains(err.Error(), "pane identity") {
+		t.Fatalf("want a pane identity error, got focused=%v err=%v", focused, err)
+	}
+	f.assertNoMutations()
+	f.assertNotCalled("tab.focus")
+}

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -9,10 +9,13 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -1165,4 +1168,523 @@ func TestReturnToCrewChecksPaneIdentity(t *testing.T) {
 	}
 	f.assertNoMutations()
 	f.assertNotCalled("tab.focus")
+}
+
+// --- Native checkout binding (strict provenance workaround) ----------------
+
+// gitEnv is an isolated Git environment: the user's global and system config
+// must not decide whether these tests pass.
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+	)
+}
+
+// runGit runs a real git command in dir, skipping the test when git is missing.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, lookErr := exec.LookPath("git"); lookErr != nil {
+			t.Skipf("git unavailable: %v", lookErr)
+		}
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// newGitRepo creates a real repository with one commit and returns its
+// canonical primary checkout path.
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	runGit(t, canonical, "init", "-b", "main", ".")
+	if err := os.WriteFile(filepath.Join(canonical, "README"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, canonical, "add", "README")
+	runGit(t, canonical, "commit", "-m", "first")
+	return canonical
+}
+
+// addWorktree registers a real linked worktree of repo and returns its
+// canonical path.
+func addWorktree(t *testing.T, repo, branch string) string {
+	t.Helper()
+	parent := t.TempDir()
+	canonicalParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	path := filepath.Join(canonicalParent, branch)
+	runGit(t, repo, "worktree", "add", "-b", branch, path)
+	return path
+}
+
+// nativeFixture models the parts of Herdr 0.9.0 that this workaround depends
+// on, as read from its worktree API source: workspace.create records NO
+// checkout provenance, worktree.list reports which registered checkout is open
+// in which workspace (by checkout, provenance or not), and worktree.open binds
+// an already-open checkout to that same workspace and reports already_open
+// without creating or touching panes.
+//
+// It is a model, not proof. It pins herdr-plus's side of the contract — the
+// calls made, their parameters, and how every answer is validated. That the
+// real herdr behaves this way is root's native canary, not this test's.
+type nativeFixture struct {
+	*fakeHerdr
+	next int
+	// openCheckouts maps a canonical checkout path to the workspace herdr has it
+	// open in, provenance or not — herdr's open_workspace_idx_for_checkout.
+	openCheckouts map[string]string
+	// provenance maps a workspace to the checkout herdr has recorded for it.
+	provenance map[string]string
+	labels     map[string]string
+}
+
+func newNativeFixture(t *testing.T) *nativeFixture {
+	t.Helper()
+	nf := &nativeFixture{
+		fakeHerdr:     startFakeHerdr(t),
+		openCheckouts: map[string]string{},
+		provenance:    map[string]string{},
+		labels:        map[string]string{},
+	}
+
+	nf.handleFunc("workspace.create", func(req request) (any, *herdrError) {
+		nf.next++
+		id := fmt.Sprintf("w%d", nf.next)
+		cwd := fmt.Sprint(req.Params["cwd"])
+		canonical, err := filepath.EvalSymlinks(cwd)
+		if err != nil {
+			canonical = cwd
+		}
+		// Herdr 0.9.0 records no checkout provenance on this path.
+		nf.openCheckouts[canonical] = id
+		nf.labels[id] = fmt.Sprint(req.Params["label"])
+		return map[string]any{
+			"workspace": map[string]any{"workspace_id": id},
+			"tab":       map[string]any{"tab_id": id + ":t1"},
+			"root_pane": map[string]any{"pane_id": id + ":p1"},
+		}, nil
+	})
+	nf.handleFunc("workspace.list", func(request) (any, *herdrError) {
+		return map[string]any{"workspaces": nf.workspaces()}, nil
+	})
+	nf.handleFunc("workspace.get", func(req request) (any, *herdrError) {
+		id := fmt.Sprint(req.Params["workspace_id"])
+		for _, ws := range nf.workspaces() {
+			if ws["workspace_id"] == id {
+				return map[string]any{"workspace": ws}, nil
+			}
+		}
+		return nil, &herdrError{Code: "workspace_not_found", Message: "no such workspace"}
+	})
+	nf.handle("workspace.focus", map[string]any{})
+	nf.handle("tab.rename", map[string]any{})
+	nf.handleFunc("pane.split", func(request) (any, *herdrError) {
+		nf.next++
+		return map[string]any{"pane": map[string]any{"pane_id": fmt.Sprintf("s%d", nf.next)}}, nil
+	})
+	nf.handleFunc("worktree.open", func(req request) (any, *herdrError) {
+		path := fmt.Sprint(req.Params["path"])
+		ws, open := nf.openCheckouts[path]
+		if !open {
+			// Herdr would create a workspace here; this workaround never asks it to.
+			return nil, &herdrError{Code: "worktree_not_found", Message: "checkout is not open"}
+		}
+		nf.provenance[ws] = path
+		return map[string]any{
+			"workspace":    map[string]any{"workspace_id": ws},
+			"tab":          map[string]any{"tab_id": ws + ":t1"},
+			"root_pane":    map[string]any{"pane_id": ws + ":p1"},
+			"worktree":     map[string]any{"path": path, "is_linked_worktree": false, "is_bare": false, "is_detached": false, "is_prunable": false, "label": "repo"},
+			"already_open": true,
+		}, nil
+	})
+	return nf
+}
+
+// workspaces renders the current workspace inventory the way herdr does, with a
+// worktree block only for workspaces that actually carry provenance.
+func (nf *nativeFixture) workspaces() []map[string]any {
+	// Always a present array, never null: herdr sends an empty list, and the
+	// client rejects a missing one on purpose.
+	out := []map[string]any{}
+	ids := make([]string, 0, len(nf.labels))
+	for id := range nf.labels {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if checkout, ok := nf.provenance[id]; ok {
+			out = append(out, wsInfo(id, nf.labels[id], checkout, false))
+			continue
+		}
+		out = append(out, wsInfoNoProvenance(id, nf.labels[id]))
+	}
+	return out
+}
+
+// registerWorktreeList makes worktree.list answer from Git's real registry for
+// repo, marking each checkout herdr currently has open.
+func (nf *nativeFixture) registerWorktreeList(t *testing.T, repo string) {
+	t.Helper()
+	nf.handleFunc("worktree.list", func(request) (any, *herdrError) {
+		listing := runGit(t, repo, "worktree", "list", "--porcelain")
+		entries := []any{}
+		for _, block := range strings.Split(listing, "\n\n") {
+			for _, line := range strings.Split(block, "\n") {
+				if !strings.HasPrefix(line, "worktree ") {
+					continue
+				}
+				path := strings.TrimPrefix(line, "worktree ")
+				entry := map[string]any{
+					"path": path, "is_bare": false, "is_detached": false,
+					"is_prunable": false, "is_linked_worktree": path != repo, "label": "repo",
+				}
+				if ws, open := nf.openCheckouts[path]; open {
+					entry["open_workspace_id"] = ws
+				}
+				entries = append(entries, entry)
+			}
+		}
+		return map[string]any{"type": "worktree_list", "source": map[string]any{}, "worktrees": entries}, nil
+	})
+}
+
+// crewTabs is the four-pane Crew shape, so these tests exercise a real layout
+// rather than a single bare pane.
+func crewTabs() []ProjectTab {
+	return []ProjectTab{{
+		Name: "Crew",
+		Panes: []ProjectPane{
+			{Label: "Orchestrator"},
+			{Label: "Issue", Split: SplitRight, SplitFrom: 1, Ratio: 0.25},
+			{Label: "Worker 1", Split: SplitRight, SplitFrom: 1},
+			{Label: "Worker 2", Split: SplitDown, SplitFrom: 3},
+		},
+	}}
+}
+
+// TestOpenProjectBindsThenReusesRealCheckout is the end-to-end answer to the
+// native gap: opening a Git project twice must build it once. The first open
+// creates the workspace, lays out its four panes, and binds the checkout; the
+// second finds it by provenance and only focuses it.
+func TestOpenProjectBindsThenReusesRealCheckout(t *testing.T) {
+	repo := newGitRepo(t)
+	nf := newNativeFixture(t)
+	nf.registerWorktreeList(t, repo)
+	project := Project{Name: "repo", WorkingDir: repo, Tabs: crewTabs()}
+
+	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	// It bound the checkout it just created, from the repository's primary
+	// checkout, without asking herdr to focus anything.
+	bind := nf.paramsFor("worktree.open")
+	if bind["path"] != repo {
+		t.Fatalf("worktree.open path = %v, want the project checkout %s", bind["path"], repo)
+	}
+	if bind["cwd"] != repo {
+		t.Fatalf("worktree.open cwd = %v, want the primary checkout %s", bind["cwd"], repo)
+	}
+	if bind["focus"] != false {
+		t.Fatalf("worktree.open focus = %v, want false", bind["focus"])
+	}
+	created := nf.paramsFor("workspace.create")
+	if created["cwd"] != repo {
+		t.Fatalf("workspace.create cwd = %v, want %s", created["cwd"], repo)
+	}
+	splits := 0
+	for _, m := range nf.methods() {
+		if m == "pane.split" {
+			splits++
+		}
+	}
+	if splits != 3 {
+		t.Fatalf("pane.split calls = %d, want 3 (the four-pane Crew)", splits)
+	}
+
+	// Second open: provenance now exists, so it is a focus and nothing else.
+	before := len(nf.methods())
+	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	second := nf.methods()[before:]
+	for _, m := range second {
+		switch m {
+		case "workspace.create", "pane.split", "tab.create", "tab.rename", "worktree.open", "pane.send_input":
+			t.Fatalf("second open issued %q; calls: %v", m, second)
+		}
+	}
+	if got := nf.calls[len(nf.calls)-1]; got.Method != "workspace.focus" || got.Params["workspace_id"] != "w1" {
+		t.Fatalf("second open ended with %s %v, want workspace.focus of w1", got.Method, got.Params)
+	}
+}
+
+// TestOpenProjectBindsLinkedAndDetachedCheckouts covers the two checkout shapes
+// that make the source parameter matter: herdr refuses a linked worktree as the
+// source of a worktree action, so the primary checkout has to come from Git's
+// registry — and a detached checkout has no branch to name it by, which is why
+// the binding is addressed by path.
+func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
+	t.Run("linked worktree", func(t *testing.T) {
+		repo := newGitRepo(t)
+		linked := addWorktree(t, repo, "feature")
+		nf := newNativeFixture(t)
+		nf.registerWorktreeList(t, repo)
+
+		project := Project{Name: "feature", WorkingDir: linked, Tabs: crewTabs()}
+		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		bind := nf.paramsFor("worktree.open")
+		if bind["path"] != linked {
+			t.Fatalf("worktree.open path = %v, want the linked checkout %s", bind["path"], linked)
+		}
+		if bind["cwd"] != repo {
+			t.Fatalf("worktree.open cwd = %v, want the primary checkout %s (herdr refuses a linked source)", bind["cwd"], repo)
+		}
+	})
+
+	t.Run("detached HEAD", func(t *testing.T) {
+		repo := newGitRepo(t)
+		linked := addWorktree(t, repo, "detachable")
+		runGit(t, linked, "checkout", "--detach")
+		nf := newNativeFixture(t)
+		nf.registerWorktreeList(t, repo)
+
+		project := Project{Name: "detached", WorkingDir: linked, Tabs: crewTabs()}
+		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+			t.Fatalf("a detached checkout must still bind: %v", err)
+		}
+		if got := nf.paramsFor("worktree.open")["path"]; got != linked {
+			t.Fatalf("worktree.open path = %v, want %s", got, linked)
+		}
+		if _, named := nf.paramsFor("worktree.open")["branch"]; named {
+			t.Fatal("the binding must never name a branch; a detached checkout has none")
+		}
+	})
+}
+
+// TestOpenProjectRefusesLegacyOpenCheckout is the deferred-decision path: herdr
+// has the checkout open in a workspace it holds no provenance for (an older
+// build made it). Adopting it would mean trusting an identity that cannot be
+// verified, so the open is refused, visibly, and nothing is created.
+func TestOpenProjectRefusesLegacyOpenCheckout(t *testing.T) {
+	repo := newGitRepo(t)
+	nf := newNativeFixture(t)
+	nf.registerWorktreeList(t, repo)
+	// A workspace from before this behavior existed: open on the checkout, no
+	// provenance recorded, and invisible to workspace.list matching.
+	nf.openCheckouts[repo] = "wLEGACY"
+	nf.labels["wLEGACY"] = "repo"
+
+	project := Project{Name: "repo", WorkingDir: repo, Tabs: crewTabs()}
+	err := openProject(nf.client(), project, reuseOptions{enabled: true})
+	if err == nil {
+		t.Fatal("want a visible refusal, got none")
+	}
+	if !strings.Contains(err.Error(), "wLEGACY") || !strings.Contains(err.Error(), "provenance") {
+		t.Fatalf("error %q must name the workspace and say why it cannot be identified", err)
+	}
+	nf.assertNoMutations()
+	nf.assertNotCalled("workspace.focus")
+	nf.assertNotCalled("worktree.open")
+}
+
+// TestOpenProjectBindingFailuresAreVisible covers every way the binding can go
+// wrong. None may be silent: a workspace that is not bound will be duplicated on
+// the next open, so the user has to be told at the moment it happens. None of
+// them may tear down the workspace that was just built either.
+func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T, nf *nativeFixture, repo string)
+		wantErr string
+		created bool
+	}{
+		{
+			name: "herdr cannot list checkouts",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.fail("worktree.list", "socket exploded")
+			},
+			wantErr: "ask herdr which checkouts are open",
+		},
+		{
+			name: "a malformed checkout listing",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.handle("worktree.list", map[string]any{"type": "worktree_list"})
+			},
+			wantErr: "no worktrees array",
+		},
+		{
+			name: "a checkout listing with an unusable path",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.handle("worktree.list", map[string]any{"worktrees": []any{map[string]any{"path": "relative/path"}}})
+			},
+			wantErr: "absolute path",
+		},
+		{
+			name: "the bind fails outright",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.registerWorktreeList(t, repo)
+				nf.fail("worktree.open", "worktree open failed")
+			},
+			wantErr: "bind checkout",
+			created: true,
+		},
+		{
+			name: "herdr binds a different workspace",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.registerWorktreeList(t, repo)
+				nf.handle("worktree.open", map[string]any{
+					"workspace":    map[string]any{"workspace_id": "wOTHER"},
+					"worktree":     map[string]any{"path": repo},
+					"already_open": true,
+				})
+			},
+			wantErr: "not the workspace",
+			created: true,
+		},
+		{
+			name: "herdr binds a different checkout",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.registerWorktreeList(t, repo)
+				nf.handle("worktree.open", map[string]any{
+					"workspace":    map[string]any{"workspace_id": "w1"},
+					"worktree":     map[string]any{"path": "/somewhere-else"},
+					"already_open": true,
+				})
+			},
+			wantErr: "to checkout /somewhere-else",
+			created: true,
+		},
+		{
+			name: "herdr did not recognize the workspace as already open",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.registerWorktreeList(t, repo)
+				nf.handle("worktree.open", map[string]any{
+					"workspace":    map[string]any{"workspace_id": "w1"},
+					"worktree":     map[string]any{"path": repo},
+					"already_open": false,
+				})
+			},
+			wantErr: "did not recognize",
+			created: true,
+		},
+		{
+			name: "a bind result with no already_open flag",
+			setup: func(t *testing.T, nf *nativeFixture, repo string) {
+				nf.registerWorktreeList(t, repo)
+				nf.handle("worktree.open", map[string]any{
+					"workspace": map[string]any{"workspace_id": "w1"},
+					"worktree":  map[string]any{"path": repo},
+				})
+			},
+			wantErr: "no already_open flag",
+			created: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := newGitRepo(t)
+			nf := newNativeFixture(t)
+			c.setup(t, nf, repo)
+
+			project := Project{Name: "repo", WorkingDir: repo, Tabs: crewTabs()}
+			err := openProject(nf.client(), project, reuseOptions{enabled: true})
+			if err == nil {
+				t.Fatal("want a visible error, got none")
+			}
+			if c.wantErr != "" && !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			created := false
+			for _, m := range nf.methods() {
+				if m == "workspace.create" {
+					created = true
+				}
+				if m == "workspace.close" {
+					t.Fatal("a finished workspace must never be torn down by a failed binding")
+				}
+			}
+			if created != c.created {
+				t.Fatalf("workspace.create happened = %v, want %v; calls: %v", created, c.created, nf.methods())
+			}
+			if c.created && !strings.Contains(err.Error(), "open and laid out") {
+				t.Fatalf("error %q must say the workspace itself is fine", err)
+			}
+		})
+	}
+}
+
+// TestOpenProjectNonGitProjectIsUnchanged confirms the whole binding path is
+// inert for a project that is not a Git checkout: no checkout listing, no bind,
+// just the workspace it always got.
+func TestOpenProjectNonGitProjectIsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	nf := newNativeFixture(t)
+
+	project := Project{Name: "notes", WorkingDir: dir, Tabs: []ProjectTab{{Name: "shell"}}}
+	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	nf.assertNotCalled("worktree.list")
+	nf.assertNotCalled("worktree.open")
+	if got := nf.paramsFor("workspace.create")["cwd"]; got != dir {
+		t.Fatalf("workspace.create cwd = %v, want %s", got, dir)
+	}
+}
+
+// TestOpenProjectSubdirectoryOfCheckoutIsNotBound documents the honest limit: a
+// project rooted at a subdirectory of a checkout is not a checkout, so herdr has
+// no provenance to record for it and none is invented.
+func TestOpenProjectSubdirectoryOfCheckoutIsNotBound(t *testing.T) {
+	repo := newGitRepo(t)
+	sub := filepath.Join(repo, "web")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	nf := newNativeFixture(t)
+	nf.registerWorktreeList(t, repo)
+
+	project := Project{Name: "web", WorkingDir: sub, Tabs: []ProjectTab{{Name: "shell"}}}
+	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	nf.assertNotCalled("worktree.open")
+	if got := nf.paramsFor("workspace.create")["cwd"]; got != sub {
+		t.Fatalf("workspace.create cwd = %v, want %s", got, sub)
+	}
+}
+
+// TestOpenProjectReuseDisabledSkipsNativeBinding confirms the default install is
+// untouched: with reuse off, neither the checkout listing nor the binding runs.
+func TestOpenProjectReuseDisabledSkipsNativeBinding(t *testing.T) {
+	repo := newGitRepo(t)
+	nf := newNativeFixture(t)
+	nf.registerWorktreeList(t, repo)
+
+	project := Project{Name: "repo", WorkingDir: repo, Tabs: []ProjectTab{{Name: "shell"}}}
+	if err := openProject(nf.client(), project, reuseOptions{}); err != nil {
+		t.Fatalf("openProject: %v", err)
+	}
+	nf.assertNotCalled("worktree.list")
+	nf.assertNotCalled("worktree.open")
+	nf.assertNotCalled("workspace.list")
 }

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -1821,6 +1821,22 @@ func TestOpenProjectInconsistentCheckoutListingNeverCreates(t *testing.T) {
 			},
 			wantErr: "unusable form",
 		},
+		{
+			name: "empty present open workspace id",
+			entries: func(repo string) []map[string]any {
+				entry := listedCheckout(repo, "")
+				entry["open_workspace_id"] = ""
+				return []map[string]any{entry}
+			},
+			wantErr: "unusable form",
+		},
+		{
+			name: "whitespace present open workspace id",
+			entries: func(repo string) []map[string]any {
+				return []map[string]any{listedCheckout(repo, "   ")}
+			},
+			wantErr: "unusable form",
+		},
 	}
 
 	for _, c := range cases {

--- a/projectreuse_test.go
+++ b/projectreuse_test.go
@@ -197,6 +197,15 @@ func (f *fakeHerdr) assertNotCalled(method string) {
 	}
 }
 
+// refuseWorktreeList makes herdr answer that this directory is not inside a Git
+// work tree — the positive identification of a non-Git project, which is the
+// only thing that lets an open proceed without checkout identity.
+func (f *fakeHerdr) refuseWorktreeList() {
+	f.handleFunc("worktree.list", func(request) (any, *herdrError) {
+		return nil, &herdrError{Code: "not_git_worktree", Message: "Herdr worktree actions require a path inside a Git work tree"}
+	})
+}
+
 // wsInfo builds one workspace.list / workspace.get entry with checkout
 // provenance, the way herdr reports a workspace opened on a git checkout.
 func wsInfo(id, label, checkout string, linked bool) map[string]any {
@@ -841,6 +850,7 @@ func TestOpenProjectReuseIgnoresSiblingWorktrees(t *testing.T) {
 	}
 
 	f := startFakeHerdr(t)
+	f.refuseWorktreeList()
 	// Same repo_key, same label, different checkout — not a match.
 	f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfo("w1", "repo", canonicalOpen, true)}})
 	f.handle("workspace.create", map[string]any{
@@ -944,6 +954,7 @@ func TestOpenProjectReuseDisabledKeepsCreating(t *testing.T) {
 func TestOpenProjectReuseIgnoresWorkspacesWithoutProvenance(t *testing.T) {
 	dir := t.TempDir()
 	f := startFakeHerdr(t)
+	f.refuseWorktreeList()
 	f.handle("workspace.list", map[string]any{"workspaces": []any{wsInfoNoProvenance("w1", "repo")}})
 	f.handle("workspace.create", map[string]any{
 		"workspace": map[string]any{"workspace_id": "w9"},
@@ -1114,6 +1125,7 @@ func TestMalformedInventoryIsNeverAbsence(t *testing.T) {
 
 	t.Run("a genuinely empty inventory still creates", func(t *testing.T) {
 		f := startFakeHerdr(t)
+		f.refuseWorktreeList()
 		f.handle("workspace.list", map[string]any{"type": "workspace_list", "workspaces": []any{}})
 		f.handle("workspace.create", map[string]any{
 			"workspace": map[string]any{"workspace_id": "w9"},
@@ -1293,10 +1305,12 @@ func newNativeFixture(t *testing.T) *nativeFixture {
 	})
 	nf.handle("workspace.focus", map[string]any{})
 	nf.handle("tab.rename", map[string]any{})
+	nf.handle("pane.rename", map[string]any{})
 	nf.handleFunc("pane.split", func(request) (any, *herdrError) {
 		nf.next++
 		return map[string]any{"pane": map[string]any{"pane_id": fmt.Sprintf("s%d", nf.next)}}, nil
 	})
+	nf.worktreeListFromGit()
 	nf.handleFunc("worktree.open", func(req request) (any, *herdrError) {
 		path := fmt.Sprint(req.Params["path"])
 		ws, open := nf.openCheckouts[path]
@@ -1337,31 +1351,59 @@ func (nf *nativeFixture) workspaces() []map[string]any {
 	return out
 }
 
-// registerWorktreeList makes worktree.list answer from Git's real registry for
-// repo, marking each checkout herdr currently has open.
-func (nf *nativeFixture) registerWorktreeList(t *testing.T, repo string) {
-	t.Helper()
-	nf.handleFunc("worktree.list", func(request) (any, *herdrError) {
-		listing := runGit(t, repo, "worktree", "list", "--porcelain")
+// worktreeListFromGit installs the default worktree.list handler: it answers
+// from the real Git registry of whatever cwd it is asked about, and refuses a
+// directory outside a work tree with the native "not_git_worktree" code — the
+// same positive identification herdr gives. Individual tests override it to
+// stand in for a herdr that answers differently.
+func (nf *nativeFixture) worktreeListFromGit() {
+	nf.handleFunc("worktree.list", func(req request) (any, *herdrError) {
+		cwd := fmt.Sprint(req.Params["cwd"])
+		cmd := exec.Command("git", "worktree", "list", "--porcelain")
+		cmd.Dir, cmd.Env = cwd, gitEnv()
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, &herdrError{Code: "not_git_worktree", Message: "Herdr worktree actions require a path inside a Git work tree"}
+		}
 		entries := []any{}
-		for _, block := range strings.Split(listing, "\n\n") {
-			for _, line := range strings.Split(block, "\n") {
-				if !strings.HasPrefix(line, "worktree ") {
-					continue
-				}
-				path := strings.TrimPrefix(line, "worktree ")
-				entry := map[string]any{
-					"path": path, "is_bare": false, "is_detached": false,
-					"is_prunable": false, "is_linked_worktree": path != repo, "label": "repo",
-				}
-				if ws, open := nf.openCheckouts[path]; open {
-					entry["open_workspace_id"] = ws
-				}
-				entries = append(entries, entry)
+		for _, line := range strings.Split(string(out), "\n") {
+			if !strings.HasPrefix(line, "worktree ") {
+				continue
 			}
+			path := strings.TrimPrefix(line, "worktree ")
+			entry := map[string]any{
+				"path": path, "is_bare": false, "is_detached": false,
+				"is_prunable": false, "is_linked_worktree": false, "label": "repo",
+			}
+			if ws, open := nf.openCheckouts[path]; open {
+				entry["open_workspace_id"] = ws
+			}
+			entries = append(entries, entry)
 		}
 		return map[string]any{"type": "worktree_list", "source": map[string]any{}, "worktrees": entries}, nil
 	})
+}
+
+// worktreeListEntries overrides worktree.list with a fixed set of entries, for
+// tests about what herdr-plus does with an answer it did not expect.
+func (nf *nativeFixture) worktreeListEntries(entries ...map[string]any) {
+	payload := []any{}
+	for _, e := range entries {
+		payload = append(payload, e)
+	}
+	nf.handle("worktree.list", map[string]any{"type": "worktree_list", "worktrees": payload})
+}
+
+// listedCheckout is one worktree.list entry for path, optionally already open.
+func listedCheckout(path, openWorkspace string) map[string]any {
+	entry := map[string]any{
+		"path": path, "is_bare": false, "is_detached": false,
+		"is_prunable": false, "is_linked_worktree": false, "label": "repo",
+	}
+	if openWorkspace != "" {
+		entry["open_workspace_id"] = openWorkspace
+	}
+	return entry
 }
 
 // crewTabs is the four-pane Crew shape, so these tests exercise a real layout
@@ -1385,7 +1427,6 @@ func crewTabs() []ProjectTab {
 func TestOpenProjectBindsThenReusesRealCheckout(t *testing.T) {
 	repo := newGitRepo(t)
 	nf := newNativeFixture(t)
-	nf.registerWorktreeList(t, repo)
 	project := Project{Name: "repo", WorkingDir: repo, Tabs: crewTabs()}
 
 	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1445,7 +1486,6 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 		repo := newGitRepo(t)
 		linked := addWorktree(t, repo, "feature")
 		nf := newNativeFixture(t)
-		nf.registerWorktreeList(t, repo)
 
 		project := Project{Name: "feature", WorkingDir: linked, Tabs: crewTabs()}
 		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1465,7 +1505,6 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 		linked := addWorktree(t, repo, "detachable")
 		runGit(t, linked, "checkout", "--detach")
 		nf := newNativeFixture(t)
-		nf.registerWorktreeList(t, repo)
 
 		project := Project{Name: "detached", WorkingDir: linked, Tabs: crewTabs()}
 		if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1487,7 +1526,6 @@ func TestOpenProjectBindsLinkedAndDetachedCheckouts(t *testing.T) {
 func TestOpenProjectRefusesLegacyOpenCheckout(t *testing.T) {
 	repo := newGitRepo(t)
 	nf := newNativeFixture(t)
-	nf.registerWorktreeList(t, repo)
 	// A workspace from before this behavior existed: open on the checkout, no
 	// provenance recorded, and invisible to workspace.list matching.
 	nf.openCheckouts[repo] = "wLEGACY"
@@ -1541,7 +1579,6 @@ func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
 		{
 			name: "the bind fails outright",
 			setup: func(t *testing.T, nf *nativeFixture, repo string) {
-				nf.registerWorktreeList(t, repo)
 				nf.fail("worktree.open", "worktree open failed")
 			},
 			wantErr: "bind checkout",
@@ -1550,7 +1587,6 @@ func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
 		{
 			name: "herdr binds a different workspace",
 			setup: func(t *testing.T, nf *nativeFixture, repo string) {
-				nf.registerWorktreeList(t, repo)
 				nf.handle("worktree.open", map[string]any{
 					"workspace":    map[string]any{"workspace_id": "wOTHER"},
 					"worktree":     map[string]any{"path": repo},
@@ -1563,7 +1599,6 @@ func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
 		{
 			name: "herdr binds a different checkout",
 			setup: func(t *testing.T, nf *nativeFixture, repo string) {
-				nf.registerWorktreeList(t, repo)
 				nf.handle("worktree.open", map[string]any{
 					"workspace":    map[string]any{"workspace_id": "w1"},
 					"worktree":     map[string]any{"path": "/somewhere-else"},
@@ -1576,7 +1611,6 @@ func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
 		{
 			name: "herdr did not recognize the workspace as already open",
 			setup: func(t *testing.T, nf *nativeFixture, repo string) {
-				nf.registerWorktreeList(t, repo)
 				nf.handle("worktree.open", map[string]any{
 					"workspace":    map[string]any{"workspace_id": "w1"},
 					"worktree":     map[string]any{"path": repo},
@@ -1589,7 +1623,6 @@ func TestOpenProjectBindingFailuresAreVisible(t *testing.T) {
 		{
 			name: "a bind result with no already_open flag",
 			setup: func(t *testing.T, nf *nativeFixture, repo string) {
-				nf.registerWorktreeList(t, repo)
 				nf.handle("worktree.open", map[string]any{
 					"workspace": map[string]any{"workspace_id": "w1"},
 					"worktree":  map[string]any{"path": repo},
@@ -1644,7 +1677,15 @@ func TestOpenProjectNonGitProjectIsUnchanged(t *testing.T) {
 	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
 		t.Fatalf("openProject: %v", err)
 	}
-	nf.assertNotCalled("worktree.list")
+	// herdr is asked, and its not_git_worktree refusal is what identifies this as
+	// a non-Git project — a local Git failure never gets to make that call.
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if got := fmt.Sprint(nf.paramsFor("worktree.list")["cwd"]); got != canonical {
+		t.Fatalf("worktree.list cwd = %v, want the canonical %s", got, canonical)
+	}
 	nf.assertNotCalled("worktree.open")
 	if got := nf.paramsFor("workspace.create")["cwd"]; got != dir {
 		t.Fatalf("workspace.create cwd = %v, want %s", got, dir)
@@ -1661,7 +1702,6 @@ func TestOpenProjectSubdirectoryOfCheckoutIsNotBound(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	nf := newNativeFixture(t)
-	nf.registerWorktreeList(t, repo)
 
 	project := Project{Name: "web", WorkingDir: sub, Tabs: []ProjectTab{{Name: "shell"}}}
 	if err := openProject(nf.client(), project, reuseOptions{enabled: true}); err != nil {
@@ -1678,7 +1718,6 @@ func TestOpenProjectSubdirectoryOfCheckoutIsNotBound(t *testing.T) {
 func TestOpenProjectReuseDisabledSkipsNativeBinding(t *testing.T) {
 	repo := newGitRepo(t)
 	nf := newNativeFixture(t)
-	nf.registerWorktreeList(t, repo)
 
 	project := Project{Name: "repo", WorkingDir: repo, Tabs: []ProjectTab{{Name: "shell"}}}
 	if err := openProject(nf.client(), project, reuseOptions{}); err != nil {
@@ -1687,4 +1726,119 @@ func TestOpenProjectReuseDisabledSkipsNativeBinding(t *testing.T) {
 	nf.assertNotCalled("worktree.list")
 	nf.assertNotCalled("worktree.open")
 	nf.assertNotCalled("workspace.list")
+}
+
+// TestOpenProjectUnknownGitFailureNeverCreates covers the audit's finding: when
+// herdr says the directory IS inside a Git work tree but the local Git registry
+// cannot be read, herdr-plus does not know whether the project is already open.
+// It must say so before creating anything, rather than treat an unreadable Git
+// as "no checkout here" and build a duplicate.
+func TestOpenProjectUnknownGitFailureNeverCreates(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T, nf *nativeFixture, dir string)
+		wantErr string
+	}{
+		{
+			name: "git cannot read the registry",
+			setup: func(t *testing.T, nf *nativeFixture, dir string) {
+				// herdr claims this is a checkout; on disk it is not a repository at
+				// all, so `git worktree list` fails. The two disagree, which is not
+				// an answer either way.
+				nf.worktreeListEntries(listedCheckout(dir, ""))
+			},
+			wantErr: "read the Git worktree registry",
+		},
+		{
+			name: "git cannot be run at all",
+			setup: func(t *testing.T, nf *nativeFixture, dir string) {
+				nf.worktreeListEntries(listedCheckout(dir, ""))
+				// An empty PATH stands in for a missing executable; a timeout reaches
+				// the same ensureGit error path.
+				t.Setenv("PATH", t.TempDir())
+			},
+			wantErr: "read the Git worktree registry",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			plain := t.TempDir()
+			canonical, err := filepath.EvalSymlinks(plain)
+			if err != nil {
+				t.Fatalf("EvalSymlinks: %v", err)
+			}
+			nf := newNativeFixture(t)
+			c.setup(t, nf, canonical)
+
+			project := Project{Name: "repo", WorkingDir: canonical, Tabs: []ProjectTab{{Name: "shell"}}}
+			err = openProject(nf.client(), project, reuseOptions{enabled: true})
+			if err == nil {
+				t.Fatal("an unreadable Git registry must not silently create a workspace")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			nf.assertNotCalled("workspace.create")
+			nf.assertNotCalled("worktree.open")
+		})
+	}
+}
+
+// TestOpenProjectInconsistentCheckoutListingNeverCreates covers the other half
+// of the audit: for a checkout Git has registered, herdr's listing must name it
+// exactly once. Anything else is an inconsistent or ambiguous answer, and none
+// of them means "nothing is open".
+func TestOpenProjectInconsistentCheckoutListingNeverCreates(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries func(repo string) []map[string]any
+		wantErr string
+	}{
+		{
+			name:    "a valid but empty listing",
+			entries: func(string) []map[string]any { return nil },
+			wantErr: "does not include it",
+		},
+		{
+			name: "a listing that omits this checkout",
+			entries: func(repo string) []map[string]any {
+				return []map[string]any{listedCheckout(filepath.Join(repo, "..", "elsewhere"), "")}
+			},
+			wantErr: "does not include it",
+		},
+		{
+			name: "a listing naming this checkout twice",
+			entries: func(repo string) []map[string]any {
+				return []map[string]any{listedCheckout(repo, ""), listedCheckout(repo, "w9")}
+			},
+			wantErr: "2 times",
+		},
+		{
+			name: "an unusable open workspace id",
+			entries: func(repo string) []map[string]any {
+				return []map[string]any{listedCheckout(repo, "w1\nrm -rf /")}
+			},
+			wantErr: "unusable form",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := newGitRepo(t)
+			nf := newNativeFixture(t)
+			nf.worktreeListEntries(c.entries(repo)...)
+
+			project := Project{Name: "repo", WorkingDir: repo, Tabs: crewTabs()}
+			err := openProject(nf.client(), project, reuseOptions{enabled: true})
+			if err == nil {
+				t.Fatal("an inconsistent listing must not lead to a second workspace")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, c.wantErr)
+			}
+			nf.assertNoMutations()
+			nf.assertNotCalled("worktree.open")
+		})
+	}
 }

--- a/projects.go
+++ b/projects.go
@@ -135,6 +135,16 @@ func runProjectsUI() {
 		errExit(err)
 	}
 	if m.worktree {
+		if len(cfg.Worktree.Projects) > 0 {
+			dir, err := m.chosen.expandedWorkingDir()
+			if err != nil {
+				errExit(err)
+			}
+			if err := runPolicyPicker(worktreeRequest{Cwd: dir, Name: m.branch}); err != nil {
+				errExit(err)
+			}
+			return
+		}
 		if err := openProjectAsWorktree(client, *m.chosen, m.branch); err != nil {
 			errExit("could not open project as worktree:", err)
 		}

--- a/projects.go
+++ b/projects.go
@@ -135,11 +135,15 @@ func runProjectsUI() {
 		errExit(err)
 	}
 	if m.worktree {
-		if len(cfg.Worktree.Projects) > 0 {
-			dir, err := m.chosen.expandedWorkingDir()
-			if err != nil {
-				errExit(err)
-			}
+		dir, err := m.chosen.expandedWorkingDir()
+		if err != nil {
+			errExit(err)
+		}
+		shared, err := projectUsesSharedWorktreePolicy(cfg, dir)
+		if err != nil {
+			errExit(err)
+		}
+		if shared {
 			// The planner takes the raw input. It applies branch_prefix itself, and
 			// only the unprefixed name still matches an existing unprefixed branch —
 			// the case W already reuses without a base query or a fetch.

--- a/projects.go
+++ b/projects.go
@@ -192,21 +192,14 @@ func openProject(client *herdrClient, p Project, reuse reuseOptions) error {
 		}
 
 		// No workspace carries provenance for this checkout — but herdr may still
-		// have it open in a workspace it holds no provenance for (one from an older
-		// build of this plugin, say). Read Git's registry, then herdr's, and refuse
-		// rather than duplicate it. See the commentary in projectreuse.go.
-		checkout, err = resolveGitCheckout(dir)
+		// have it open in a workspace it holds none for (one from an older build of
+		// this plugin, say), and the question of whether this is even a Git checkout
+		// belongs to herdr rather than to a local Git command that might not answer.
+		// Everything uncertain is settled here, before anything is created. See the
+		// commentary in projectreuse.go.
+		checkout, err = resolveCheckoutForReuse(client, dir)
 		if err != nil {
 			return err
-		}
-		if checkout != nil {
-			open, err := legacyOpenCheckout(client, *checkout)
-			if err != nil {
-				return err
-			}
-			if open != "" {
-				return fmt.Errorf("workspace %s already has %s checked out, but herdr holds no checkout provenance for it — so it cannot be identified as this project. Nothing was created or changed. Close that workspace and open the project again, or open the checkout through herdr's own worktree open so it carries provenance", open, checkout.Path)
-			}
 		}
 	}
 

--- a/projects.go
+++ b/projects.go
@@ -23,12 +23,53 @@ import (
 // herdr-plugin.toml) — zoomed by default, or the placement set by
 // [projects].placement in config.toml. herdr creates and tears down that pane for
 // us, so — unlike the old design — there is no throwaway workspace to manage.
-func launchProjects() {
+//
+// With [projects].crew_tab configured the action gains one step in front of that:
+// fired from inside a linked worktree workspace, it returns to that workspace's
+// task tab instead of offering a picker, so the same key both starts work and
+// comes back to it. Nothing is created or relaid on that path — see returnToCrew.
+// `projects --pick` skips the step entirely when you do want another project.
+func launchProjects(args []string) {
+	pick, err := parseProjectsArgs(args)
+	if err != nil {
+		errExit(err)
+	}
+
 	cfg, err := loadPluginConfig()
 	if err != nil {
 		errExit(err)
 	}
 	placement := resolvePlacement(cfg.Projects.Placement, "zoomed")
+
+	// The context herdr injected for this invocation: the pane the action fired
+	// from. It decides whether there is a Crew to return to, and is forwarded to
+	// the picker pane so the browser runs with the caller's directory in hand.
+	ctx := contextFromPluginEnv()
+
+	if !pick && strings.TrimSpace(cfg.Projects.CrewTab) != "" {
+		pc, err := pluginContextFromEnv()
+		if err != nil {
+			errExit(err)
+		}
+		if strings.TrimSpace(pc.WorkspaceID) != "" {
+			client, err := newHerdrClient()
+			if err != nil {
+				errExit(err)
+			}
+			focused, err := returnToCrew(client, pc, cfg.Projects.CrewTab)
+			if err != nil {
+				errExit(err)
+			}
+			if focused {
+				return
+			}
+		}
+	}
+
+	enc, err := ctx.encode()
+	if err != nil {
+		errExit("could not encode run context:", err)
+	}
 
 	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
 	// call back into the CLI from a plugin command.
@@ -37,10 +78,16 @@ func launchProjects() {
 		herdr = "herdr"
 	}
 
+	// IMPORTANT: no --cwd. The manifest registers this pane with a relative
+	// command (./bin/herdr-plus), which herdr resolves against the pane's working
+	// directory, so the pane must run in the plugin's own install dir. The user's
+	// directory is context data, not an executable lookup path, and reaches the
+	// browser through HERDR_PLUS_CTX — the same way Quick Actions forwards it.
 	cmd := exec.Command(herdr, "plugin", "pane", "open",
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("picker"),
 		"--placement", placement,
+		"--env", "HERDR_PLUS_CTX="+enc,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -93,17 +140,28 @@ func runProjectsUI() {
 		}
 		return
 	}
-	if err := openProject(client, *m.chosen); err != nil {
+	// With [projects].reuse_checkout on, a project whose checkout is already open
+	// focuses that workspace instead of building a second one; several matches ask
+	// which, in this same pane, before anything happens. See reuseOpenCheckout.
+	reuse := reuseOptions{enabled: cfg.Projects.ReuseCheckout}
+	if reuse.enabled {
+		reuse.choose = func(candidates []workspaceCandidate) (workspaceCandidate, bool, error) {
+			return chooseWorkspaceInteractively(candidates, m.chosen.displayWorkingDir())
+		}
+	}
+	if err := openProject(client, *m.chosen, reuse); err != nil {
 		errExit("could not open project:", err)
 	}
 }
 
 // openProject turns a project into a live herdr workspace: it creates a focused
 // workspace rooted at the project's working directory and lays out its tabs and
-// panes, running each startup command. Creating the focused workspace switches
+// panes, running each startup command — unless reuse is enabled and that exact
+// checkout is already open, in which case the existing workspace is focused and
+// nothing is created. Creating the focused workspace switches
 // the user to it; the picker pane this was launched from is then torn down by
 // herdr when runProjectsUI exits.
-func openProject(client *herdrClient, p Project) error {
+func openProject(client *herdrClient, p Project, reuse reuseOptions) error {
 	dir, err := p.expandedWorkingDir()
 	if err != nil {
 		return err
@@ -117,6 +175,20 @@ func openProject(client *herdrClient, p Project) error {
 	// workspace exists — leaving the user an empty workspace to close by hand.
 	if err := checkTabDirs(dir, p.Tabs); err != nil {
 		return err
+	}
+
+	// Before creating anything, ask herdr whether this exact checkout is already
+	// open. A match is focused as it stands — no layout, no startup commands, no
+	// repair — and a failure to find out is an error, never a licence to make a
+	// duplicate. Off by default; see reuseOpenCheckout for the identity rules.
+	if reuse.enabled {
+		reused, err := reuseOpenCheckout(client, dir, reuse.choose)
+		if err != nil {
+			return err
+		}
+		if reused {
+			return nil
+		}
 	}
 
 	ws, rootTab, rootPane, err := client.workspaceCreate(dir, p.Name, true)
@@ -224,13 +296,48 @@ func checkTabDirs(root string, tabs []ProjectTab) error {
 	return err
 }
 
+// resolveSplitTargets resolves, for every pane of every tab, which pane it is
+// split off — the previous one by default, or the pane its split_from names.
+// targets[i][j] is the 0-based index within tab i of the pane that tab i's pane j
+// splits, and -1 for each tab's root pane, which splits nothing.
+//
+// It runs as one pass before any native call so an impossible target is refused
+// while backing out is free. Config loading validates the same rule (see
+// splitTargetIndex), so this is a second, closer guard rather than the only one:
+// layoutTabs is reachable from both projects and worktree layouts.
+func resolveSplitTargets(tabs []ProjectTab) ([][]int, error) {
+	targets := make([][]int, len(tabs))
+	for i, t := range tabs {
+		panes := t.effectivePanes()
+		targets[i] = make([]int, len(panes))
+		for j := range panes {
+			// Check the pane as it was written, not as effectivePanes normalized it:
+			// normalization clears the root pane's split fields, which would hide a
+			// root pane that declared a split_from it cannot have. Only SplitFrom is
+			// read here, so the raw and normalized panes are otherwise equivalent.
+			pane := panes[j]
+			if j < len(t.Panes) {
+				pane = t.Panes[j]
+			}
+			idx, err := splitTargetIndex(j, pane)
+			if err != nil {
+				return nil, fmt.Errorf("tab %q %w", t.Name, err)
+			}
+			targets[i][j] = idx
+		}
+	}
+	return targets, nil
+}
+
 // layoutTabs lays an ordered list of tabs — each with its panes and optional
 // startup commands — into an existing workspace whose root tab and root pane are
 // rootTab and rootPane, and whose own directory is root. tab[0] reuses the root
 // tab (renamed) and root pane; each later tab is created without focus so the
 // first stays in front while the rest spin up. Within a tab the first pane is the
-// tab's root and each later pane is split off the previous one. Every startup
-// command is run last, once all panes exist, paced to its freshly spawned shell.
+// tab's root and each later pane is split off the previous one — or off the
+// earlier pane its split_from names, which is how a full-height edge pane is
+// kept whole. Every startup command is run last, once all panes exist, paced to
+// its freshly spawned shell.
 //
 // root anchors the optional per-tab and per-pane working_dir: a relative one is
 // resolved against it, and a tab or pane that declares none simply inherits it.
@@ -247,6 +354,14 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane, root string, tabs []
 	// found halfway through would otherwise leave a half-built workspace behind,
 	// which is worse than not starting. dirs[i][j] is tab i pane j's directory.
 	dirs, err := resolvePaneDirs(root, tabs)
+	if err != nil {
+		return err
+	}
+
+	// Same reasoning for split targets: resolve every one up front so a layout
+	// that cannot be built is refused before the first native call, not halfway
+	// through. targets[i][j] is the index of the pane tab i pane j splits off.
+	targets, err := resolveSplitTargets(tabs)
 	if err != nil {
 		return err
 	}
@@ -276,15 +391,26 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane, root string, tabs []
 			}
 		}
 
-		prev := tabRoot
+		// panes[j] is the native id of this tab's pane j, so a later pane can be
+		// split off any earlier one rather than only the pane before it. It is
+		// per-tab: a pane index never reaches into another tab's panes.
+		panes := make([]string, len(t.effectivePanes()))
 		for j, pane := range t.effectivePanes() {
 			paneID := tabRoot
 			if j > 0 {
-				paneID, err = client.paneSplit(prev, pane.Split, pane.splitRatio(), dirs[i][j], false)
+				// tabRoot may not be the workspace's original root pane — a first tab
+				// with its own working_dir is rebuilt above — so targets are read from
+				// the ids this invocation actually created.
+				target := panes[targets[i][j]]
+				if target == "" {
+					return fmt.Errorf("tab %q pane %d: split target pane %d was not created", t.Name, j+1, targets[i][j]+1)
+				}
+				paneID, err = client.paneSplit(target, pane.Split, pane.splitRatio(), dirs[i][j], false)
 				if err != nil {
 					return fmt.Errorf("split pane %d in tab %q: %w", j+1, t.Name, err)
 				}
 			}
+			panes[j] = paneID
 			if lbl := strings.TrimSpace(pane.Label); lbl != "" {
 				if err := client.paneRename(paneID, lbl); err != nil {
 					// Labeling is cosmetic — warn but keep building the workspace.
@@ -294,7 +420,6 @@ func layoutTabs(client *herdrClient, ws, rootTab, rootPane, root string, tabs []
 			if strings.TrimSpace(pane.Command) != "" {
 				runs = append(runs, pendingRun{pane: paneID, command: pane.Command})
 			}
-			prev = paneID
 		}
 	}
 

--- a/projects.go
+++ b/projects.go
@@ -181,6 +181,7 @@ func openProject(client *herdrClient, p Project, reuse reuseOptions) error {
 	// open. A match is focused as it stands — no layout, no startup commands, no
 	// repair — and a failure to find out is an error, never a licence to make a
 	// duplicate. Off by default; see reuseOpenCheckout for the identity rules.
+	var checkout *gitCheckout
 	if reuse.enabled {
 		reused, err := reuseOpenCheckout(client, dir, reuse.choose)
 		if err != nil {
@@ -188,6 +189,24 @@ func openProject(client *herdrClient, p Project, reuse reuseOptions) error {
 		}
 		if reused {
 			return nil
+		}
+
+		// No workspace carries provenance for this checkout — but herdr may still
+		// have it open in a workspace it holds no provenance for (one from an older
+		// build of this plugin, say). Read Git's registry, then herdr's, and refuse
+		// rather than duplicate it. See the commentary in projectreuse.go.
+		checkout, err = resolveGitCheckout(dir)
+		if err != nil {
+			return err
+		}
+		if checkout != nil {
+			open, err := legacyOpenCheckout(client, *checkout)
+			if err != nil {
+				return err
+			}
+			if open != "" {
+				return fmt.Errorf("workspace %s already has %s checked out, but herdr holds no checkout provenance for it — so it cannot be identified as this project. Nothing was created or changed. Close that workspace and open the project again, or open the checkout through herdr's own worktree open so it carries provenance", open, checkout.Path)
+			}
 		}
 	}
 
@@ -198,7 +217,22 @@ func openProject(client *herdrClient, p Project, reuse reuseOptions) error {
 
 	// Lay the project's tabs into the new workspace. dir anchors any per-tab or
 	// per-pane working_dir written relative to the project.
-	return layoutTabs(client, ws, rootTab, rootPane, dir, p.Tabs)
+	if err := layoutTabs(client, ws, rootTab, rootPane, dir, p.Tabs); err != nil {
+		return err
+	}
+
+	// The workspace and its layout are finished; now let herdr record which
+	// checkout it holds, so opening this project again returns to it instead of
+	// building a second one. Only for a Git checkout, and only with reuse on —
+	// nothing about the default behavior changes. A failure here leaves the
+	// finished workspace alone and says so: the work is usable, but this
+	// workspace will not be recognized on the next open.
+	if checkout != nil {
+		if err := bindCheckoutProvenance(client, ws, *checkout); err != nil {
+			return fmt.Errorf("%w\n  The workspace is open and laid out; only its checkout binding failed, so opening this project again will not return to it", err)
+		}
+	}
+	return nil
 }
 
 // openProjectAsWorktree creates a git worktree from the project's working

--- a/projects.go
+++ b/projects.go
@@ -140,7 +140,10 @@ func runProjectsUI() {
 			if err != nil {
 				errExit(err)
 			}
-			if err := runPolicyPicker(worktreeRequest{Cwd: dir, Name: m.branch}); err != nil {
+			// The planner takes the raw input. It applies branch_prefix itself, and
+			// only the unprefixed name still matches an existing unprefixed branch —
+			// the case W already reuses without a base query or a fetch.
+			if err := runPolicyPicker(worktreeRequest{Cwd: dir, Name: m.rawBranch}); err != nil {
 				errExit(err)
 			}
 			return

--- a/projects.go
+++ b/projects.go
@@ -32,12 +32,12 @@ import (
 func launchProjects(args []string) {
 	pick, err := parseProjectsArgs(args)
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 
 	cfg, err := loadPluginConfig()
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	placement := resolvePlacement(cfg.Projects.Placement, "zoomed")
 
@@ -49,16 +49,16 @@ func launchProjects(args []string) {
 	if !pick && strings.TrimSpace(cfg.Projects.CrewTab) != "" {
 		pc, err := pluginContextFromEnv()
 		if err != nil {
-			errExit(err)
+			actionErrExit(err)
 		}
 		if strings.TrimSpace(pc.WorkspaceID) != "" {
 			client, err := newHerdrClient()
 			if err != nil {
-				errExit(err)
+				actionErrExit(err)
 			}
 			focused, err := returnToCrew(client, pc, cfg.Projects.CrewTab)
 			if err != nil {
-				errExit(err)
+				actionErrExit(err)
 			}
 			if focused {
 				return
@@ -68,7 +68,7 @@ func launchProjects(args []string) {
 
 	enc, err := ctx.encode()
 	if err != nil {
-		errExit("could not encode run context:", err)
+		actionErrExit("could not encode run context:", err)
 	}
 
 	// HERDR_BIN_PATH points at the running herdr binary; it is the portable way to
@@ -92,7 +92,7 @@ func launchProjects(args []string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		errExit("could not open the projects browser:", err)
+		actionErrExit("could not open the projects browser:", err)
 	}
 }
 

--- a/projects_test.go
+++ b/projects_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,7 +77,7 @@ func TestLaunchProjectsPlacement(t *testing.T) {
 			record := filepath.Join(t.TempDir(), "args.txt")
 			t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
 
-			launchProjects()
+			launchProjects(nil)
 
 			got, err := os.ReadFile(record)
 			if err != nil {
@@ -99,4 +100,273 @@ func containsPlacement(args []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// layoutFixture wires the fake native side for a layoutTabs run: tabs and splits
+// hand back fresh ids, and every id handed out is recorded so a test can assert
+// which pane each split actually targeted.
+type layoutFixture struct {
+	*fakeHerdr
+	next int
+}
+
+func newLayoutFixture(t *testing.T) *layoutFixture {
+	t.Helper()
+	lf := &layoutFixture{fakeHerdr: startFakeHerdr(t)}
+	// Ids say where they came from, so an assertion about a split target reads as
+	// "the second tab's root", not as an opaque counter that could coincide.
+	lf.handleFunc("tab.create", func(request) (any, *herdrError) {
+		lf.next++
+		return map[string]any{
+			"tab":       map[string]any{"tab_id": fmt.Sprintf("t%d", lf.next)},
+			"root_pane": map[string]any{"pane_id": fmt.Sprintf("t%d:root", lf.next)},
+		}, nil
+	})
+	lf.handleFunc("pane.split", func(request) (any, *herdrError) {
+		lf.next++
+		return map[string]any{"pane": map[string]any{"pane_id": fmt.Sprintf("s%d", lf.next)}}, nil
+	})
+	lf.handle("tab.rename", map[string]any{})
+	lf.handle("tab.close", map[string]any{})
+	lf.handle("pane.rename", map[string]any{})
+	return lf
+}
+
+// splitTargets returns the target_pane_id of each pane.split, in call order.
+func (lf *layoutFixture) splitTargets() []string {
+	lf.mu.Lock()
+	defer lf.mu.Unlock()
+	var out []string
+	for _, c := range lf.calls {
+		if c.Method == "pane.split" {
+			out = append(out, fmt.Sprint(c.Params["target_pane_id"]))
+		}
+	}
+	return out
+}
+
+// splitParams returns the params of each pane.split, in call order.
+func (lf *layoutFixture) splitParams() []map[string]any {
+	lf.mu.Lock()
+	defer lf.mu.Unlock()
+	var out []map[string]any
+	for _, c := range lf.calls {
+		if c.Method == "pane.split" {
+			out = append(out, c.Params)
+		}
+	}
+	return out
+}
+
+// TestLayoutTabsSplitFromTargets runs the real layoutTabs against synthetic
+// native IPC and checks which pane each split was actually taken from. The shape
+// under test is the one plain "split the pane before me" cannot express: two
+// full-height edge panes with a worker pair stacked between them.
+func TestLayoutTabsSplitFromTargets(t *testing.T) {
+	lf := newLayoutFixture(t)
+	root := t.TempDir()
+	tabs := []ProjectTab{{
+		Name: "Crew",
+		Panes: []ProjectPane{
+			{Label: "Orchestrator"},
+			{Label: "Issue", Split: SplitRight, SplitFrom: 1, Ratio: 0.25},
+			{Label: "Worker 1", Split: SplitRight, SplitFrom: 1},
+			{Label: "Worker 2", Split: SplitDown, SplitFrom: 3},
+		},
+	}}
+
+	if err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs); err != nil {
+		t.Fatalf("layoutTabs: %v", err)
+	}
+
+	// Panes 2 and 3 both split the root, keeping it full height; pane 4 splits
+	// pane 3 — the pane the second split created — not the pane made just before
+	// it. That is the arrangement a previous-pane chain cannot produce.
+	want := []string{"w1:p1", "w1:p1", "s2"}
+	got := lf.splitTargets()
+	if len(got) != len(want) {
+		t.Fatalf("split targets = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("split %d targeted %q, want %q (all targets: %v)", i+1, got[i], want[i], got)
+		}
+	}
+
+	// Ratios and directions still ride along untouched.
+	params := lf.splitParams()
+	if params[0]["direction"] != SplitRight || params[0]["ratio"] != 0.75 {
+		t.Fatalf("first split params = %v, want a right split keeping 0.75", params[0])
+	}
+	if _, ok := params[1]["ratio"]; ok {
+		t.Fatalf("second split params = %v, want no ratio key for an even split", params[1])
+	}
+	if params[2]["direction"] != SplitDown {
+		t.Fatalf("third split params = %v, want a down split", params[2])
+	}
+}
+
+// TestLayoutTabsWithoutSplitFromIsUnchanged pins the existing behavior: with no
+// split_from anywhere, every pane still splits the one created before it.
+func TestLayoutTabsWithoutSplitFromIsUnchanged(t *testing.T) {
+	lf := newLayoutFixture(t)
+	root := t.TempDir()
+	tabs := []ProjectTab{{
+		Name: "work",
+		Panes: []ProjectPane{
+			{Label: "one"},
+			{Label: "two", Split: SplitDown},
+			{Label: "three", Split: SplitDown},
+		},
+	}}
+
+	if err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs); err != nil {
+		t.Fatalf("layoutTabs: %v", err)
+	}
+	want := []string{"w1:p1", "s1"}
+	got := lf.splitTargets()
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("split targets = %v, want %v (the unchanged previous-pane chain)", got, want)
+	}
+}
+
+// TestLayoutTabsSplitFromIsPerTab confirms a pane index means "in my own tab":
+// the second tab's split_from = 1 targets that tab's own root, never a pane from
+// the tab before it.
+func TestLayoutTabsSplitFromIsPerTab(t *testing.T) {
+	lf := newLayoutFixture(t)
+	root := t.TempDir()
+	tabs := []ProjectTab{
+		{Name: "first", Panes: []ProjectPane{{Label: "a"}, {Label: "b", Split: SplitRight, SplitFrom: 1}}},
+		{Name: "second", Panes: []ProjectPane{{Label: "c"}, {Label: "d", Split: SplitRight, SplitFrom: 1}}},
+	}
+
+	if err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs); err != nil {
+		t.Fatalf("layoutTabs: %v", err)
+	}
+	got := lf.splitTargets()
+	if len(got) != 2 {
+		t.Fatalf("split targets = %v, want two", got)
+	}
+	if got[0] != "w1:p1" {
+		t.Fatalf("first tab split targeted %q, want the workspace root pane", got[0])
+	}
+	if got[1] != "t2:root" {
+		t.Fatalf("second tab split targeted %q, want that tab's own root pane t2:root", got[1])
+	}
+}
+
+// TestLayoutTabsSplitFromAfterRootRebuild covers the awkward case: when the
+// first tab declares its own working_dir the root tab is rebuilt, so pane 1 is a
+// different native pane than the workspace's original root. split_from = 1 must
+// follow the rebuilt root, not the discarded one.
+func TestLayoutTabsSplitFromAfterRootRebuild(t *testing.T) {
+	lf := newLayoutFixture(t)
+	root := t.TempDir()
+	nested := filepath.Join(root, "web")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tabs := []ProjectTab{{
+		Name:       "work",
+		WorkingDir: "web",
+		Panes: []ProjectPane{
+			{Label: "a"},
+			{Label: "b", Split: SplitRight, SplitFrom: 1},
+			{Label: "c", Split: SplitDown, SplitFrom: 1},
+		},
+	}}
+
+	if err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs); err != nil {
+		t.Fatalf("layoutTabs: %v", err)
+	}
+	got := lf.splitTargets()
+	for i, target := range got {
+		if target == "w1:p1" {
+			t.Fatalf("split %d targeted the replaced root pane %q; targets: %v", i+1, target, got)
+		}
+		if target != "t1:root" {
+			t.Fatalf("split %d targeted %q, want the rebuilt tab's root pane t1:root; targets: %v", i+1, target, got)
+		}
+	}
+}
+
+// TestLayoutTabsRejectsBadSplitFromBeforeMutating is the safety property: an
+// impossible split target stops the layout before a single native call, so a
+// mistyped config never leaves half a workspace behind.
+func TestLayoutTabsRejectsBadSplitFromBeforeMutating(t *testing.T) {
+	lf := newLayoutFixture(t)
+	root := t.TempDir()
+	tabs := []ProjectTab{{
+		Name:  "work",
+		Panes: []ProjectPane{{Label: "a"}, {Label: "b", Split: SplitDown, SplitFrom: 7}},
+	}}
+
+	err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs)
+	if err == nil || !strings.Contains(err.Error(), "split_from") {
+		t.Fatalf("want a split_from error, got %v", err)
+	}
+	if len(lf.methods()) != 0 {
+		t.Fatalf("native calls %v; an invalid layout must not touch anything", lf.methods())
+	}
+}
+
+// TestLayoutTabsRunsCommandsAfterEveryPaneExists confirms the ordering the
+// layout has always had: panes are all created first, then startup commands are
+// typed — so a command never runs in a workspace that is still being built.
+func TestLayoutTabsRunsCommandsAfterEveryPaneExists(t *testing.T) {
+	lf := newLayoutFixture(t)
+	lf.handleFunc("pane.read", func(request) (any, *herdrError) {
+		// A settled pane echoing back whatever was typed, so runCommand's
+		// readiness and echo checks resolve immediately instead of timing out.
+		return map[string]any{"read": map[string]any{"text": "$ htop lazygit"}}, nil
+	})
+	lf.handle("pane.send_input", map[string]any{})
+
+	root := t.TempDir()
+	tabs := []ProjectTab{{
+		Name: "work",
+		Panes: []ProjectPane{
+			{Label: "a", Command: "htop"},
+			{Label: "b", Split: SplitRight, SplitFrom: 1, Command: "lazygit"},
+		},
+	}}
+
+	if err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", root, tabs); err != nil {
+		t.Fatalf("layoutTabs: %v", err)
+	}
+
+	lastSplit, firstInput := -1, -1
+	for i, m := range lf.methods() {
+		if m == "pane.split" {
+			lastSplit = i
+		}
+		if m == "pane.send_input" && firstInput < 0 {
+			firstInput = i
+		}
+	}
+	if lastSplit < 0 || firstInput < 0 || firstInput < lastSplit {
+		t.Fatalf("calls %v; every pane must exist before the first startup command is typed", lf.methods())
+	}
+}
+
+// TestLayoutTabsRejectsRootSplitFromBeforeMutating covers the root pane rule at
+// the executor: a tab whose first pane declares a split_from is refused before
+// any native call. The check has to read the authored config — pane
+// normalization clears the root pane's split fields, so validating the
+// normalized panes would silently accept it.
+func TestLayoutTabsRejectsRootSplitFromBeforeMutating(t *testing.T) {
+	lf := newLayoutFixture(t)
+	tabs := []ProjectTab{{
+		Name:  "work",
+		Panes: []ProjectPane{{Label: "a", SplitFrom: 2}, {Label: "b", Split: SplitDown}},
+	}}
+
+	err := layoutTabs(lf.client(), "w1", "w1:t1", "w1:p1", t.TempDir(), tabs)
+	if err == nil || !strings.Contains(err.Error(), "splits nothing") {
+		t.Fatalf("want a root-pane split_from error, got %v", err)
+	}
+	if len(lf.methods()) != 0 {
+		t.Fatalf("native calls %v; an invalid layout must not touch anything", lf.methods())
+	}
 }

--- a/projectsmodel.go
+++ b/projectsmodel.go
@@ -107,8 +107,14 @@ type projectsModel struct {
 	branchInput  textinput.Model
 	branchPrefix string
 	worktree     bool
-	branch       string
-	quitting     bool
+	// branch is the name the legacy herdr-native worktree path uses: the typed
+	// input with branch_prefix already applied. rawBranch is the input exactly as
+	// typed, which is what the shared planner needs — it does its own prefixing,
+	// and only the unprefixed name can still match an existing branch that has no
+	// prefix. Prefixing before the planner sees it loses that branch.
+	branch    string
+	rawBranch string
+	quitting  bool
 
 	// Path-prompt state for projects with working_dir = "{prompt}": the input,
 	// the last validation error, and whether the worktree branch prompt should
@@ -327,13 +333,14 @@ func (m projectsModel) updateBranch(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.worktree = true
+			m.rawBranch = strings.TrimSpace(m.branchInput.Value())
 			m.branch = resolveWorktreeBranch(m.branchInput.Value(), m.branchPrefix)
 			return m, tea.Quit
 		case "esc":
 			m.mode = modeList
 			m.chosen = nil
 			m.worktree = false
-			m.branch = ""
+			m.branch, m.rawBranch = "", ""
 			return m, nil
 		}
 
@@ -388,7 +395,7 @@ func (m projectsModel) promptWorktreeBranch() (tea.Model, tea.Cmd) {
 // continue-to-branch step, so both arrive with a clean input.
 func (m projectsModel) enterBranchMode() (tea.Model, tea.Cmd) {
 	m.worktree = false
-	m.branch = ""
+	m.branch, m.rawBranch = "", ""
 	m.branchInput.SetValue("")
 	m.branchInput.Prompt = ""
 	m.branchInput.Placeholder = "empty → generated name"

--- a/quickactions.go
+++ b/quickactions.go
@@ -7,28 +7,49 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
+	"time"
 )
 
 // launchQuickActions is the Quick Actions action's entry point. herdr runs it
 // server-side (from the plugin action / keybinding), so it has no terminal of its
-// own. It captures the focused pane's context (working directory, workspace) from
-// the env herdr injects, then asks herdr to open the action picker as a pane —
-// overlay by default, or the placement set by [quick_actions].placement in
-// config.toml — passing the encoded context along so the chosen command runs in
-// the directory you launched from, not the picker's. herdr creates the pane and,
-// when the picker exits, tears it down and restores your previous focus.
+// own. It verifies the pane the action fired from, then asks herdr to open the
+// action picker as a pane over that pane — overlay by default, or the placement
+// set by [quick_actions].placement in config.toml — passing the encoded context
+// along so the chosen command runs in the directory you launched from, not the
+// picker's. herdr creates the pane and, when the picker exits, tears it down and
+// restores your previous focus.
+//
+// The invoking pane is established explicitly, exactly as the worktree action
+// does it: the picker is placed with --target-pane over the pane named in the
+// action context, never over whatever pane holds global focus by the time herdr
+// gets here — that may belong to another client's window. Failures are reported
+// through actionErrExit so they appear as a notification rather than only in the
+// plugin log, since this action has no terminal to print to.
 func launchQuickActions() {
-	ctx := contextFromPluginEnv()
+	pc, err := pluginContextFromEnv()
+	if err != nil {
+		actionErrExit(err)
+	}
+	client, err := newHerdrClient()
+	if err != nil {
+		actionErrExit(err)
+	}
+	client.timeout = 15 * time.Second
+	ctx, err := quickActionsInvocation(client, pc)
+	if err != nil {
+		actionErrExit(err)
+	}
 	enc, err := ctx.encode()
 	if err != nil {
-		errExit("could not encode run context:", err)
+		actionErrExit("could not encode run context:", err)
 	}
 
 	cfg, err := loadPluginConfig()
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	placement := resolvePlacement(cfg.QuickActions.Placement, "overlay")
 
@@ -44,6 +65,10 @@ func launchQuickActions() {
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("quick-actions-picker"),
 		"--placement", placement,
+		// Place the picker over the pane that invoked the action. target_pane_id
+		// is independent of placement in the native schema, so this pins where the
+		// overlay lands without changing which placement the user configured.
+		"--target-pane", ctx.PaneId,
 		// Hand the launch context to the picker as a single shell-safe env var.
 		"--env", "HERDR_PLUS_CTX=" + enc,
 	}
@@ -57,10 +82,15 @@ func launchQuickActions() {
 	// the per-repo action lookup. So --cwd was purely cosmetic; dropping it loses
 	// nothing and matches how the projects pane (which never set it) already works.
 
-	cmd := exec.Command(herdr, args...)
+	// Bounded like the worktree action's launch: a herdr CLI that never returns
+	// must not leave the action hanging with no terminal to interrupt.
+	deadline, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(deadline, herdr, args...)
+	cmd.WaitDelay = time.Second
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		errExit("could not open the quick-actions picker:", err)
+		actionErrExit("could not open the quick-actions picker:", err)
 	}
 }

--- a/quickactions.go
+++ b/quickactions.go
@@ -23,11 +23,20 @@ import (
 // restores your previous focus.
 //
 // The invoking pane is established explicitly, exactly as the worktree action
-// does it: the picker is placed with --target-pane over the pane named in the
-// action context, never over whatever pane holds global focus by the time herdr
-// gets here — that may belong to another client's window. Failures are reported
-// through actionErrExit so they appear as a notification rather than only in the
-// plugin log, since this action has no terminal to print to.
+// does it: the context herdr injected is proved against the live pane before
+// anything opens, so a pane that has moved, changed workspace or changed
+// directory refuses the launch instead of running the chosen command somewhere
+// the user is not. The working directory the picker and its actions use is that
+// verified pane's own, never whatever pane holds global focus by the time herdr
+// gets here — that may belong to another client's window.
+//
+// Where the picker is *drawn* is native's decision for the configured
+// placement: a split, tab or zoomed pane is opened with --target-pane over the
+// invoking pane, while an overlay or popup covers the active pane because herdr
+// refuses an explicit target for those (see placementAcceptsTargetPane).
+// Failures are reported through actionErrExit so they appear as a notification
+// rather than only in the plugin log, since this action has no terminal to
+// print to.
 func launchQuickActions() {
 	pc, err := pluginContextFromEnv()
 	if err != nil {
@@ -65,13 +74,15 @@ func launchQuickActions() {
 		"--plugin", pluginID,
 		"--entrypoint", paneEntrypoint("quick-actions-picker"),
 		"--placement", placement,
-		// Place the picker over the pane that invoked the action. target_pane_id
-		// is independent of placement in the native schema, so this pins where the
-		// overlay lands without changing which placement the user configured.
-		"--target-pane", ctx.PaneId,
-		// Hand the launch context to the picker as a single shell-safe env var.
-		"--env", "HERDR_PLUS_CTX=" + enc,
 	}
+	// Name the invoking pane only where herdr honors it. An overlay or popup
+	// targets the active pane by native design and refuses an explicit one, so
+	// asking would fail the launch outright rather than place it more precisely.
+	if placementAcceptsTargetPane(placement) {
+		args = append(args, "--target-pane", ctx.PaneId)
+	}
+	// Hand the launch context to the picker as a single shell-safe env var.
+	args = append(args, "--env", "HERDR_PLUS_CTX="+enc)
 	// IMPORTANT: do not add --cwd here. The manifest registers this pane with a
 	// relative command (./bin/herdr-plus), which herdr resolves against the pane's
 	// working directory — so the pane must run in the plugin's own install dir for

--- a/quickactions_test.go
+++ b/quickactions_test.go
@@ -13,6 +13,39 @@ import (
 	"testing"
 )
 
+// quickActionsInvoker wires a verifiable invoking pane: the action context herdr
+// injects, and a fake herdr that answers pane.get with the matching pane. It
+// returns the fake and the invoking directory.
+func quickActionsInvoker(t *testing.T) (*fakeHerdr, string) {
+	t.Helper()
+	dir := t.TempDir()
+	f := startFakeHerdr(t)
+	f.handle("pane.get", map[string]any{"pane": map[string]any{
+		"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": dir,
+	}})
+	setPluginContext(t, map[string]any{
+		"workspace_id":       "w1",
+		"workspace_label":    "Repo",
+		"workspace_cwd":      "/somewhere/else",
+		"tab_id":             "w1:t1",
+		"tab_label":          "Task",
+		"focused_pane_id":    "w1:p2",
+		"focused_pane_cwd":   dir,
+		"focused_pane_agent": "claude",
+	})
+	return f, dir
+}
+
+// argValue returns the value that follows flag in the recorded argv.
+func argValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
 // TestLaunchQuickActionsPlacement mirrors TestLaunchProjectsPlacement for the
 // quick-actions picker, whose built-in default is overlay rather than zoomed.
 func TestLaunchQuickActionsPlacement(t *testing.T) {
@@ -28,6 +61,7 @@ func TestLaunchQuickActionsPlacement(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			quickActionsInvoker(t)
 			configDir := t.TempDir()
 			t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
 			if c.configToml != "" {
@@ -49,6 +83,97 @@ func TestLaunchQuickActionsPlacement(t *testing.T) {
 			if !containsPlacement(args, c.want) {
 				t.Fatalf("recorded args %v do not contain --placement %q", args, c.want)
 			}
+		})
+	}
+}
+
+// The Quick Actions picker is placed over the pane the action fired from, and
+// the chosen command runs in that pane's directory. Both have to come from the
+// explicit action context, verified against herdr — not from whatever pane holds
+// global focus by the time herdr runs this server-side action.
+func TestLaunchQuickActionsTargetsTheVerifiedInvokingPane(t *testing.T) {
+	f, dir := quickActionsInvoker(t)
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", t.TempDir())
+	record := filepath.Join(t.TempDir(), "args.txt")
+	t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+	launchQuickActions()
+
+	raw, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("read recorded args: %v", err)
+	}
+	args := strings.Split(string(raw), "\n")
+	if got, ok := argValue(args, "--target-pane"); !ok || got != "w1:p2" {
+		t.Fatalf("picker was not placed over the invoking pane: %v", args)
+	}
+	if _, ok := argValue(args, "--cwd"); ok {
+		t.Fatalf("--cwd would break the plugin executable's relative command: %v", args)
+	}
+
+	// The launch directory still reaches the picker, and the commands it runs,
+	// through the encoded context — not through the pane's own working directory.
+	encoded, ok := argValue(args, "--env")
+	if !ok || !strings.HasPrefix(encoded, "HERDR_PLUS_CTX=") {
+		t.Fatalf("no encoded context was handed to the picker: %v", args)
+	}
+	ctx, err := decodeRunContext(strings.TrimPrefix(encoded, "HERDR_PLUS_CTX="))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.WorkDir != dir {
+		t.Fatalf("carried working directory %q, want the invoking pane's %q", ctx.WorkDir, dir)
+	}
+	// Everything herdr supplied is still carried; the guard adds proof, not loss.
+	if ctx.PaneId != "w1:p2" || ctx.TabId != "w1:t1" || ctx.TabLabel != "Task" || ctx.WorkspaceId != "w1" || ctx.WorkspaceLabel != "Repo" || ctx.Agent != "claude" {
+		t.Fatalf("guard dropped context herdr supplied: %+v", ctx)
+	}
+	f.assertNotCalled("pane.list")
+	f.assertNoMutations()
+}
+
+// Every way the invoking pane cannot be established must stop before a pane is
+// opened, so the picker is never placed over a pane the user is not in.
+func TestQuickActionsInvocationRefusesUnprovenPanes(t *testing.T) {
+	dir := t.TempDir()
+	valid := pluginContext{WorkspaceID: "w1", TabID: "w1:t1", FocusedPaneID: "w1:p2", FocusedPaneCwd: dir}
+	for _, tc := range []struct {
+		name    string
+		context func(pluginContext) pluginContext
+		pane    map[string]any
+	}{
+		{"no invoking workspace", func(pc pluginContext) pluginContext { pc.WorkspaceID = ""; return pc }, nil},
+		{"no invoking pane", func(pc pluginContext) pluginContext { pc.FocusedPaneID = ""; return pc }, nil},
+		{"no invoking directory", func(pc pluginContext) pluginContext { pc.FocusedPaneCwd = ""; return pc }, nil},
+		{"relative invoking directory", func(pc pluginContext) pluginContext { pc.FocusedPaneCwd = "relative"; return pc }, nil},
+		{"workspace cwd is not a pane directory", func(pc pluginContext) pluginContext {
+			pc.FocusedPaneCwd, pc.WorkspaceCwd = "", dir
+			return pc
+		}, nil},
+		{"pane moved to another workspace", nil, map[string]any{"pane_id": "w1:p2", "workspace_id": "w-other", "tab_id": "w1:t1", "cwd": dir}},
+		{"pane answered for another id", nil, map[string]any{"pane_id": "w1:p9", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": dir}},
+		{"pane moved to another directory", nil, map[string]any{"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": t.TempDir()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := startFakeHerdr(t)
+			if tc.pane != nil {
+				f.handle("pane.get", map[string]any{"pane": tc.pane})
+			} else {
+				f.handle("pane.get", map[string]any{"pane": map[string]any{
+					"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": dir,
+				}})
+			}
+			pc := valid
+			if tc.context != nil {
+				pc = tc.context(valid)
+			}
+			if ctx, err := quickActionsInvocation(f.client(), pc); err == nil {
+				t.Fatalf("accepted an unproven invoking pane: %+v", ctx)
+			}
+			// Nothing native was changed. That the refusal also stops before the
+			// herdr CLI is opened is proved end to end by the quick-actions cases
+			// in TestActionFailureIsVisibleAndNotificationIsBounded.
+			f.assertNoMutations()
 		})
 	}
 }

--- a/quickactions_test.go
+++ b/quickactions_test.go
@@ -104,8 +104,10 @@ func TestLaunchQuickActionsTargetsTheVerifiedInvokingPane(t *testing.T) {
 		t.Fatalf("read recorded args: %v", err)
 	}
 	args := strings.Split(string(raw), "\n")
-	if got, ok := argValue(args, "--target-pane"); !ok || got != "w1:p2" {
-		t.Fatalf("picker was not placed over the invoking pane: %v", args)
+	// The default placement is overlay, which herdr refuses to combine with an
+	// explicit target pane, so the launch must not ask for one.
+	if got, ok := argValue(args, "--target-pane"); ok {
+		t.Fatalf("overlay launch named a target pane %q; herdr rejects that: %v", got, args)
 	}
 	if _, ok := argValue(args, "--cwd"); ok {
 		t.Fatalf("--cwd would break the plugin executable's relative command: %v", args)
@@ -173,6 +175,128 @@ func TestQuickActionsInvocationRefusesUnprovenPanes(t *testing.T) {
 			// Nothing native was changed. That the refusal also stops before the
 			// herdr CLI is opened is proved end to end by the quick-actions cases
 			// in TestActionFailureIsVisibleAndNotificationIsBounded.
+			f.assertNoMutations()
+		})
+	}
+}
+
+// herdr 0.9 refuses `--target-pane` for an overlay or popup plugin pane:
+// `invalid_params: overlay and popup plugin panes target the active pane`, with
+// no pane created. Naming one broke every launch at the default placement, so
+// the flag must appear only for the placements that honor it.
+func TestLaunchQuickActionsOnlyTargetsPanesWherePlacementAllowsIt(t *testing.T) {
+	for _, tc := range []struct {
+		placement string
+		wantFlag  bool
+	}{
+		{"overlay", false},
+		{"popup", false},
+		{"split", true},
+		{"tab", true},
+		{"zoomed", true},
+	} {
+		t.Run(tc.placement, func(t *testing.T) {
+			quickActionsInvoker(t)
+			configDir := t.TempDir()
+			t.Setenv("HERDR_PLUGIN_CONFIG_DIR", configDir)
+			config := "[quick_actions]\nplacement = \"" + tc.placement + "\"\n"
+			if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(config), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			record := filepath.Join(t.TempDir(), "args.txt")
+			t.Setenv("HERDR_BIN_PATH", writeArgRecordingHerdr(t, record))
+
+			launchQuickActions()
+
+			raw, err := os.ReadFile(record)
+			if err != nil {
+				t.Fatalf("read recorded args: %v", err)
+			}
+			args := strings.Split(string(raw), "\n")
+			if !containsPlacement(args, tc.placement) {
+				t.Fatalf("placement %q was not passed through: %v", tc.placement, args)
+			}
+			got, ok := argValue(args, "--target-pane")
+			if ok != tc.wantFlag {
+				t.Fatalf("placement %q: --target-pane present=%v (%q), want present=%v: %v",
+					tc.placement, ok, got, tc.wantFlag, args)
+			}
+			if tc.wantFlag && got != "w1:p2" {
+				t.Fatalf("placement %q targeted %q, want the invoking pane w1:p2", tc.placement, got)
+			}
+			// Whatever the placement, the launch context still carries the
+			// verified invoking pane and its directory: losing the placement
+			// flag must not lose the identity behind it.
+			encoded, ok := argValue(args, "--env")
+			if !ok || !strings.HasPrefix(encoded, "HERDR_PLUS_CTX=") {
+				t.Fatalf("no encoded context: %v", args)
+			}
+			ctx, err := decodeRunContext(strings.TrimPrefix(encoded, "HERDR_PLUS_CTX="))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ctx.PaneId != "w1:p2" || ctx.WorkspaceId != "w1" {
+				t.Fatalf("placement %q lost the verified invoking context: %+v", tc.placement, ctx)
+			}
+		})
+	}
+}
+
+// The worktree picker is always an overlay, so it must never name a target pane.
+func TestPlacementTargetPaneRuleMatchesInstalledHerdr(t *testing.T) {
+	for placement, want := range map[string]bool{
+		"overlay": false, "popup": false, "split": true, "tab": true, "zoomed": true,
+	} {
+		if got := placementAcceptsTargetPane(placement); got != want {
+			t.Errorf("placementAcceptsTargetPane(%q) = %v, want %v", placement, got, want)
+		}
+	}
+	// Every placement the config accepts has a decided answer here.
+	for placement := range validPanePlacements {
+		_ = placementAcceptsTargetPane(placement)
+	}
+}
+
+// The guard compares the pane's foreground working directory, falling back to
+// the pane's own. That preference is what makes it the directory a command
+// would actually run in, so both halves are pinned here: narrowing the guard to
+// pane.cwd would silently compare the wrong directory.
+func TestInvokingPaneGuardFollowsTheForegroundDirectory(t *testing.T) {
+	foreground := t.TempDir()
+	shell := t.TempDir()
+	for _, tc := range []struct {
+		name       string
+		pane       map[string]any
+		invokedCwd string
+		accept     bool
+	}{
+		{"foreground directory is the one compared", map[string]any{
+			"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1",
+			"foreground_cwd": foreground, "cwd": shell,
+		}, foreground, true},
+		{"the pane's own directory does not stand in for it", map[string]any{
+			"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1",
+			"foreground_cwd": foreground, "cwd": shell,
+		}, shell, false},
+		{"absent foreground falls back to the pane directory", map[string]any{
+			"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": shell,
+		}, shell, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := startFakeHerdr(t)
+			f.handle("pane.get", map[string]any{"pane": tc.pane})
+			pc := pluginContext{WorkspaceID: "w1", TabID: "w1:t1", FocusedPaneID: "w1:p2", FocusedPaneCwd: tc.invokedCwd}
+			ctx, err := quickActionsInvocation(f.client(), pc)
+			if tc.accept {
+				if err != nil {
+					t.Fatalf("refused the verified invoking pane: %v", err)
+				}
+				if ctx.WorkDir != tc.invokedCwd {
+					t.Fatalf("carried %q, want %q", ctx.WorkDir, tc.invokedCwd)
+				}
+			} else if err == nil {
+				t.Fatalf("accepted a directory the foreground process is not in: %+v", ctx)
+			}
 			f.assertNoMutations()
 		})
 	}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,21 +6,32 @@
 #
 # Build herdr-plus for `herdr plugin install`. herdr runs this as the manifest's
 # [[build]] step after cloning the repo, in the plugin root, with no plugin
-# context and no guaranteed Go toolchain.
+# context.
 #
-# Prefer a local Go toolchain — it builds the exact cloned source. When Go is
-# absent, fall back to downloading the latest prebuilt release binary via
-# install.sh, so installing the plugin works without Go. Either way the result is
-# ./bin/herdr-plus, which the manifest's actions and panes invoke.
+# A Go toolchain is required. The plugin must be the exact source herdr just
+# checked out, so this script only ever runs `go build` against this directory.
+# There is deliberately no fallback to a prebuilt release binary: a published
+# release does not contain the code in this checkout, so installing it would
+# silently run something other than what was reviewed. A missing toolchain or a
+# failed compile fails the install instead. The result is ./bin/herdr-plus,
+# which the manifest's actions and panes invoke.
 
 set -eu
 
-mkdir -p bin
-
-if command -v go >/dev/null 2>&1; then
-	echo "herdr-plus: building from source (go build)…" >&2
-	exec go build -o bin/herdr-plus .
+if ! command -v go >/dev/null 2>&1; then
+	printf '%s\n' \
+		'herdr-plus: no Go toolchain found on PATH.' \
+		'' \
+		'This plugin is built from the source herdr just checked out, so a Go' \
+		'toolchain is required. There is no prebuilt-binary fallback, because a' \
+		'published release does not contain the code in this checkout.' \
+		'' \
+		'Install Go from https://go.dev/dl/, make sure `go` is on PATH, then run' \
+		'`herdr plugin install` again.' >&2
+	exit 1
 fi
 
-echo "herdr-plus: no Go toolchain found — downloading the latest prebuilt binary…" >&2
-INSTALL_DIR="$(pwd)/bin" sh install.sh
+mkdir -p bin
+
+echo "herdr-plus: building from source (go build)…" >&2
+exec go build -o bin/herdr-plus .

--- a/worktree.go
+++ b/worktree.go
@@ -187,6 +187,7 @@ type worktreeEvent struct {
 	RepoRoot     string
 	Branch       string
 	CheckoutPath string
+	AlreadyOpen  bool
 }
 
 // worktreeCreatedPayload mirrors the JSON herdr puts in HERDR_PLUGIN_EVENT_JSON
@@ -194,7 +195,8 @@ type worktreeEvent struct {
 // Only the fields we use are declared.
 type worktreeCreatedPayload struct {
 	Data struct {
-		Workspace struct {
+		AlreadyOpen bool `json:"already_open"`
+		Workspace   struct {
 			WorkspaceID string `json:"workspace_id"`
 			ActiveTabID string `json:"active_tab_id"`
 			Worktree    struct {
@@ -223,6 +225,7 @@ func parseWorktreeEvent(eventJSON string, getenv func(string) string) (worktreeE
 		}
 	}
 	return worktreeEvent{
+		AlreadyOpen:  p.Data.AlreadyOpen,
 		WorkspaceID:  firstNonEmpty(getenv("HERDR_WORKSPACE_ID"), p.Data.Workspace.WorkspaceID),
 		RootTabID:    firstNonEmpty(getenv("HERDR_TAB_ID"), p.Data.Workspace.ActiveTabID),
 		RootPaneID:   getenv("HERDR_PANE_ID"),
@@ -246,6 +249,13 @@ func runOnWorktreeEvent(_ []string) {
 	ev, err := parseWorktreeEvent(os.Getenv("HERDR_PLUGIN_EVENT_JSON"), os.Getenv)
 	if err != nil {
 		errExit("worktree event:", err)
+	}
+	// A native reopen can return an existing workspace with just one pane.
+	// That pane may be busy or intentionally customized; its count does not
+	// authorize applying a new layout over it.
+	if ev.AlreadyOpen {
+		fmt.Printf("herdr-plus: worktree workspace %q is already open; leaving its layout intact.\n", ev.WorkspaceID)
+		return
 	}
 
 	layouts, err := loadWorktreeLayouts()
@@ -279,9 +289,16 @@ func runOnWorktreeEvent(_ []string) {
 	// handler can fire for a workspace we already laid out. A freshly created or
 	// opened worktree workspace has exactly one (root) pane, so more than one pane
 	// means the layout is already in place and we skip rather than stack a second
-	// copy of the tabs on top. A pane.list error returns 0, which fails open
-	// (proceeds) rather than wrongly skipping.
-	if n, err := client.workspacePaneCount(ev.WorkspaceID); err == nil && n > 1 {
+	// copy of the tabs on top. Failed or empty inventory cannot establish that
+	// this workspace is fresh, so leave it untouched and report the failure.
+	n, err := client.workspacePaneCount(ev.WorkspaceID)
+	if err != nil {
+		errExit("inspect worktree workspace before layout:", err)
+	}
+	if n == 0 {
+		errExit("worktree workspace has no reported panes; refusing layout")
+	}
+	if n > 1 {
 		fmt.Printf("herdr-plus: worktree workspace %q already has %d panes; skipping layout %q (already applied).\n", ev.WorkspaceID, n, layout.source)
 		return
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -291,16 +291,21 @@ func runOnWorktreeEvent(_ []string) {
 	// means the layout is already in place and we skip rather than stack a second
 	// copy of the tabs on top. Failed or empty inventory cannot establish that
 	// this workspace is fresh, so leave it untouched and report the failure.
-	n, err := client.workspacePaneCount(ev.WorkspaceID)
+	panes, err := client.workspacePanes(ev.WorkspaceID)
 	if err != nil {
 		errExit("inspect worktree workspace before layout:", err)
 	}
+	n := len(panes)
 	if n == 0 {
 		errExit("worktree workspace has no reported panes; refusing layout")
 	}
 	if n > 1 {
 		fmt.Printf("herdr-plus: worktree workspace %q already has %d panes; skipping layout %q (already applied).\n", ev.WorkspaceID, n, layout.source)
 		return
+	}
+
+	if panes[0].PaneID != ev.RootPaneID || panes[0].TabID != ev.RootTabID {
+		errExit("worktree pane inventory does not match the event root; refusing layout")
 	}
 
 	if err := layoutTabs(client, ev.WorkspaceID, ev.RootTabID, ev.RootPaneID, ev.CheckoutPath, layout.Tabs); err != nil {

--- a/worktreeguard_test.go
+++ b/worktreeguard_test.go
@@ -33,7 +33,14 @@ func TestWorktreeEventInventoryGuard(t *testing.T) {
 		{"empty inventory", `{"result":{"panes":[]}}`, false, false},
 		{"missing inventory", `{"result":{}}`, false, false},
 		{"unrelated workspace only", `{"result":{"panes":[{"workspace_id":"w2","pane_id":"w2:p1"}]}}`, false, false},
-		{"existing layout", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1"},{"workspace_id":"w1","pane_id":"w1:p2"}]}}`, true, false},
+		{"existing layout", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t1"},{"workspace_id":"w1","pane_id":"w1:p2","tab_id":"w1:t1"}]}}`, true, false},
+		{"missing pane identity", `{"result":{"panes":[{"workspace_id":"w1"}]}}`, false, false},
+		{"partly attributed inventory", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t1"},{"pane_id":"w1:p2","tab_id":"w1:t1"}]}}`, false, false},
+		{"null pane", `{"result":{"panes":[null]}}`, false, false},
+		{"duplicate pane", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t1"},{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t1"}]}}`, false, false},
+		{"wrong root pane", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p9","tab_id":"w1:t1"}]}}`, false, false},
+		{"wrong root tab", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t9"}]}}`, false, false},
+		{"fresh single root", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1","tab_id":"w1:t1"}]}}`, true, false},
 		{"native already open", "", true, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,8 +78,10 @@ func TestWorktreeEventInventoryGuard(t *testing.T) {
 					}
 					if json.NewDecoder(conn).Decode(&req) == nil {
 						calls = append(calls, req.Method)
-						if req.Method == "pane.list" {
+						if req.Method == "pane.list" && req.Params["workspace_id"] == "w1" {
 							_, _ = conn.Write([]byte(tc.reply + "\n"))
+						} else if req.Method == "tab.rename" && tc.name == "fresh single root" {
+							_, _ = conn.Write([]byte("{\"result\":{}}\n"))
 						} else {
 							_, _ = conn.Write([]byte("{\"error\":{\"code\":\"unexpected_mutation\",\"message\":\"inventory did not authorize layout\"}}\n"))
 						}
@@ -105,6 +114,9 @@ func TestWorktreeEventInventoryGuard(t *testing.T) {
 			var wantCalls []string
 			if !tc.alreadyOpen {
 				wantCalls = []string{"pane.list"}
+			}
+			if tc.name == "fresh single root" {
+				wantCalls = append(wantCalls, "tab.rename")
 			}
 			if !reflect.DeepEqual(calls, wantCalls) {
 				t.Fatalf("layout proceeded without inventory proof: %v; output=%s", calls, out)

--- a/worktreeguard_test.go
+++ b/worktreeguard_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Drive the real event entrypoint: failed inventory must never authorize a
+// tab rename or split, even though a matching layout is configured.
+func TestWorktreeEventInventoryGuard(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix IPC fixture; Windows runtime is a separate gate")
+	}
+	bin := filepath.Join(t.TempDir(), "herdr-plus")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	for _, tc := range []struct {
+		name, reply string
+		wantSuccess bool
+		alreadyOpen bool
+	}{
+		{"native error", `{"error":{"code":"unavailable","message":"inventory unavailable"}}`, false, false},
+		{"empty inventory", `{"result":{"panes":[]}}`, false, false},
+		{"missing inventory", `{"result":{}}`, false, false},
+		{"unrelated workspace only", `{"result":{"panes":[{"workspace_id":"w2","pane_id":"w2:p1"}]}}`, false, false},
+		{"existing layout", `{"result":{"panes":[{"workspace_id":"w1","pane_id":"w1:p1"},{"workspace_id":"w1","pane_id":"w1:p2"}]}}`, true, false},
+		{"native already open", "", true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			config := t.TempDir()
+			if err := os.Mkdir(filepath.Join(config, "worktrees"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(config, "worktrees", "crew.toml"), []byte("repo = \"*\"\n[[tabs]]\nname = \"Crew\"\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			// Short socket paths are required on macOS.
+			dir, err := os.MkdirTemp("", "wtguard-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			socket := filepath.Join(dir, "s")
+			listener, err := net.Listen("unix", socket)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan []string, 1)
+			go func() {
+				var calls []string
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						done <- calls
+						return
+					}
+					_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+					var req struct {
+						Method string         `json:"method"`
+						Params map[string]any `json:"params"`
+					}
+					if json.NewDecoder(conn).Decode(&req) == nil {
+						calls = append(calls, req.Method)
+						if req.Method == "pane.list" {
+							_, _ = conn.Write([]byte(tc.reply + "\n"))
+						} else {
+							_, _ = conn.Write([]byte("{\"error\":{\"code\":\"unexpected_mutation\",\"message\":\"inventory did not authorize layout\"}}\n"))
+						}
+					}
+					conn.Close()
+				}
+			}()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, "on-worktree")
+			event := `{"data":{"already_open":false,"workspace":{"worktree":{"repo_name":"fixture"}},"worktree":{"branch":"fixture"}}}`
+			if tc.alreadyOpen {
+				event = `{"data":{"already_open":true,"workspace":{"worktree":{"repo_name":"fixture"}},"worktree":{"branch":"fixture"}}}`
+			}
+			cmd.Env = []string{
+				"PATH=" + os.Getenv("PATH"), "HOME=" + config,
+				"HERDR_PLUGIN_CONFIG_DIR=" + config, "HERDR_SOCKET_PATH=" + socket,
+				"HERDR_WORKSPACE_ID=w1", "HERDR_TAB_ID=w1:t1", "HERDR_PANE_ID=w1:p1",
+				"HERDR_PLUGIN_EVENT_JSON=" + event,
+			}
+			out, runErr := cmd.CombinedOutput()
+			listener.Close()
+			calls := <-done
+			if ctx.Err() != nil {
+				t.Fatal("event handler exceeded fixture deadline")
+			}
+			if (runErr == nil) != tc.wantSuccess {
+				t.Fatalf("success=%v want=%v: %s", runErr == nil, tc.wantSuccess, out)
+			}
+			var wantCalls []string
+			if !tc.alreadyOpen {
+				wantCalls = []string{"pane.list"}
+			}
+			if !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("layout proceeded without inventory proof: %v; output=%s", calls, out)
+			}
+		})
+	}
+}

--- a/worktreepolicy.go
+++ b/worktreepolicy.go
@@ -185,6 +185,8 @@ func canonicalDestination(path string) (string, error) {
 	}
 }
 
+var errNoWorktreePolicy = errors.New("no configured worktree policy")
+
 func policyForCheckout(cfg PluginConfig, primary string) (WorktreePolicy, error) {
 	var matches []WorktreePolicy
 	for _, policy := range cfg.Worktree.Projects {
@@ -220,10 +222,45 @@ func policyForCheckout(cfg PluginConfig, primary string) (WorktreePolicy, error)
 		}
 		matches = append(matches, policy)
 	}
+	if len(matches) == 0 {
+		return WorktreePolicy{}, fmt.Errorf("expected one worktree policy for %s, found 0: %w", primary, errNoWorktreePolicy)
+	}
 	if len(matches) != 1 {
 		return WorktreePolicy{}, fmt.Errorf("expected one worktree policy for %s, found %d", primary, len(matches))
 	}
 	return matches[0], nil
+}
+
+// Projects retains its legacy path only when this repository has no policy.
+// Invalid or ambiguous configuration must not silently select another route.
+func projectUsesSharedWorktreePolicy(cfg PluginConfig, cwd string) (bool, error) {
+	if len(cfg.Worktree.Projects) == 0 {
+		return false, nil
+	}
+	canonical, err := canonicalPath(cwd)
+	if err != nil {
+		return false, err
+	}
+	listing, err := ensureGit(canonical, 10*time.Second, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return false, err
+	}
+	records, err := parseGitWorktreeList(canonical, listing)
+	if err != nil {
+		return false, err
+	}
+	if len(records) == 0 {
+		return false, errors.New("project has no primary Git checkout")
+	}
+	primary, err := canonicalPath(records[0].Path)
+	if err != nil {
+		return false, err
+	}
+	_, err = policyForCheckout(cfg, primary)
+	if errors.Is(err, errNoWorktreePolicy) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 // Resolve against the remote itself. A stale local origin/HEAD is not evidence of
@@ -363,7 +400,10 @@ func planWorktree(req worktreeRequest) (worktreePlan, error) {
 	}
 	plan = worktreePlan{Version: 1, Project: policy.Name, Repository: primary, Issue: strings.ToUpper(req.Issue), Candidates: []worktreeChoice{}}
 	for name := range heads {
-		if name != branch && name != req.Name && !matchesIssue(name, req.Issue) {
+		if req.Issue != "" && !matchesIssue(name, req.Issue) {
+			continue
+		}
+		if req.Issue == "" && name != branch && name != req.Name {
 			continue
 		}
 		path, checkedOut := paths[name]

--- a/worktreepolicy.go
+++ b/worktreepolicy.go
@@ -355,13 +355,16 @@ func planWorktree(req worktreeRequest) (worktreePlan, error) {
 			req.Issue = match[1]
 		}
 	}
-	branch, err := policyBranch(cfg.Worktree.BranchPrefix, req.Name, req.Issue, policy.MaxTail)
+	// Validate configuration independently from a hypothetical new name.
+	// Existing branch names and issue matches need no normalization.
+	probe, err := policyBranch(cfg.Worktree.BranchPrefix, "valid", "", policy.MaxTail)
 	if err != nil {
 		return plan, err
 	}
-	if err := ensureBranchName(primary, "branch", branch); err != nil {
+	if err := ensureBranchName(primary, "branch prefix", probe); err != nil {
 		return plan, err
 	}
+	branch, nameErr := policyBranch(cfg.Worktree.BranchPrefix, req.Name, req.Issue, policy.MaxTail)
 	refs, err := ensureGit(primary, 10*time.Second, "for-each-ref", "--format=%(refname)%00%(objectname)", "refs/heads/")
 	if err != nil {
 		return plan, err
@@ -413,6 +416,12 @@ func planWorktree(req worktreeRequest) (worktreePlan, error) {
 		plan.Candidates = append(plan.Candidates, worktreeChoice{Branch: name, Path: path, Existing: true, Checkout: checkedOut})
 	}
 	if len(plan.Candidates) == 0 {
+		if nameErr != nil {
+			return plan, nameErr
+		}
+		if err := ensureBranchName(primary, "branch", branch); err != nil {
+			return plan, err
+		}
 		plan.Base, plan.BaseOID, err = policyRemoteBase(primary, policy.Base)
 		if err != nil {
 			return plan, err

--- a/worktreepolicy.go
+++ b/worktreepolicy.go
@@ -149,6 +149,42 @@ func matchesIssue(branch, issue string) bool {
 	return regexp.MustCompile(pattern).MatchString(branch)
 }
 
+// canonicalDestination gives an absolute path that does not exist yet the same
+// single spelling canonicalPath gives an existing one. It resolves the deepest
+// ancestor that does exist and reattaches the components that do not, so a root
+// reached through a symlink is identified by the directory it physically lands
+// in. It creates nothing: planning stays read-only, and a destination whose
+// ancestor is a file — or unreadable — is an error rather than a guess.
+func canonicalDestination(path string) (string, error) {
+	if !filepath.IsAbs(path) || strings.ContainsRune(path, 0) {
+		return "", fmt.Errorf("%q is not an absolute path", path)
+	}
+	current := filepath.Clean(path)
+	var missing []string
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			info, err := os.Stat(resolved)
+			if err != nil {
+				return "", err
+			}
+			if !info.IsDir() {
+				return "", fmt.Errorf("%s is not a directory", current)
+			}
+			return filepath.Join(append([]string{resolved}, missing...)...), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("%q has no existing ancestor directory", path)
+		}
+		missing = append([]string{filepath.Base(current)}, missing...)
+		current = parent
+	}
+}
+
 func policyForCheckout(cfg PluginConfig, primary string) (WorktreePolicy, error) {
 	var matches []WorktreePolicy
 	for _, policy := range cfg.Worktree.Projects {
@@ -173,6 +209,14 @@ func policyForCheckout(cfg PluginConfig, primary string) (WorktreePolicy, error)
 		policy.Root, err = expandPath(policy.Root)
 		if err != nil || !filepath.IsAbs(policy.Root) {
 			return WorktreePolicy{}, errors.New("project root must expand to an absolute path")
+		}
+		// The root is a destination, not an existing directory, so it cannot be
+		// canonicalized outright. Resolving the ancestors it does have gives the
+		// plan a physical identity: a retargeted symlink above the root then
+		// changes the fingerprint instead of silently redirecting the checkout.
+		policy.Root, err = canonicalDestination(policy.Root)
+		if err != nil {
+			return WorktreePolicy{}, fmt.Errorf("resolve configured root %s: %w", policy.Name, err)
 		}
 		matches = append(matches, policy)
 	}
@@ -392,5 +436,17 @@ func applyWorktreePlan(req worktreeRequest, plan worktreePlan) (json.RawMessage,
 	if !selected.Existing {
 		args = append(args, "--base", plan.Base)
 	}
-	return ensureWorktree(args)
+	// The flags above name the selection; the snapshot below is what the user
+	// actually accepted. ensure-worktree reads Git again, and without the
+	// snapshot its fresh answer would silently become the decision — a moved
+	// checkout opened instead of the chosen one, or a base that advanced between
+	// the plan and the fetch.
+	return ensureWorktreeSelected(args, &worktreeSelection{
+		Repository: plan.Repository,
+		Branch:     selected.Branch,
+		Path:       selected.Path,
+		Checkout:   selected.Checkout,
+		Existing:   selected.Existing,
+		BaseOID:    plan.BaseOID,
+	})
 }

--- a/worktreepolicy.go
+++ b/worktreepolicy.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Personal names and paths belong in configuration, shared by every UI caller.
+type WorktreePolicy struct {
+	Name       string `toml:"name" json:"name"`
+	Repository string `toml:"repository" json:"repository"`
+	Root       string `toml:"root" json:"root"`
+	MaxTail    int    `toml:"max_tail" json:"max_tail"`
+	Base       string `toml:"base" json:"base,omitempty"`
+}
+
+type worktreeRequest struct {
+	Cwd, Name, Issue, Candidate, Fingerprint string
+}
+
+type worktreeChoice struct {
+	ID       string `json:"id"`
+	Branch   string `json:"branch"`
+	Path     string `json:"path"`
+	Existing bool   `json:"existing"`
+	Checkout bool   `json:"checkout"`
+}
+
+type worktreePlan struct {
+	Version     int              `json:"version"`
+	Project     string           `json:"project"`
+	Repository  string           `json:"repository"`
+	Issue       string           `json:"issue,omitempty"`
+	Base        string           `json:"base,omitempty"`
+	BaseOID     string           `json:"base_oid,omitempty"`
+	Candidates  []worktreeChoice `json:"candidates"`
+	Fingerprint string           `json:"fingerprint"`
+}
+
+func parseWorktreeRequest(args []string, apply bool) (worktreeRequest, error) {
+	var req worktreeRequest
+	f := flag.NewFlagSet("worktree policy", flag.ContinueOnError)
+	f.SetOutput(io.Discard)
+	seen := map[string]bool{}
+	for _, spec := range []struct {
+		name  string
+		value *string
+	}{
+		{"cwd", &req.Cwd}, {"name", &req.Name}, {"issue", &req.Issue},
+		{"candidate", &req.Candidate}, {"fingerprint", &req.Fingerprint},
+	} {
+		f.Func(spec.name, spec.name, func(value string) error {
+			if seen[spec.name] {
+				return fmt.Errorf("duplicate --%s", spec.name)
+			}
+			seen[spec.name] = true
+			*spec.value = value
+			return nil
+		})
+	}
+	if err := f.Parse(args); err != nil {
+		return req, err
+	}
+	if f.NArg() != 0 || !filepath.IsAbs(req.Cwd) || strings.TrimSpace(req.Name) == "" {
+		return req, errors.New("explicit absolute --cwd and nonempty --name are required")
+	}
+	if apply && (req.Candidate == "" || req.Fingerprint == "") {
+		return req, errors.New("apply-worktree requires a candidate and fingerprint from plan-worktree")
+	}
+	if !apply && (seen["candidate"] || seen["fingerprint"]) {
+		return req, errors.New("candidate and fingerprint are apply-worktree flags")
+	}
+	return req, nil
+}
+
+func runWorktreePolicy(command string, args []string) {
+	req, err := parseWorktreeRequest(args, command == "apply-worktree")
+	if err != nil {
+		errExit(err)
+	}
+	plan, err := planWorktree(req)
+	if err != nil {
+		errExit(err)
+	}
+	if command == "plan-worktree" {
+		if err := json.NewEncoder(os.Stdout).Encode(plan); err != nil {
+			errExit(err)
+		}
+		return
+	}
+	result, err := applyWorktreePlan(req, plan)
+	if err != nil {
+		errExit(err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(struct {
+		Result json.RawMessage `json:"result"`
+	}{result}); err != nil {
+		errExit(err)
+	}
+}
+
+var issuePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-[1-9][0-9]*$`)
+var leadingIssuePattern = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9]*-[1-9][0-9]*)(?:[^A-Za-z0-9]|$)`)
+var slugBreak = regexp.MustCompile(`[^a-z0-9]+`)
+
+func policyBranch(prefix, name, issue string, limit int) (string, error) {
+	if prefix == "" || !strings.HasSuffix(prefix, "/") {
+		return "", errors.New("worktree.branch_prefix must end in /")
+	}
+	name = strings.TrimPrefix(strings.TrimSpace(name), prefix)
+	tail := strings.Trim(slugBreak.ReplaceAllString(strings.ToLower(name), "-"), "-")
+	if issue != "" {
+		if !issuePattern.MatchString(issue) {
+			return "", errors.New("invalid issue identifier")
+		}
+		id := strings.ToLower(issue)
+		if tail != id && !strings.HasPrefix(tail, id+"-") {
+			tail = id + "-" + tail
+		}
+	}
+	if limit < 1 || limit > 200 {
+		return "", errors.New("project max_tail must be between 1 and 200")
+	}
+	if len(tail) > limit {
+		tail = strings.TrimRight(tail[:limit], "-")
+	}
+	if tail == "" || (issue != "" && len(tail) < len(issue)) {
+		return "", errors.New("project max_tail leaves no complete issue/name")
+	}
+	return prefix + tail, nil
+}
+
+func matchesIssue(branch, issue string) bool {
+	if issue == "" {
+		return false
+	}
+	pattern := `(?i)(^|[/_-])` + regexp.QuoteMeta(issue) + `($|[/_-])`
+	return regexp.MustCompile(pattern).MatchString(branch)
+}
+
+func policyForCheckout(cfg PluginConfig, primary string) (WorktreePolicy, error) {
+	var matches []WorktreePolicy
+	for _, policy := range cfg.Worktree.Projects {
+		if policy.Repository == "" {
+			return WorktreePolicy{}, errors.New("worktree project repository is required")
+		}
+		expanded, err := expandPath(policy.Repository)
+		if err != nil || !filepath.IsAbs(expanded) {
+			return WorktreePolicy{}, errors.New("worktree project repository must expand to an absolute path")
+		}
+		canonical, err := canonicalPath(expanded)
+		if err != nil {
+			return WorktreePolicy{}, fmt.Errorf("resolve configured repository %s: %w", policy.Name, err)
+		}
+		if canonical != primary {
+			continue
+		}
+		if policy.Name == "" || policy.Root == "" {
+			return WorktreePolicy{}, errors.New("project name and root are required")
+		}
+		policy.Repository = canonical
+		policy.Root, err = expandPath(policy.Root)
+		if err != nil || !filepath.IsAbs(policy.Root) {
+			return WorktreePolicy{}, errors.New("project root must expand to an absolute path")
+		}
+		matches = append(matches, policy)
+	}
+	if len(matches) != 1 {
+		return WorktreePolicy{}, fmt.Errorf("expected one worktree policy for %s, found %d", primary, len(matches))
+	}
+	return matches[0], nil
+}
+
+// Resolve against the remote itself. A stale local origin/HEAD is not evidence of
+// today's remote default, and a failed query never means "main".
+func policyRemoteBase(repo, override string) (string, string, error) {
+	args := []string{"ls-remote", "--symref", "origin", "HEAD"}
+	if override != "" {
+		if err := ensureBranchName(repo, "base", override); err != nil {
+			return "", "", err
+		}
+		args = []string{"ls-remote", "origin", "refs/heads/" + override}
+	}
+	out, err := ensureGit(repo, 30*time.Second, args...)
+	if err != nil {
+		return "", "", err
+	}
+	branch, oid := override, ""
+	refs, objects := 0, 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		left, right, ok := strings.Cut(line, "\t")
+		if !ok {
+			return "", "", errors.New("malformed remote base response")
+		}
+		if strings.HasPrefix(left, "ref: refs/heads/") && right == "HEAD" && override == "" {
+			refs++
+			branch = strings.TrimPrefix(left, "ref: refs/heads/")
+			continue
+		}
+		expectedRef := "HEAD"
+		if override != "" {
+			expectedRef = "refs/heads/" + override
+		}
+		if right != expectedRef {
+			return "", "", errors.New("unexpected remote base ref")
+		}
+		if len(left) != 40 && len(left) != 64 {
+			return "", "", errors.New("invalid remote object id")
+		}
+		if _, err := hex.DecodeString(left); err != nil {
+			return "", "", errors.New("invalid remote object id")
+		}
+		objects++
+		oid = left
+	}
+	if objects != 1 || (override == "" && refs != 1) {
+		return "", "", errors.New("remote default branch is missing or ambiguous; configure a project base explicitly")
+	}
+	if err := ensureBranchName(repo, "base", branch); err != nil {
+		return "", "", err
+	}
+	return branch, oid, nil
+}
+
+func planWorktree(req worktreeRequest) (worktreePlan, error) {
+	var plan worktreePlan
+	if !filepath.IsAbs(req.Cwd) || strings.TrimSpace(req.Name) == "" {
+		return plan, errors.New("explicit cwd/name required")
+	}
+	if req.Issue != "" && !issuePattern.MatchString(req.Issue) {
+		return plan, errors.New("invalid issue identifier")
+	}
+	cwd, err := canonicalPath(req.Cwd)
+	if err != nil {
+		return plan, err
+	}
+	listing, err := ensureGit(cwd, 10*time.Second, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return plan, err
+	}
+	records, err := parseGitWorktreeList(cwd, listing)
+	if err != nil {
+		return plan, err
+	}
+	if len(records) == 0 || records[0].Bare {
+		return plan, errors.New("shared worktree policy requires a non-bare primary checkout")
+	}
+	primary, err := canonicalPath(records[0].Path)
+	if err != nil {
+		return plan, err
+	}
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		return plan, err
+	}
+	policy, err := policyForCheckout(cfg, primary)
+	if err != nil {
+		return plan, err
+	}
+	if req.Issue == "" {
+		name := strings.TrimPrefix(strings.TrimSpace(req.Name), cfg.Worktree.BranchPrefix)
+		if match := leadingIssuePattern.FindStringSubmatch(name); len(match) > 1 {
+			req.Issue = match[1]
+		}
+	}
+	branch, err := policyBranch(cfg.Worktree.BranchPrefix, req.Name, req.Issue, policy.MaxTail)
+	if err != nil {
+		return plan, err
+	}
+	if err := ensureBranchName(primary, "branch", branch); err != nil {
+		return plan, err
+	}
+	refs, err := ensureGit(primary, 10*time.Second, "for-each-ref", "--format=%(refname)%00%(objectname)", "refs/heads/")
+	if err != nil {
+		return plan, err
+	}
+	heads := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSuffix(string(refs), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		ref, oid, ok := strings.Cut(line, "\x00")
+		if !ok || !strings.HasPrefix(ref, "refs/heads/") || (len(oid) != 40 && len(oid) != 64) {
+			return plan, errors.New("malformed local branch inventory")
+		}
+		if _, err := hex.DecodeString(oid); err != nil {
+			return plan, errors.New("malformed local branch object id")
+		}
+		name := strings.TrimPrefix(ref, "refs/heads/")
+		if _, exists := heads[name]; exists {
+			return plan, errors.New("duplicate local branch inventory")
+		}
+		heads[name] = oid
+	}
+	paths := map[string]string{}
+	for _, record := range records {
+		if record.Ref == "" {
+			continue
+		}
+		name := strings.TrimPrefix(record.Ref, "refs/heads/")
+		if _, exists := paths[name]; exists {
+			return plan, errors.New("ambiguous registered branch checkouts")
+		}
+		if _, exists := heads[name]; !exists {
+			return plan, errors.New("worktree registry disagrees with local branches")
+		}
+		paths[name] = record.Path
+	}
+	plan = worktreePlan{Version: 1, Project: policy.Name, Repository: primary, Issue: strings.ToUpper(req.Issue), Candidates: []worktreeChoice{}}
+	for name := range heads {
+		if name != branch && name != req.Name && !matchesIssue(name, req.Issue) {
+			continue
+		}
+		path, checkedOut := paths[name]
+		if !checkedOut {
+			path = filepath.Join(policy.Root, strings.ReplaceAll(name, "/", "--"))
+		}
+		plan.Candidates = append(plan.Candidates, worktreeChoice{Branch: name, Path: path, Existing: true, Checkout: checkedOut})
+	}
+	if len(plan.Candidates) == 0 {
+		plan.Base, plan.BaseOID, err = policyRemoteBase(primary, policy.Base)
+		if err != nil {
+			return plan, err
+		}
+		plan.Candidates = append(plan.Candidates, worktreeChoice{Branch: branch, Path: filepath.Join(policy.Root, strings.ReplaceAll(branch, "/", "--"))})
+	}
+	sort.Slice(plan.Candidates, func(i, j int) bool { return plan.Candidates[i].Branch < plan.Candidates[j].Branch })
+	for i := range plan.Candidates {
+		c := &plan.Candidates[i]
+		hash := sha256.Sum256([]byte(c.Branch + "\x00" + c.Path))
+		c.ID = hex.EncodeToString(hash[:])
+	}
+	data, err := json.Marshal(struct {
+		Plan                   worktreePlan
+		Policy                 WorktreePolicy
+		Prefix, Registry, Refs string
+	}{plan, policy, cfg.Worktree.BranchPrefix, string(listing), string(refs)})
+	if err != nil {
+		return plan, err
+	}
+	hash := sha256.Sum256(data)
+	plan.Fingerprint = hex.EncodeToString(hash[:])
+	return plan, nil
+}
+
+func applyWorktreePlan(req worktreeRequest, plan worktreePlan) (json.RawMessage, error) {
+	if req.Fingerprint == "" || req.Fingerprint != plan.Fingerprint {
+		return nil, errors.New("worktree plan changed; refresh and choose again")
+	}
+	var selected *worktreeChoice
+	for i := range plan.Candidates {
+		if plan.Candidates[i].ID == req.Candidate {
+			selected = &plan.Candidates[i]
+		}
+	}
+	if selected == nil {
+		return nil, errors.New("selected worktree candidate is no longer available")
+	}
+	client, err := newHerdrClient()
+	if err != nil {
+		return nil, err
+	}
+	client.timeout = 30 * time.Second
+	entries, err := client.worktreeList(plan.Repository)
+	if err != nil {
+		return nil, err
+	}
+	var parentIDs []string
+	for _, entry := range entries {
+		if samePath(entry.Path, plan.Repository) && entry.OpenWorkspaceID != nil {
+			parentIDs = append(parentIDs, *entry.OpenWorkspaceID)
+		}
+	}
+	if len(parentIDs) != 1 || !workspaceIDPattern.MatchString(parentIDs[0]) {
+		return nil, errors.New("open the primary-checkout project first; no worktree was created")
+	}
+	args := []string{"--cwd", plan.Repository, "--branch", selected.Branch, "--workspace", parentIDs[0], "--focus"}
+	if !selected.Checkout {
+		args = append(args, "--path", selected.Path)
+	}
+	if !selected.Existing {
+		args = append(args, "--base", plan.Base)
+	}
+	return ensureWorktree(args)
+}

--- a/worktreepolicy_test.go
+++ b/worktreepolicy_test.go
@@ -55,6 +55,59 @@ func TestPolicyPlansRemoteDefaultWithoutMutating(t *testing.T) {
 	}
 }
 
+func TestPolicyExplicitIssueCannotReuseAnUnrelatedExactName(t *testing.T) {
+	for _, name := range []string{"cleanup", "ingwon/ic-1770-other"} {
+		t.Run(name, func(t *testing.T) {
+			repo, _ := policyFixture(t)
+			runGit(t, repo, "branch", name)
+			plan, err := planWorktree(worktreeRequest{Cwd: repo, Name: name, Issue: "IC-177"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(plan.Candidates) != 1 || plan.Candidates[0].Existing || !matchesIssue(plan.Candidates[0].Branch, "IC-177") {
+				t.Fatalf("explicit issue selected an unrelated branch: %+v", plan)
+			}
+			runGit(t, repo, "branch", "team/ic-177-existing")
+			plan, err = planWorktree(worktreeRequest{Cwd: repo, Name: name, Issue: "IC-177"})
+			if err != nil || len(plan.Candidates) != 1 || plan.Candidates[0].Branch != "team/ic-177-existing" {
+				t.Fatalf("whole-issue branch must be the only existing choice: %+v %v", plan, err)
+			}
+		})
+	}
+}
+
+func TestPolicyProjectsRouteBySelectedRepository(t *testing.T) {
+	repo, _ := policyFixture(t)
+	linked := addWorktree(t, repo, "linked")
+	other := newGitRepo(t)
+	bare := t.TempDir()
+	runGit(t, bare, "init", "--bare")
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []struct {
+		cwd    string
+		shared bool
+	}{{repo, true}, {linked, true}, {other, false}, {bare, false}} {
+		shared, err := projectUsesSharedWorktreePolicy(cfg, item.cwd)
+		if err != nil || shared != item.shared {
+			t.Fatalf("route for %s = %v, %v; want shared=%v", item.cwd, shared, err, item.shared)
+		}
+	}
+	duplicate := cfg
+	duplicate.Worktree.Projects = append(append([]WorktreePolicy{}, cfg.Worktree.Projects...), cfg.Worktree.Projects[0])
+	if shared, err := projectUsesSharedWorktreePolicy(duplicate, repo); err == nil || shared {
+		t.Fatal("duplicate policy must refuse, not choose a route")
+	}
+	malformed := cfg
+	malformed.Worktree.Projects = append([]WorktreePolicy{}, cfg.Worktree.Projects...)
+	malformed.Worktree.Projects[0].Root = ""
+	if shared, err := projectUsesSharedWorktreePolicy(malformed, repo); err == nil || shared {
+		t.Fatal("malformed matching policy must not fall back to legacy")
+	}
+}
+
 func TestPolicyPreservesWholeIssueCandidatesAndOldPaths(t *testing.T) {
 	repo, origin := policyFixture(t)
 	old := addWorktree(t, repo, "old/IC-177-original")

--- a/worktreepolicy_test.go
+++ b/worktreepolicy_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func policyFixture(t *testing.T) (string, string) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+	repo := newGitRepo(t)
+	origin := newGitRepo(t)
+	runGit(t, origin, "branch", "-m", "trunk")
+	runGit(t, repo, "remote", "add", "origin", origin)
+	config := t.TempDir()
+	t.Setenv("HERDR_PLUGIN_CONFIG_DIR", config)
+	root := filepath.Join(t.TempDir(), "flat worktrees")
+	contents := fmt.Sprintf("[worktree]\nbranch_prefix = 'ingwon/'\n[[worktree.projects]]\nname = 'fixture'\nrepository = '%s'\nroot = '%s'\nmax_tail = 29\n", repo, root)
+	if err := os.WriteFile(filepath.Join(config, "config.toml"), []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return repo, origin
+}
+
+func TestPolicyPlansRemoteDefaultWithoutMutating(t *testing.T) {
+	repo, _ := policyFixture(t)
+	before := runGit(t, repo, "show-ref", "--heads")
+	plan, err := planWorktree(worktreeRequest{Cwd: repo, Name: "Fix The Layout's Very Long Description", Issue: "HSYS-4619"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := plan.Candidates[0]
+	if plan.Base != "trunk" || len(plan.BaseOID) != 40 || !strings.HasPrefix(c.Branch, "ingwon/hsys-4619-") || len(strings.TrimPrefix(c.Branch, "ingwon/")) > 29 {
+		t.Fatalf("wrong remote/name policy: %+v", plan)
+	}
+	if filepath.Base(c.Path) != strings.ReplaceAll(c.Branch, "/", "--") {
+		t.Fatal(c)
+	}
+	if _, err := os.Stat(filepath.Dir(c.Path)); !os.IsNotExist(err) {
+		t.Fatalf("planning created directories: %v", err)
+	}
+	if after := runGit(t, repo, "show-ref", "--heads"); before != after {
+		t.Fatal("planning changed refs")
+	}
+	if got := runGit(t, repo, "for-each-ref", "refs/remotes/"); got != "" {
+		t.Fatal("planning fetched remote refs")
+	}
+}
+
+func TestPolicyPreservesWholeIssueCandidatesAndOldPaths(t *testing.T) {
+	repo, origin := policyFixture(t)
+	old := addWorktree(t, repo, "old/IC-177-original")
+	runGit(t, repo, "branch", "another/ic-177-local")
+	runGit(t, repo, "branch", "ingwon/ic-1770-other")
+	// Existing candidates need neither base discovery nor a reachable remote.
+	runGit(t, repo, "remote", "set-url", "origin", filepath.Join(origin, "missing"))
+	plan, err := planWorktree(worktreeRequest{Cwd: old, Name: "New title", Issue: "IC-177"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Repository != repo || plan.Base != "" || len(plan.Candidates) != 2 {
+		t.Fatalf("wrong candidates: %+v", plan)
+	}
+	for _, c := range plan.Candidates {
+		if !c.Existing || strings.Contains(c.Branch, "1770") {
+			t.Fatal(c)
+		}
+		if c.Checkout && c.Path != old {
+			t.Fatalf("renamed existing checkout: %+v", c)
+		}
+	}
+	fromW, err := planWorktree(worktreeRequest{Cwd: old, Name: "ingwon/IC-177 new description"})
+	if err != nil || len(fromW.Candidates) != 2 || fromW.Issue != "IC-177" {
+		t.Fatalf("W and L issue matching disagree: %+v %v", fromW, err)
+	}
+}
+
+func TestPolicyDefaultFailuresAndDuplicateConfigRefuse(t *testing.T) {
+	repo, _ := policyFixture(t)
+	runGit(t, repo, "remote", "remove", "origin")
+	if _, err := planWorktree(worktreeRequest{Cwd: repo, Name: "brand new"}); err == nil {
+		t.Fatal("missing origin guessed a base")
+	}
+	path := filepath.Join(os.Getenv("HERDR_PLUGIN_CONFIG_DIR"), "config.toml")
+	data, _ := os.ReadFile(path)
+	section := string(data[strings.Index(string(data), "[[worktree.projects]]"):])
+	if err := os.WriteFile(path, append(data, []byte(section)...), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := planWorktree(worktreeRequest{Cwd: repo, Name: "main"}); err == nil || !strings.Contains(err.Error(), "found 2") {
+		t.Fatalf("duplicate policy: %v", err)
+	}
+}
+
+func TestPolicyStalePlanAndCancellationNeverMutate(t *testing.T) {
+	repo, _ := policyFixture(t)
+	req := worktreeRequest{Cwd: repo, Name: "main"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint = plan.Fingerprint
+	req.Candidate = plan.Candidates[0].ID
+	runGit(t, repo, "branch", "another-task")
+	fresh, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := startFakeHerdr(t)
+	if _, err := applyWorktreePlan(req, fresh); err == nil {
+		t.Fatal("accepted stale candidate inventory")
+	}
+	req.Fingerprint = fresh.Fingerprint
+	req.Candidate = ""
+	if _, err := applyWorktreePlan(req, fresh); err == nil {
+		t.Fatal("empty choice was treated as consent")
+	}
+	if len(f.methods()) != 0 {
+		t.Fatal("stale/cancelled plan reached native IPC")
+	}
+}
+
+func TestPolicyApplyUsesSharedEnsureAndExplicitParent(t *testing.T) {
+	repo, _ := policyFixture(t)
+	old := addWorktree(t, repo, "legacy/IC-72-kept")
+	req := worktreeRequest{Cwd: old, Name: "new title", Issue: "IC-72"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint = plan.Fingerprint
+	req.Candidate = plan.Candidates[0].ID
+	f := startFakeHerdr(t)
+	f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent"), listedCheckout(old, "wchild")}})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)})
+	f.handleFunc("worktree.open", func(req request) (any, *herdrError) {
+		if req.Params["workspace_id"] != "wparent" || req.Params["cwd"] != nil || req.Params["branch"] != "legacy/IC-72-kept" {
+			t.Errorf("wrong shared native target: %v", req.Params)
+		}
+		return map[string]any{"workspace": map[string]any{"workspace_id": "wchild"}, "root_pane": map[string]any{"pane_id": "wchild:p1"}, "worktree": map[string]any{"branch": "legacy/IC-72-kept", "path": old}, "already_open": true}, nil
+	})
+	if _, err := applyWorktreePlan(req, plan); err != nil {
+		t.Fatal(err)
+	}
+	f.assertNotCalled("worktree.create")
+	f.assertNotCalled("workspace.create")
+}
+
+func TestPolicyNamesAndRequestBoundaries(t *testing.T) {
+	for _, issue := range []string{"IC-1770", "IC-17", "XIC-177"} {
+		if matchesIssue("ingwon/ic-177-description", issue) {
+			t.Fatal("partial issue token matched", issue)
+		}
+	}
+	if _, err := policyBranch("ingwon/", "x", "HSYS-4619", 5); err == nil {
+		t.Fatal("truncated issue token")
+	}
+	for _, args := range [][]string{{"--cwd", "relative", "--name", "x"}, {"--cwd", "/tmp", "--cwd", "/else", "--name", "x"}, {"--cwd", "/tmp", "--name", "x", "--candidate", "unexpected"}} {
+		if _, err := parseWorktreeRequest(args, false); err == nil {
+			t.Fatalf("accepted %v", args)
+		}
+	}
+}
+
+func TestPolicyInvocationNeverUsesAnotherClientsFocus(t *testing.T) {
+	dir := t.TempDir()
+	f := startFakeHerdr(t)
+	f.handle("pane.get", map[string]any{"pane": map[string]any{"pane_id": "w1:p2", "workspace_id": "w1", "tab_id": "w1:t1", "cwd": dir}})
+	pc := pluginContext{WorkspaceID: "w1", FocusedPaneID: "w1:p2", FocusedPaneCwd: dir}
+	ctx, err := policyInvocation(f.client(), pc)
+	if err != nil || ctx.WorkDir != dir || ctx.PaneId != "w1:p2" {
+		t.Fatalf("explicit context: %+v %v", ctx, err)
+	}
+	pc.WorkspaceID = "w-other"
+	if _, err := policyInvocation(f.client(), pc); err == nil {
+		t.Fatal("accepted moved pane")
+	}
+	if _, err := policyInvocation(f.client(), pluginContext{}); err == nil {
+		t.Fatal("empty context fell back to focus")
+	}
+	f.assertNotCalled("pane.list")
+	f.assertNoMutations()
+}
+
+func TestPolicyPickerKeepsFilterAndDoesNotCancelSubmittedWork(t *testing.T) {
+	m := newWorktreeUI(worktreeRequest{Cwd: "/tmp"})
+	updated, _ := m.Update(worktreePlanned{plan: worktreePlan{Candidates: []worktreeChoice{
+		{Branch: "ingwon/alpha", Path: "/tmp/alpha"}, {Branch: "ingwon/beta", Path: "/tmp/beta"},
+	}}})
+	m = updated.(worktreeUI)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("beta")})
+	m = updated.(worktreeUI)
+	if m.list.selectedIndex() != 1 {
+		t.Fatalf("filter selected original index %d", m.list.selectedIndex())
+	}
+	m.busy = true
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatal("picker exited while native operation was outstanding")
+	}
+	m.busy = false
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("idle picker could not cancel")
+	}
+}

--- a/worktreepolicy_test.go
+++ b/worktreepolicy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -144,7 +145,7 @@ func TestPolicyApplyUsesSharedEnsureAndExplicitParent(t *testing.T) {
 		if req.Params["workspace_id"] != "wparent" || req.Params["cwd"] != nil || req.Params["branch"] != "legacy/IC-72-kept" {
 			t.Errorf("wrong shared native target: %v", req.Params)
 		}
-		return map[string]any{"workspace": map[string]any{"workspace_id": "wchild"}, "root_pane": map[string]any{"pane_id": "wchild:p1"}, "worktree": map[string]any{"branch": "legacy/IC-72-kept", "path": old}, "already_open": true}, nil
+		return map[string]any{"workspace": map[string]any{"workspace_id": "wchild"}, "root_pane": map[string]any{"pane_id": "wchild:p1", "workspace_id": "wchild"}, "worktree": map[string]any{"branch": "legacy/IC-72-kept", "path": old}, "already_open": true}, nil
 	})
 	if _, err := applyWorktreePlan(req, plan); err != nil {
 		t.Fatal(err)
@@ -209,5 +210,252 @@ func TestPolicyPickerKeepsFilterAndDoesNotCancelSubmittedWork(t *testing.T) {
 	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd == nil {
 		t.Fatal("idle picker could not cancel")
+	}
+}
+
+// selectionResult is the native reply for a delegated worktree action, shaped
+// the way herdr 0.9 sends one: a workspace, and a root pane that names it.
+func selectionResult(branch, path string) map[string]any {
+	return map[string]any{
+		"workspace": map[string]any{"workspace_id": "wchild"},
+		"root_pane": map[string]any{"pane_id": "wchild:p1", "workspace_id": "wchild"},
+		"worktree":  map[string]any{"branch": branch, "path": path},
+	}
+}
+
+// The accepted candidate names one registered checkout. Between the plan the
+// user confirmed and the Git read inside apply, that registration can move —
+// and opening whatever Git now points at would silently substitute a checkout
+// for the one on screen.
+func TestPolicyApplyRefusesMovedRegisteredCheckout(t *testing.T) {
+	repo, _ := policyFixture(t)
+	old := addWorktree(t, repo, "legacy/IC-72-kept")
+	req := worktreeRequest{Cwd: repo, Name: "new title", Issue: "IC-72"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	if !plan.Candidates[0].Checkout || plan.Candidates[0].Path != old {
+		t.Fatalf("fixture must select the registered checkout: %+v", plan.Candidates)
+	}
+	moved := filepath.Join(t.TempDir(), "moved")
+	f := startFakeHerdr(t)
+	f.handleFunc("worktree.list", func(request) (any, *herdrError) {
+		runGit(t, repo, "worktree", "move", old, moved)
+		return map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}}, nil
+	})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)})
+	f.handle("worktree.open", selectionResult(plan.Candidates[0].Branch, moved))
+	out, err := applyWorktreePlan(req, plan)
+	if err == nil {
+		t.Fatalf("accepted a checkout that moved to %s: %s", moved, out)
+	}
+	if !strings.Contains(err.Error(), old) {
+		t.Fatalf("refusal does not name the selected checkout: %v", err)
+	}
+	f.assertNotCalled("worktree.open")
+	f.assertNotCalled("worktree.create")
+}
+
+// A new branch is created from the commit the plan resolved, not from wherever
+// origin/BASE has moved to by the time the fetch runs.
+func TestPolicyApplyRefusesAdvancedRemoteBase(t *testing.T) {
+	repo, origin := policyFixture(t)
+	req := worktreeRequest{Cwd: repo, Name: "new task"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	if plan.BaseOID == "" || plan.Candidates[0].Existing {
+		t.Fatalf("fixture must plan a new branch from a resolved base: %+v", plan)
+	}
+	f := startFakeHerdr(t)
+	f.handleFunc("worktree.list", func(request) (any, *herdrError) {
+		runGit(t, origin, "commit", "--allow-empty", "-m", "advance after the accepted plan")
+		return map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}}, nil
+	})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)})
+	f.handle("worktree.create", selectionResult(plan.Candidates[0].Branch, plan.Candidates[0].Path))
+	out, err := applyWorktreePlan(req, plan)
+	if err == nil {
+		t.Fatalf("accepted a base that advanced past %s: %s", plan.BaseOID, out)
+	}
+	if !strings.Contains(err.Error(), plan.BaseOID) {
+		t.Fatalf("refusal does not name the accepted base commit: %v", err)
+	}
+	f.assertNotCalled("worktree.create")
+	f.assertNotCalled("worktree.open")
+	if got := runGit(t, repo, "for-each-ref", "refs/heads/"+plan.Candidates[0].Branch); got != "" {
+		t.Fatalf("refused apply created a local branch: %s", got)
+	}
+}
+
+// The configured root is a destination, so its identity is the directory it
+// physically resolves to. Retargeting a symlink above it must change the
+// fingerprint, or a plan accepted for one location applies to another.
+func TestPolicyRootSymlinkParticipatesInFingerprint(t *testing.T) {
+	repo, _ := policyFixture(t)
+	first, second := t.TempDir(), t.TempDir()
+	link := filepath.Join(t.TempDir(), "root")
+	if err := os.Symlink(first, link); err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(os.Getenv("HERDR_PLUGIN_CONFIG_DIR"), "config.toml")
+	data, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadPluginConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config, []byte(strings.ReplaceAll(string(data), cfg.Worktree.Projects[0].Root, link)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	req := worktreeRequest{Cwd: repo, Name: "new task"}
+	before, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	physical, err := filepath.EvalSymlinks(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(before.Candidates[0].Path) != physical {
+		t.Fatalf("candidate kept the symlinked spelling: %s", before.Candidates[0].Path)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(second, link); err != nil {
+		t.Fatal(err)
+	}
+	after, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Fingerprint == after.Fingerprint {
+		t.Fatalf("root moved from %s to %s but the fingerprint stayed %s", first, second, before.Fingerprint)
+	}
+	if before.Candidates[0].Path == after.Candidates[0].Path {
+		t.Fatalf("retargeted root kept candidate path %s", after.Candidates[0].Path)
+	}
+	if _, err := os.Stat(filepath.Join(second, filepath.Base(after.Candidates[0].Path))); !os.IsNotExist(err) {
+		t.Fatalf("planning created the destination: %v", err)
+	}
+}
+
+// Projects' ctrl+g and the worktree action are the same planner. Projects must
+// hand it the name as typed: prefixing first hides an existing unprefixed
+// branch, turning a reuse that needs no remote into a create that does.
+func TestPolicyProjectsAndWorktreeAgreeOnUnprefixedBranch(t *testing.T) {
+	repo, origin := policyFixture(t)
+	runGit(t, repo, "branch", "legacy")
+	// An existing branch needs no base query, so an unreachable origin is only
+	// fatal to a caller that lost the existing name.
+	runGit(t, repo, "remote", "set-url", "origin", filepath.Join(origin, "missing"))
+
+	fromW, err := planWorktree(worktreeRequest{Cwd: repo, Name: "legacy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fromW.Candidates[0].Existing || fromW.Candidates[0].Branch != "legacy" {
+		t.Fatalf("the worktree action lost the existing branch: %+v", fromW.Candidates)
+	}
+
+	m := newProjectsModel([]Project{{Name: "fixture", WorkingDir: repo}}, "", "ingwon/")
+	view, _ := m.promptWorktreeBranch()
+	m = view.(projectsModel)
+	m.branchInput.SetValue("legacy")
+	view, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = view.(projectsModel)
+	if m.rawBranch != "legacy" || m.branch != "ingwon/legacy" {
+		t.Fatalf("projects lost the typed name: raw=%q legacy=%q", m.rawBranch, m.branch)
+	}
+	fromProjects, err := planWorktree(worktreeRequest{Cwd: repo, Name: m.rawBranch})
+	if err != nil {
+		t.Fatalf("projects could not plan an existing branch with an unreachable origin: %v", err)
+	}
+	if fromProjects.Candidates[0].ID != fromW.Candidates[0].ID {
+		t.Fatalf("same typed name planned differently: worktree=%+v projects=%+v", fromW.Candidates, fromProjects.Candidates)
+	}
+}
+
+// Herdr routes a workspace-addressed worktree action through that workspace's
+// stored repo_root. A record that names another repository, or none, is not
+// evidence that the delegated mutation lands in the repository just planned.
+func TestPolicyApplyRefusesUnusableParentProvenance(t *testing.T) {
+	for _, tc := range []struct{ name, repoRoot, diagnostic string }{
+		{"contradictory repo root", "/repo", "repository root"},
+		{"missing repo root", "", "repository root"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, _ := policyFixture(t)
+			runGit(t, repo, "branch", "ingwon/main")
+			req := worktreeRequest{Cwd: repo, Name: "main"}
+			plan, err := planWorktree(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+			f := startFakeHerdr(t)
+			f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
+			f.handle("workspace.get", map[string]any{"workspace": wsInfoWithRoot("wparent", "Primary", repo, tc.repoRoot, false)})
+			f.handle("worktree.open", selectionResult(plan.Candidates[0].Branch, repo))
+			f.handle("worktree.create", selectionResult(plan.Candidates[0].Branch, plan.Candidates[0].Path))
+			if out, err := applyWorktreePlan(req, plan); err == nil {
+				t.Fatalf("accepted repo_root %q against primary %s: %s", tc.repoRoot, repo, out)
+			} else if !strings.Contains(err.Error(), tc.diagnostic) {
+				t.Fatalf("refusal does not explain the provenance gap: %v", err)
+			}
+			f.assertNotCalled("worktree.open")
+			f.assertNotCalled("worktree.create")
+		})
+	}
+}
+
+// The success object is passed on whole. A workspace and a root pane that name
+// different workspaces are two native objects, not one result, and the caller
+// has no basis for treating them as related.
+func TestPolicyRefusesUnusableNativeResultIdentities(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		workspace map[string]any
+		rootPane  map[string]any
+	}{
+		{"pane owned by another workspace", map[string]any{"workspace_id": "w1"}, map[string]any{"pane_id": "w2:p1", "workspace_id": "w2"}},
+		{"pane id disagrees with its own workspace_id", map[string]any{"workspace_id": "w1"}, map[string]any{"pane_id": "w2:p1", "workspace_id": "w1"}},
+		{"pane without an owning workspace", map[string]any{"workspace_id": "w1"}, map[string]any{"pane_id": "w1:p1"}},
+		{"unusable workspace id", map[string]any{"workspace_id": "w 1\n"}, map[string]any{"pane_id": "w 1\n:p1", "workspace_id": "w 1\n"}},
+		{"unusable pane number", map[string]any{"workspace_id": "w1"}, map[string]any{"pane_id": "w1:t1", "workspace_id": "w1"}},
+		{"pane id is only the workspace id", map[string]any{"workspace_id": "w1"}, map[string]any{"pane_id": "w1", "workspace_id": "w1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(map[string]any{
+				"workspace": tc.workspace,
+				"root_pane": tc.rootPane,
+				"worktree":  map[string]any{"branch": "ingwon/task", "path": "/tmp/checkout"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validateEnsureResult(raw, "ingwon/task", "/tmp/checkout"); err == nil {
+				t.Fatalf("accepted %s: %s", tc.name, raw)
+			}
+		})
+	}
+	valid, err := json.Marshal(map[string]any{
+		"workspace":    map[string]any{"workspace_id": "w3V"},
+		"root_pane":    map[string]any{"pane_id": "w3V:p1", "workspace_id": "w3V"},
+		"worktree":     map[string]any{"branch": "ingwon/task", "path": "/tmp/checkout"},
+		"native_extra": "preserved",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateEnsureResult(valid, "ingwon/task", "/tmp/checkout"); err != nil {
+		t.Fatalf("refused a consistent native result: %v", err)
 	}
 }

--- a/worktreepolicy_test.go
+++ b/worktreepolicy_test.go
@@ -577,3 +577,35 @@ func TestPolicyApplyCreatesFromTheImmutableAcceptedBase(t *testing.T) {
 		t.Fatalf("wrong native create target: %v", params)
 	}
 }
+
+// A workspace that holds this very checkout but carries no recorded provenance
+// is refused with its own remedy, not with a claim that it moved. herdr records
+// membership on worktree.open, not on workspace.create, so this is the state a
+// workspace opened outside Plus is in.
+func TestPolicyApplyExplainsMissingParentProvenance(t *testing.T) {
+	repo, _ := policyFixture(t)
+	runGit(t, repo, "branch", "ingwon/main")
+	req := worktreeRequest{Cwd: repo, Name: "main"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	f := startFakeHerdr(t)
+	f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
+	f.handle("workspace.get", map[string]any{"workspace": wsInfoNoProvenance("wparent", "Primary")})
+	f.handle("worktree.open", selectionResult(plan.Candidates[0].Branch, repo))
+	f.handle("worktree.create", selectionResult(plan.Candidates[0].Branch, plan.Candidates[0].Path))
+	_, err = applyWorktreePlan(req, plan)
+	if err == nil {
+		t.Fatal("accepted a parent workspace with no recorded provenance")
+	}
+	if !strings.Contains(err.Error(), "no recorded checkout provenance") {
+		t.Fatalf("refusal does not name the missing provenance: %v", err)
+	}
+	if strings.Contains(err.Error(), "no longer holds") {
+		t.Fatalf("refusal describes a state that is not the case: %v", err)
+	}
+	f.assertNotCalled("worktree.open")
+	f.assertNotCalled("worktree.create")
+}

--- a/worktreepolicy_test.go
+++ b/worktreepolicy_test.go
@@ -384,12 +384,19 @@ func TestPolicyProjectsAndWorktreeAgreeOnUnprefixedBranch(t *testing.T) {
 }
 
 // Herdr routes a workspace-addressed worktree action through that workspace's
-// stored repo_root. A record that names another repository, or none, is not
-// evidence that the delegated mutation lands in the repository just planned.
+// stored repo_root, and groups repositories by repo_key — the canonical Git
+// common directory. A record that names another repository, or omits either
+// identity, is not evidence that the delegated mutation lands in the repository
+// just planned.
 func TestPolicyApplyRefusesUnusableParentProvenance(t *testing.T) {
-	for _, tc := range []struct{ name, repoRoot, diagnostic string }{
-		{"contradictory repo root", "/repo", "repository root"},
-		{"missing repo root", "", "repository root"},
+	// key is resolved per-case against the fixture repository; "" omits the
+	// field and "KEEP" means the real canonical Git common directory.
+	for _, tc := range []struct{ name, repoRoot, key, diagnostic string }{
+		{"contradictory repo root", "/repo", "KEEP", "repository root"},
+		{"missing repo root", "", "KEEP", "repository root"},
+		{"contradictory repo key", "KEEP", "/elsewhere/.git", "repository key"},
+		{"missing repo key", "KEEP", "", "repository key"},
+		{"repo key names the checkout, not its git dir", "KEEP", "KEEP-ROOT", "repository key"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo, _ := policyFixture(t)
@@ -400,13 +407,23 @@ func TestPolicyApplyRefusesUnusableParentProvenance(t *testing.T) {
 				t.Fatal(err)
 			}
 			req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+			root, key := tc.repoRoot, tc.key
+			if root == "KEEP" {
+				root = repo
+			}
+			switch key {
+			case "KEEP":
+				key = filepath.Join(repo, ".git")
+			case "KEEP-ROOT":
+				key = repo
+			}
 			f := startFakeHerdr(t)
 			f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
-			f.handle("workspace.get", map[string]any{"workspace": wsInfoWithRoot("wparent", "Primary", repo, tc.repoRoot, false)})
+			f.handle("workspace.get", map[string]any{"workspace": wsInfoWithProvenance("wparent", "Primary", repo, root, key, false)})
 			f.handle("worktree.open", selectionResult(plan.Candidates[0].Branch, repo))
 			f.handle("worktree.create", selectionResult(plan.Candidates[0].Branch, plan.Candidates[0].Path))
 			if out, err := applyWorktreePlan(req, plan); err == nil {
-				t.Fatalf("accepted repo_root %q against primary %s: %s", tc.repoRoot, repo, out)
+				t.Fatalf("accepted repo_root %q / repo_key %q against primary %s: %s", root, key, repo, out)
 			} else if !strings.Contains(err.Error(), tc.diagnostic) {
 				t.Fatalf("refusal does not explain the provenance gap: %v", err)
 			}
@@ -457,5 +474,53 @@ func TestPolicyRefusesUnusableNativeResultIdentities(t *testing.T) {
 	}
 	if err := validateEnsureResult(valid, "ingwon/task", "/tmp/checkout"); err != nil {
 		t.Fatalf("refused a consistent native result: %v", err)
+	}
+}
+
+// A new branch is created from the exact commit the plan showed, handed to
+// native as an object id.
+//
+// Verifying the fetched ref proves what origin held at fetch time; it cannot
+// bind what origin/BASE names later. Herdr passes base straight into the
+// start-point of `git worktree add -b <branch> <path> <base>`, so sending the
+// commit rather than the ref is what makes the accepted base unmovable — here
+// the ref is deliberately moved after verification and before the native call.
+func TestPolicyApplyCreatesFromTheImmutableAcceptedBase(t *testing.T) {
+	repo, origin := policyFixture(t)
+	req := worktreeRequest{Cwd: repo, Name: "new task"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	if !isObjectID(plan.BaseOID) || plan.Candidates[0].Existing {
+		t.Fatalf("fixture must plan a new branch from a resolved base: %+v", plan)
+	}
+
+	f := startFakeHerdr(t)
+	f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
+	// workspace.get runs after the base has been fetched and verified, and
+	// before the create is submitted: exactly the window a ref-named base would
+	// still be exposed in.
+	f.handleFunc("workspace.get", func(request) (any, *herdrError) {
+		runGit(t, origin, "commit", "--allow-empty", "-m", "advance after verification")
+		runGit(t, repo, "fetch", "origin", "refs/heads/trunk:refs/remotes/origin/trunk")
+		return map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)}, nil
+	})
+	f.handle("worktree.create", selectionResult(plan.Candidates[0].Branch, plan.Candidates[0].Path))
+
+	if _, err := applyWorktreePlan(req, plan); err != nil {
+		t.Fatal(err)
+	}
+	moved := runGit(t, repo, "rev-parse", "refs/remotes/origin/trunk")
+	if moved == plan.BaseOID {
+		t.Fatal("fixture must move origin/trunk after verification")
+	}
+	params := f.paramsFor("worktree.create")
+	if params["base"] != plan.BaseOID {
+		t.Fatalf("native base was %q, want the accepted commit %s (origin/trunk is now %s)", params["base"], plan.BaseOID, moved)
+	}
+	if params["branch"] != plan.Candidates[0].Branch || params["path"] != plan.Candidates[0].Path || params["workspace_id"] != "wparent" {
+		t.Fatalf("wrong native create target: %v", params)
 	}
 }

--- a/worktreeselection_regression_test.go
+++ b/worktreeselection_regression_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPolicyExistingNamesDoNotRequireNewSlug(t *testing.T) {
+	for _, mode := range []string{"unicode exact name", "existing issue exceeds new tail budget"} {
+		t.Run(mode, func(t *testing.T) {
+			repo, _ := policyFixture(t)
+			req := worktreeRequest{Cwd: repo, Name: "ingwon/한글"}
+			branch := req.Name
+			if mode != "unicode exact name" {
+				req.Name = "new description"
+				req.Issue = "IC-177"
+				branch = "old/ic-177-kept"
+				path := filepath.Join(os.Getenv("HERDR_PLUGIN_CONFIG_DIR"), "config.toml")
+				data, _ := os.ReadFile(path)
+				if err := os.WriteFile(path, []byte(strings.ReplaceAll(string(data), "max_tail = 29", "max_tail = 5")), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			old := addWorktree(t, repo, branch)
+			runGit(t, repo, "remote", "remove", "origin")
+			plan, err := planWorktree(req)
+			if err != nil {
+				t.Fatalf("valid registered branch %q at %s cannot be reused: %v", branch, old, err)
+			}
+			if len(plan.Candidates) != 1 || plan.Candidates[0].Branch != branch || plan.Candidates[0].Path != old {
+				t.Fatalf("lost existing checkout: %+v", plan)
+			}
+		})
+	}
+}
+func TestPolicyBranchAppearsDuringParentLookup(t *testing.T) {
+	repo, _ := policyFixture(t)
+	req := worktreeRequest{Cwd: repo, Name: "new task"}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	c := plan.Candidates[0]
+	f := startFakeHerdr(t)
+	f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
+	f.handleFunc("workspace.get", func(request) (any, *herdrError) {
+		runGit(t, repo, "commit", "--allow-empty", "-m", "concurrent branch origin")
+		runGit(t, repo, "branch", c.Branch, "HEAD")
+		return map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)}, nil
+	})
+	// Model the pinned native run_worktree_add_command existing-branch path with
+	// real disposable Git. No actual Herdr process is used.
+	f.handleFunc("worktree.create", func(request) (any, *herdrError) {
+		runGit(t, repo, "worktree", "add", c.Path, c.Branch)
+		return selectionResult(c.Branch, c.Path), nil
+	})
+	_, err = applyWorktreePlan(req, plan)
+	if err == nil {
+		actual := runGit(t, c.Path, "rev-parse", "HEAD")
+		t.Fatalf("apply succeeded after new selection became existing; accepted base=%s actual checkout=%s", plan.BaseOID, actual)
+	}
+	f.assertNotCalled("worktree.create")
+}
+
+func TestPolicyBranchDisappearsDuringParentLookup(t *testing.T) {
+	repo, _ := policyFixture(t)
+	branch := "ingwon/existing-task"
+	runGit(t, repo, "branch", branch)
+	req := worktreeRequest{Cwd: repo, Name: branch}
+	plan, err := planWorktree(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Fingerprint, req.Candidate = plan.Fingerprint, plan.Candidates[0].ID
+	f := startFakeHerdr(t)
+	f.handle("worktree.list", map[string]any{"worktrees": []any{listedCheckout(repo, "wparent")}})
+	f.handleFunc("workspace.get", func(request) (any, *herdrError) {
+		runGit(t, repo, "branch", "-D", branch)
+		return map[string]any{"workspace": wsInfo("wparent", "Primary", repo, false)}, nil
+	})
+	if _, err := applyWorktreePlan(req, plan); err == nil {
+		t.Fatal("accepted disappearance during parent lookup")
+	}
+	f.assertNotCalled("worktree.create")
+}

--- a/worktreeui.go
+++ b/worktreeui.go
@@ -15,15 +15,9 @@ import (
 
 // W is tied to the invoking pane, even if another client moves global focus.
 func policyInvocation(client *herdrClient, pc pluginContext) (RunContext, error) {
-	if pc.WorkspaceID == "" || pc.FocusedPaneID == "" || !filepath.IsAbs(pc.FocusedPaneCwd) {
-		return RunContext{}, fmt.Errorf("worktree action needs an explicit invoking workspace, pane and directory")
-	}
-	pane, err := client.paneGet(pc.FocusedPaneID)
+	pane, err := verifyInvokingPane(client, pc, "worktree")
 	if err != nil {
 		return RunContext{}, err
-	}
-	if pane.PaneID != pc.FocusedPaneID || pane.WorkspaceID != pc.WorkspaceID || !samePath(firstNonEmpty(pane.ForegroundCwd, pane.Cwd), pc.FocusedPaneCwd) {
-		return RunContext{}, fmt.Errorf("invoking pane changed; invoke the worktree action again")
 	}
 	return RunContext{WorkDir: pc.FocusedPaneCwd, PaneId: pc.FocusedPaneID, WorkspaceId: pc.WorkspaceID, TabId: pane.TabID}, nil
 }

--- a/worktreeui.go
+++ b/worktreeui.go
@@ -43,7 +43,17 @@ func launchPolicyWorktree() {
 	herdr := firstNonEmpty(os.Getenv("HERDR_BIN_PATH"), "herdr")
 	deadline, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(deadline, herdr, "plugin", "pane", "open", "--plugin", pluginID, "--entrypoint", paneEntrypoint("worktree-picker"), "--placement", "overlay", "--target-pane", ctx.PaneId, "--env", "HERDR_PLUS_CTX="+encoded)
+	// This picker is always an overlay, and herdr refuses an explicit target
+	// pane for one: it covers the active pane by design. policyInvocation has
+	// already proved the invoking pane, so the checkout this plans against is
+	// still that pane's, whatever herdr draws the overlay over.
+	args := []string{"plugin", "pane", "open", "--plugin", pluginID,
+		"--entrypoint", paneEntrypoint("worktree-picker"), "--placement", "overlay"}
+	if placementAcceptsTargetPane("overlay") {
+		args = append(args, "--target-pane", ctx.PaneId)
+	}
+	args = append(args, "--env", "HERDR_PLUS_CTX="+encoded)
+	cmd := exec.CommandContext(deadline, herdr, args...)
 	cmd.WaitDelay = time.Second
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/worktreeui.go
+++ b/worktreeui.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// W is tied to the invoking pane, even if another client moves global focus.
+func policyInvocation(client *herdrClient, pc pluginContext) (RunContext, error) {
+	if pc.WorkspaceID == "" || pc.FocusedPaneID == "" || !filepath.IsAbs(pc.FocusedPaneCwd) {
+		return RunContext{}, fmt.Errorf("worktree action needs an explicit invoking workspace, pane and directory")
+	}
+	pane, err := client.paneGet(pc.FocusedPaneID)
+	if err != nil {
+		return RunContext{}, err
+	}
+	if pane.PaneID != pc.FocusedPaneID || pane.WorkspaceID != pc.WorkspaceID || !samePath(firstNonEmpty(pane.ForegroundCwd, pane.Cwd), pc.FocusedPaneCwd) {
+		return RunContext{}, fmt.Errorf("invoking pane changed; invoke the worktree action again")
+	}
+	return RunContext{WorkDir: pc.FocusedPaneCwd, PaneId: pc.FocusedPaneID, WorkspaceId: pc.WorkspaceID, TabId: pane.TabID}, nil
+}
+
+func launchPolicyWorktree() {
+	pc, err := pluginContextFromEnv()
+	if err != nil {
+		errExit(err)
+	}
+	client, err := newHerdrClient()
+	if err != nil {
+		errExit(err)
+	}
+	client.timeout = 15 * time.Second
+	ctx, err := policyInvocation(client, pc)
+	if err != nil {
+		errExit(err)
+	}
+	encoded, err := ctx.encode()
+	if err != nil {
+		errExit(err)
+	}
+	herdr := firstNonEmpty(os.Getenv("HERDR_BIN_PATH"), "herdr")
+	deadline, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(deadline, herdr, "plugin", "pane", "open", "--plugin", pluginID, "--entrypoint", paneEntrypoint("worktree-picker"), "--placement", "overlay", "--target-pane", ctx.PaneId, "--env", "HERDR_PLUS_CTX="+encoded)
+	cmd.WaitDelay = time.Second
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		errExit("open worktree picker:", err)
+	}
+}
+
+type worktreePlanned struct {
+	plan worktreePlan
+	err  error
+}
+type worktreeApplied struct{ err error }
+type worktreeUI struct {
+	req           worktreeRequest
+	input         textinput.Model
+	list          fuzzyList
+	plan          *worktreePlan
+	busy          bool
+	err           string
+	width, height int
+}
+
+func newWorktreeUI(req worktreeRequest) worktreeUI {
+	input := textinput.New()
+	input.Placeholder = "short description or ISSUE-123 description"
+	input.Focus()
+	input.SetValue(req.Name)
+	return worktreeUI{req: req, input: input, list: newFuzzyList("Filter branches…", nil), busy: strings.TrimSpace(req.Name) != ""}
+}
+
+func (m worktreeUI) planCommand() tea.Cmd {
+	req := m.req
+	return func() tea.Msg { p, err := planWorktree(req); return worktreePlanned{p, err} }
+}
+
+func (m worktreeUI) Init() tea.Cmd {
+	if strings.TrimSpace(m.req.Name) != "" {
+		return m.planCommand()
+	}
+	return textinput.Blink
+}
+
+func (m worktreeUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.input.Width = max(1, m.width-4)
+		m.list.setViewport(max(1, m.height-9-listPromptLines), m.width)
+		return m, nil
+	case worktreePlanned:
+		m.busy = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			m.plan = nil
+			return m, nil
+		}
+		m.err = ""
+		m.plan = &msg.plan
+		items := make([]listItem, len(msg.plan.Candidates))
+		for i, c := range msg.plan.Candidates {
+			verb := "create"
+			if c.Checkout {
+				verb = "open existing checkout"
+			} else if c.Existing {
+				verb = "check out existing branch"
+			}
+			items[i] = listItem{name: c.Branch, desc: verb + " · " + c.Path, selectable: true, ref: i}
+		}
+		m.list = newFuzzyList("Filter branches…", items)
+		m.list.setViewport(max(1, m.height-9-listPromptLines), m.width)
+		return m, nil
+	case worktreeApplied:
+		m.busy = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		return m, tea.Quit
+	case tea.KeyMsg:
+		// A submitted native operation must return before the picker exits; leaving
+		// midway could hide a created worktree behind an apparent cancellation.
+		if m.busy {
+			return m, nil
+		}
+		if msg.String() == "ctrl+c" || msg.String() == "esc" {
+			return m, tea.Quit
+		}
+		if m.plan == nil {
+			if msg.String() == "enter" {
+				m.req.Name = strings.TrimSpace(m.input.Value())
+				if m.req.Name == "" {
+					m.err = "Enter a short description."
+					return m, nil
+				}
+				m.busy = true
+				return m, m.planCommand()
+			}
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(msg)
+			return m, cmd
+		}
+		switch msg.String() {
+		case "up", "ctrl+p":
+			m.list.moveUp()
+			return m, nil
+		case "down", "ctrl+n":
+			m.list.moveDown()
+			return m, nil
+		case "ctrl+r":
+			m.busy = true
+			m.err = ""
+			return m, m.planCommand()
+		case "enter":
+			i := m.list.selectedIndex()
+			if i < 0 {
+				return m, nil
+			}
+			req := m.req
+			req.Candidate = m.plan.Candidates[i].ID
+			req.Fingerprint = m.plan.Fingerprint
+			m.busy = true
+			return m, func() tea.Msg {
+				fresh, err := planWorktree(req)
+				if err == nil {
+					_, err = applyWorktreePlan(req, fresh)
+				}
+				return worktreeApplied{err}
+			}
+		}
+		cmd := m.list.editQuery(msg)
+		return m, cmd
+	}
+	if m.plan == nil {
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m worktreeUI) View() string {
+	body := headerBarStyle.Render("Herdr Plus · Worktree") + "\n\n"
+	if m.plan == nil {
+		body += "Name the work\n" + m.input.View() + "\n"
+	} else {
+		body += m.plan.Project + "\n"
+		if m.plan.Base != "" {
+			body += "New branch from origin/" + m.plan.Base + "\n"
+		}
+		body += m.list.view("No matching branches") + "\n"
+	}
+	if m.busy {
+		body += "Working…\n"
+	}
+	if m.err != "" {
+		body += m.err + "\n"
+	}
+	return body + footerStyle.Render("enter choose · ctrl+r refresh · esc cancel")
+}
+
+func runPolicyPicker(req worktreeRequest) error {
+	if !filepath.IsAbs(req.Cwd) {
+		return fmt.Errorf("worktree picker needs an explicit absolute invoking directory")
+	}
+	_, err := tea.NewProgram(newWorktreeUI(req), tea.WithAltScreen()).Run()
+	return err
+}

--- a/worktreeui.go
+++ b/worktreeui.go
@@ -31,20 +31,20 @@ func policyInvocation(client *herdrClient, pc pluginContext) (RunContext, error)
 func launchPolicyWorktree() {
 	pc, err := pluginContextFromEnv()
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	client, err := newHerdrClient()
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	client.timeout = 15 * time.Second
 	ctx, err := policyInvocation(client, pc)
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	encoded, err := ctx.encode()
 	if err != nil {
-		errExit(err)
+		actionErrExit(err)
 	}
 	herdr := firstNonEmpty(os.Getenv("HERDR_BIN_PATH"), "herdr")
 	deadline, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -53,7 +53,7 @@ func launchPolicyWorktree() {
 	cmd.WaitDelay = time.Second
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
-		errExit("open worktree picker:", err)
+		actionErrExit("open worktree picker:", err)
 	}
 }
 


### PR DESCRIPTION
## Context

Native verification during install wrap-up found a real compatibility blocker that mocked tests and schema review both missed.

Installed herdr 0.9.0 refuses an explicit target pane for overlay and popup plugin panes:

```
herdr plugin pane open --plugin cloudmanic.herdr-plus --entrypoint picker \
  --placement overlay --target-pane w1D:p3
-> {"error":{"code":"invalid_params","message":"overlay and popup plugin panes target the active pane"}}
```

No pane is created, so the launch fails outright.

## Root cause of the miss

`target_pane_id` is a top-level field in the protocol-22 schema, and the CLI help lists `--target-pane`, so it read as placement-independent. Neither fact proves the server accepts the *combination*, and the tests asserted only that the flag was emitted. Schema support plus green reviews is not evidence of runtime acceptance.

## What shipped

- `placementAcceptsTargetPane` decides per placement; both launchers consult it. `--target-pane` now goes only to `split`, `tab` and `zoomed`.
- The pre-flight invoking-pane proof is unchanged, so a pane that moved, changed workspace or changed directory still refuses the launch. The checkout and working directory stay the verified pane's. What changes is that native chooses which pane an overlay covers — its documented behavior for a full-screen overlay or centered popup.
- README no longer claims the plugin pins overlay placement.

## Review follow-up folded in

- `verifyNativeParent` distinguishes *no recorded provenance* from *provenance that disagrees*. herdr records checkout membership on `worktree.open`, not `workspace.create`, so a workspace opened outside Plus can hold this checkout and carry nothing; the old message described a state that was not the case and hid the remedy.
- New coverage: `--target-pane` presence per placement; the pane guard's `foreground_cwd` preference, including that `pane.cwd` does not stand in for it; the missing-provenance refusal.

## Verification

`go vet ./...` clean. `go test -race -count=1 -timeout=900s ./...` passes.

## Non-goals / risks

Overlay and popup placement is now native's choice; that is a deliberate acceptance of the native contract, not a workaround. Reviewer attention: the placement table in `placementAcceptsTargetPane` must stay in sync with herdr's own rule if a future version relaxes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETfx67xHxAcAVDVQMoPRN6